### PR TITLE
refactor: centralize ComponentEventTrigger and Reactive wiring

### DIFF
--- a/Alis.Reactive.Fusion/Components/FusionAutoComplete/FusionAutoCompleteReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAutoComplete/FusionAutoCompleteReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.DropDowns;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionAutoCompleteReactiveExtensions
     {
-        private static readonly FusionAutoComplete Component = new FusionAutoComplete();
-
         public static AutoCompleteBuilder Reactive<TModel, TArgs>(
             this AutoCompleteBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionAutoCompleteEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionAutoComplete, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionAutoCompleteEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionDatePicker/FusionDatePickerReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDatePicker/FusionDatePickerReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Calendars;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionDatePickerReactiveExtensions
     {
-        private static readonly FusionDatePicker Component = new FusionDatePicker();
-
         public static DatePickerBuilder Reactive<TModel, TArgs>(
             this DatePickerBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionDatePickerEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionDatePicker, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionDatePickerEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionDateRangePicker/FusionDateRangePickerReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDateRangePicker/FusionDateRangePickerReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Calendars;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionDateRangePickerReactiveExtensions
     {
-        private static readonly FusionDateRangePicker Component = new FusionDateRangePicker();
-
         public static DateRangePickerBuilder Reactive<TModel, TArgs>(
             this DateRangePickerBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionDateRangePickerEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionDateRangePicker, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionDateRangePickerEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionDateTimePicker/FusionDateTimePickerReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDateTimePicker/FusionDateTimePickerReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Calendars;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionDateTimePickerReactiveExtensions
     {
-        private static readonly FusionDateTimePicker Component = new FusionDateTimePicker();
-
         public static DateTimePickerBuilder Reactive<TModel, TArgs>(
             this DateTimePickerBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionDateTimePickerEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionDateTimePicker, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionDateTimePickerEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionDropDownList/FusionDropDownListReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownList/FusionDropDownListReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.DropDowns;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionDropDownListReactiveExtensions
     {
-        private static readonly FusionDropDownList Component = new FusionDropDownList();
-
         public static DropDownListBuilder Reactive<TModel, TArgs>(
             this DropDownListBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,20 +25,11 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionDropDownListEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionDropDownList, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionDropDownListEvents.Instance), pipeline);
             return builder;
         }
-
     }
 }

--- a/Alis.Reactive.Fusion/Components/FusionFileUpload/FusionFileUploadReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionFileUpload/FusionFileUploadReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Inputs;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionFileUploadReactiveExtensions
     {
-        private static readonly FusionFileUpload Component = new FusionFileUpload();
-
         public static UploaderBuilder Reactive<TModel, TArgs>(
             this UploaderBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,20 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionFileUploadEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            // Uploader uses Uploader(id) — id is set via the constructor, stored in model.Id.
-            // name is set via HtmlAttributes.
-            var componentId = builder.model.Id;
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionFileUpload, TArgs>(
+                plan, builder.model.Id, (string)attrs["name"],
+                eventSelector(FusionFileUploadEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionInputMask/FusionInputMaskReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionInputMask/FusionInputMaskReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Inputs;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionInputMaskReactiveExtensions
     {
-        private static readonly FusionInputMask Component = new FusionInputMask();
-
         public static MaskedTextBoxBuilder Reactive<TModel, TArgs>(
             this MaskedTextBoxBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionInputMaskEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionInputMask, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionInputMaskEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionMultiColumnComboBox/FusionMultiColumnComboBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMultiColumnComboBox/FusionMultiColumnComboBoxReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.MultiColumnComboBox;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionMultiColumnComboBoxReactiveExtensions
     {
-        private static readonly FusionMultiColumnComboBox Component = new FusionMultiColumnComboBox();
-
         public static MultiColumnComboBoxBuilder Reactive<TModel, TArgs>(
             this MultiColumnComboBoxBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionMultiColumnComboBoxEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionMultiColumnComboBox, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionMultiColumnComboBoxEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionMultiSelect/FusionMultiSelectReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMultiSelect/FusionMultiSelectReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.DropDowns;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionMultiSelectReactiveExtensions
     {
-        private static readonly FusionMultiSelect Component = new FusionMultiSelect();
-
         public static MultiSelectBuilder Reactive<TModel, TArgs>(
             this MultiSelectBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionMultiSelectEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionMultiSelect, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionMultiSelectEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionNumericTextBox/FusionNumericTextBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionNumericTextBox/FusionNumericTextBoxReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Inputs;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionNumericTextBoxReactiveExtensions
     {
-        private static readonly FusionNumericTextBox Component = new FusionNumericTextBox();
-
         public static NumericTextBoxBuilder Reactive<TModel, TArgs>(
             this NumericTextBoxBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,20 +25,11 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionNumericTextBoxEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionNumericTextBox, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionNumericTextBoxEvents.Instance), pipeline);
             return builder;
         }
-
     }
 }

--- a/Alis.Reactive.Fusion/Components/FusionRichTextEditor/FusionRichTextEditorReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRichTextEditor/FusionRichTextEditorReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.RichTextEditor;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionRichTextEditorReactiveExtensions
     {
-        private static readonly FusionRichTextEditor Component = new FusionRichTextEditor();
-
         public static RichTextEditorBuilder Reactive<TModel, TArgs>(
             this RichTextEditorBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,21 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionRichTextEditorEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            // RTE uses model.Id (set by FusionRichTextEditorHtmlExtensions) instead
-            // of HtmlAttributes["id"] because SF RTE Render() uses model.Id for the
-            // textarea's id attribute, not HtmlAttributes.
-            var componentId = builder.model.Id;
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionRichTextEditor, TArgs>(
+                plan, builder.model.Id, (string)attrs["name"],
+                eventSelector(FusionRichTextEditorEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionSwitch/FusionSwitchReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSwitch/FusionSwitchReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Buttons;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionSwitchReactiveExtensions
     {
-        private static readonly FusionSwitch Component = new FusionSwitch();
-
         public static SwitchBuilder Reactive<TModel, TArgs>(
             this SwitchBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionSwitchEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionSwitch, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionSwitchEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/FusionTimePicker/FusionTimePickerReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTimePicker/FusionTimePickerReactiveExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 using Syncfusion.EJ2.Calendars;
 
 namespace Alis.Reactive.Fusion.Components
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     public static class FusionTimePickerReactiveExtensions
     {
-        private static readonly FusionTimePicker Component = new FusionTimePicker();
-
         public static TimePickerBuilder Reactive<TModel, TArgs>(
             this TimePickerBuilder builder,
             IReactivePlan<TModel> plan,
@@ -29,18 +25,10 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(FusionTimePickerEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
-            var componentId = (string)attrs["id"];
-            var bindingPath = (string)attrs["name"];
-
-            var trigger = new ComponentEventTrigger(componentId, descriptor.JsEvent, Component.Vendor, bindingPath, Component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, FusionTimePicker, TArgs>(
+                plan, (string)attrs["id"], (string)attrs["name"],
+                eventSelector(FusionTimePickerEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Fusion/Components/TestWidgetSyncFusion/TestWidgetSyncFusionReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/TestWidgetSyncFusion/TestWidgetSyncFusionReactiveExtensions.cs
@@ -1,14 +1,10 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Fusion.Components
 {
     public static class TestWidgetSyncFusionReactiveExtensions
     {
-        private static readonly TestWidgetSyncFusion _component = new TestWidgetSyncFusion();
-
         public static TestWidgetSyncFusionBuilder<TModel> Reactive<TModel, TArgs>(
             this TestWidgetSyncFusionBuilder<TModel> builder,
             IReactivePlan<TModel> plan,
@@ -16,18 +12,9 @@ namespace Alis.Reactive.Fusion.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(TestWidgetSyncFusionEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            var trigger = new ComponentEventTrigger(
-                builder.ElementId,
-                descriptor.JsEvent,
-                _component.Vendor,
-                readExpr: _component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, TestWidgetSyncFusion, TArgs>(
+                plan, builder.ElementId, null,
+                eventSelector(TestWidgetSyncFusionEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeButton/NativeButtonReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeButton/NativeButtonReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -21,8 +19,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeButtonReactiveExtensions
     {
-        private static readonly NativeButton _component = new NativeButton();
-
         public static NativeButtonBuilder<TModel> Reactive<TModel, TArgs>(
             this NativeButtonBuilder<TModel> builder,
             IReactivePlan<TModel> plan,
@@ -30,14 +26,9 @@ namespace Alis.Reactive.Native.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(NativeButtonEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            var trigger = new ComponentEventTrigger(builder.ElementId, descriptor.JsEvent, _component.Vendor);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, NativeButton, TArgs>(
+                plan, builder.ElementId, null,
+                eventSelector(NativeButtonEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeCheckBox/NativeCheckBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeCheckBox/NativeCheckBoxReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -11,8 +9,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeCheckBoxReactiveExtensions
     {
-        private static readonly NativeCheckBox _component = new NativeCheckBox();
-
         public static NativeCheckBoxBuilder<TModel, TProp> Reactive<TModel, TProp, TArgs>(
             this NativeCheckBoxBuilder<TModel, TProp> builder,
             IReactivePlan<TModel> plan,
@@ -20,14 +16,9 @@ namespace Alis.Reactive.Native.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(NativeCheckBoxEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            var trigger = new ComponentEventTrigger(builder.ElementId, descriptor.JsEvent, _component.Vendor, builder.BindingPath, _component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, NativeCheckBox, TArgs>(
+                plan, builder.ElementId, builder.BindingPath,
+                eventSelector(NativeCheckBoxEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeCheckList/NativeCheckListReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeCheckList/NativeCheckListReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -16,8 +14,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeCheckListReactiveExtensions
     {
-        private static readonly NativeCheckList _component = new NativeCheckList();
-
         public static NativeCheckListBuilder<TModel, TProp> Reactive<TModel, TProp, TArgs>(
             this NativeCheckListBuilder<TModel, TProp> builder,
             IReactivePlan<TModel> plan,
@@ -25,19 +21,10 @@ namespace Alis.Reactive.Native.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(NativeCheckListEvents.Instance);
-
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
             // Single entry on the hidden input — checklist.ts dispatches change after sync
-            var trigger = new ComponentEventTrigger(
-                builder.ElementId, descriptor.JsEvent, _component.Vendor,
-                builder.BindingPath, _component.ReadExpr);
-
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, NativeCheckList, TArgs>(
+                plan, builder.ElementId, builder.BindingPath,
+                eventSelector(NativeCheckListEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeDropDown/NativeDropDownReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeDropDown/NativeDropDownReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -21,8 +19,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeDropDownReactiveExtensions
     {
-        private static readonly NativeDropDown _component = new NativeDropDown();
-
         public static NativeDropDownBuilder<TModel, TProp> Reactive<TModel, TProp, TArgs>(
             this NativeDropDownBuilder<TModel, TProp> builder,
             IReactivePlan<TModel> plan,
@@ -30,14 +26,9 @@ namespace Alis.Reactive.Native.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(NativeDropDownEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            var trigger = new ComponentEventTrigger(builder.ElementId, descriptor.JsEvent, _component.Vendor, builder.BindingPath, _component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, NativeDropDown, TArgs>(
+                plan, builder.ElementId, builder.BindingPath,
+                eventSelector(NativeDropDownEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeHiddenField/NativeHiddenFieldReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeHiddenField/NativeHiddenFieldReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -12,8 +10,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeHiddenFieldReactiveExtensions
     {
-        private static readonly NativeHiddenField _component = new NativeHiddenField();
-
         public static NativeHiddenFieldBuilder<TModel, TProp> Reactive<TModel, TProp, TArgs>(
             this NativeHiddenFieldBuilder<TModel, TProp> builder,
             IReactivePlan<TModel> plan,
@@ -21,14 +17,9 @@ namespace Alis.Reactive.Native.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(NativeHiddenFieldEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            var trigger = new ComponentEventTrigger(builder.ElementId, descriptor.JsEvent, _component.Vendor, builder.BindingPath, _component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, NativeHiddenField, TArgs>(
+                plan, builder.ElementId, builder.BindingPath,
+                eventSelector(NativeHiddenFieldEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeRadioGroup/NativeRadioGroupReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeRadioGroup/NativeRadioGroupReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -17,8 +15,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeRadioGroupReactiveExtensions
     {
-        private static readonly NativeRadioGroup _component = new NativeRadioGroup();
-
         public static NativeRadioGroupBuilder<TModel, TProp> Reactive<TModel, TProp, TArgs>(
             this NativeRadioGroupBuilder<TModel, TProp> builder,
             IReactivePlan<TModel> plan,
@@ -27,21 +23,12 @@ namespace Alis.Reactive.Native.Components
             where TModel : class
         {
             var descriptor = eventSelector(NativeRadioGroupEvents.Instance);
-
             for (int i = 0; i < builder.Options.Count; i++)
             {
-                var pb = new PipelineBuilder<TModel>();
-                pipeline(descriptor.Args, pb);
-
-                var radioId = $"{builder.ElementId}_r{i}";
-                var trigger = new ComponentEventTrigger(
-                    radioId, descriptor.JsEvent, _component.Vendor,
-                    builder.BindingPath, _component.ReadExpr);
-
-                foreach (var reaction in pb.BuildReactions())
-                    plan.AddEntry(new Entry(trigger, reaction));
+                ReactiveWiringHelper.Wire<TModel, NativeRadioGroup, TArgs>(
+                    plan, $"{builder.ElementId}_r{i}", builder.BindingPath,
+                    descriptor, pipeline);
             }
-
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeTextArea/NativeTextAreaReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeTextArea/NativeTextAreaReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeTextAreaReactiveExtensions
     {
-        private static readonly NativeTextArea _component = new NativeTextArea();
-
         public static NativeTextAreaBuilder<TModel, TProp> Reactive<TModel, TProp, TArgs>(
             this NativeTextAreaBuilder<TModel, TProp> builder,
             IReactivePlan<TModel> plan,
@@ -29,14 +25,9 @@ namespace Alis.Reactive.Native.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(NativeTextAreaEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            var trigger = new ComponentEventTrigger(builder.ElementId, descriptor.JsEvent, _component.Vendor, builder.BindingPath, _component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, NativeTextArea, TArgs>(
+                plan, builder.ElementId, builder.BindingPath,
+                eventSelector(NativeTextAreaEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive.Native/Components/NativeTextBox/NativeTextBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeTextBox/NativeTextBoxReactiveExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Alis.Reactive.Builders;
-using Alis.Reactive.Descriptors;
-using Alis.Reactive.Descriptors.Triggers;
 
 namespace Alis.Reactive.Native.Components
 {
@@ -20,8 +18,6 @@ namespace Alis.Reactive.Native.Components
     /// </summary>
     public static class NativeTextBoxReactiveExtensions
     {
-        private static readonly NativeTextBox _component = new NativeTextBox();
-
         public static NativeTextBoxBuilder<TModel, TProp> Reactive<TModel, TProp, TArgs>(
             this NativeTextBoxBuilder<TModel, TProp> builder,
             IReactivePlan<TModel> plan,
@@ -29,14 +25,9 @@ namespace Alis.Reactive.Native.Components
             Action<TArgs, PipelineBuilder<TModel>> pipeline)
             where TModel : class
         {
-            var descriptor = eventSelector(NativeTextBoxEvents.Instance);
-            var pb = new PipelineBuilder<TModel>();
-            pipeline(descriptor.Args, pb);
-
-            var trigger = new ComponentEventTrigger(builder.ElementId, descriptor.JsEvent, _component.Vendor, builder.BindingPath, _component.ReadExpr);
-            foreach (var reaction in pb.BuildReactions())
-                plan.AddEntry(new Entry(trigger, reaction));
-
+            ReactiveWiringHelper.Wire<TModel, NativeTextBox, TArgs>(
+                plan, builder.ElementId, builder.BindingPath,
+                eventSelector(NativeTextBoxEvents.Instance), pipeline);
             return builder;
         }
     }

--- a/Alis.Reactive/Descriptors/Triggers/ComponentEventTrigger.cs
+++ b/Alis.Reactive/Descriptors/Triggers/ComponentEventTrigger.cs
@@ -48,15 +48,21 @@ namespace Alis.Reactive.Descriptors.Triggers
         /// <summary>
         /// Factory that resolves Vendor and ReadExpr from TComponent's interface declarations.
         /// Centralizes trigger construction — all .Reactive() extensions call this instead of
-        /// manually assembling 5 constructor args.
+        /// manually assembling 5 constructor args. Uses a static cache per TComponent to match
+        /// the ComponentRef caching pattern — one allocation per component type for the app lifetime.
         /// </summary>
         public static ComponentEventTrigger For<TComponent>(
             string componentId, string jsEvent, string? bindingPath = null)
             where TComponent : IComponent, new()
         {
-            var component = new TComponent();
+            var component = ComponentCache<TComponent>.Instance;
             var readExpr = (component is IInputComponent input) ? input.ReadExpr : null;
             return new ComponentEventTrigger(componentId, jsEvent, component.Vendor, bindingPath, readExpr);
+        }
+
+        private static class ComponentCache<T> where T : IComponent, new()
+        {
+            internal static readonly T Instance = new T();
         }
     }
 }

--- a/Alis.Reactive/Descriptors/Triggers/ComponentEventTrigger.cs
+++ b/Alis.Reactive/Descriptors/Triggers/ComponentEventTrigger.cs
@@ -44,5 +44,19 @@ namespace Alis.Reactive.Descriptors.Triggers
             BindingPath = bindingPath;
             ReadExpr = readExpr;
         }
+
+        /// <summary>
+        /// Factory that resolves Vendor and ReadExpr from TComponent's interface declarations.
+        /// Centralizes trigger construction — all .Reactive() extensions call this instead of
+        /// manually assembling 5 constructor args.
+        /// </summary>
+        public static ComponentEventTrigger For<TComponent>(
+            string componentId, string jsEvent, string? bindingPath = null)
+            where TComponent : IComponent, new()
+        {
+            var component = new TComponent();
+            var readExpr = (component is IInputComponent input) ? input.ReadExpr : null;
+            return new ComponentEventTrigger(componentId, jsEvent, component.Vendor, bindingPath, readExpr);
+        }
     }
 }

--- a/Alis.Reactive/ReactiveWiringHelper.cs
+++ b/Alis.Reactive/ReactiveWiringHelper.cs
@@ -22,6 +22,13 @@ namespace Alis.Reactive
             where TModel : class
             where TComponent : IComponent, new()
         {
+            if (string.IsNullOrEmpty(componentId))
+                throw new InvalidOperationException(
+                    $"{typeof(TComponent).Name} has no element ID. " +
+                    "Ensure the component builder sets an id — for Native builders use " +
+                    "the factory method (e.g. Html.NativeTextBoxFor), for Fusion builders " +
+                    "ensure HtmlAttributes contains 'id'.");
+
             var pb = new PipelineBuilder<TModel>();
             pipeline(descriptor.Args, pb);
 

--- a/Alis.Reactive/ReactiveWiringHelper.cs
+++ b/Alis.Reactive/ReactiveWiringHelper.cs
@@ -1,0 +1,34 @@
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Descriptors;
+using Alis.Reactive.Descriptors.Triggers;
+
+namespace Alis.Reactive
+{
+    /// <summary>
+    /// Shared plumbing for every component's .Reactive() extension method.
+    /// Builds the pipeline, creates the trigger via the factory, and adds entries to the plan.
+    /// Each component's .Reactive() becomes a thin wrapper that extracts componentId/bindingPath
+    /// from its builder type and delegates here.
+    /// </summary>
+    internal static class ReactiveWiringHelper
+    {
+        internal static void Wire<TModel, TComponent, TArgs>(
+            IReactivePlan<TModel> plan,
+            string componentId,
+            string? bindingPath,
+            TypedEventDescriptor<TArgs> descriptor,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+            where TComponent : IComponent, new()
+        {
+            var pb = new PipelineBuilder<TModel>();
+            pipeline(descriptor.Args, pb);
+
+            var trigger = ComponentEventTrigger.For<TComponent>(
+                componentId, descriptor.JsEvent, bindingPath);
+            foreach (var reaction in pb.BuildReactions())
+                plan.AddEntry(new Entry(trigger, reaction));
+        }
+    }
+}

--- a/Alis.Reactive/ReactiveWiringHelper.cs
+++ b/Alis.Reactive/ReactiveWiringHelper.cs
@@ -22,13 +22,6 @@ namespace Alis.Reactive
             where TModel : class
             where TComponent : IComponent, new()
         {
-            if (string.IsNullOrEmpty(componentId))
-                throw new InvalidOperationException(
-                    $"{typeof(TComponent).Name} has no element ID. " +
-                    "Ensure the component builder sets an id — for Native builders use " +
-                    "the factory method (e.g. Html.NativeTextBoxFor), for Fusion builders " +
-                    "ensure HtmlAttributes contains 'id'.");
-
             var pb = new PipelineBuilder<TModel>();
             pipeline(descriptor.Args, pb);
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,13 +472,13 @@ Read and write are two sides of the same property:
 
 #### Adding a New Component Type (Zero Runtime Changes)
 
-1. C# sealed class implementing `IComponent` + `IInputComponent` (declares Vendor + ReadExpr as instance properties)
-2. Event args class (typed payload properties)
+1. C# sealed class — Native: implements `IComponent` + `IInputComponent` directly. Fusion: extends `FusionComponent` + implements `IInputComponent`. Declares Vendor + ReadExpr as instance properties.
+2. Event args class(es) — one per event type (typed payload properties)
 3. Events singleton (TypedEventDescriptor registry)
 4. Extensions (structured prop/method fields for property writes, method calls, read expressions)
-5. Builder (IHtmlContent, renders HTML, registers component in ComponentsMap)
+5. Builder — Native: `IHtmlContent`, renders HTML. Fusion: extension on `InputFieldSetup<TModel, TProp>`. Both register component in ComponentsMap.
 6. Reactive extension (.Reactive() calls `ReactiveWiringHelper.Wire<TModel, TComponent, TArgs>()` — 3-line wrapper)
-7. Gather extension (uses TComponent.ReadExpr via `new()` constraint)
+7. Gather extension — shared generic per vendor (`NativeGatherExtensions` / `FusionGatherExtensions`), not per-component
 8. Tests at all 3 layers
 
 The runtime does NOT change. The plan JSON carries vendor, readExpr, prop/method, jsEvent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,7 +477,7 @@ Read and write are two sides of the same property:
 3. Events singleton (TypedEventDescriptor registry)
 4. Extensions (structured prop/method fields for property writes, method calls, read expressions)
 5. Builder (IHtmlContent, renders HTML, registers component in ComponentsMap)
-6. Reactive extension (.Reactive() creates ComponentEventTrigger)
+6. Reactive extension (.Reactive() calls `ReactiveWiringHelper.Wire<TModel, TComponent, TArgs>()` — 3-line wrapper)
 7. Gather extension (uses TComponent.ReadExpr via `new()` constraint)
 8. Tests at all 3 layers
 

--- a/tests/Alis.Reactive.UnitTests/Schema/WhenDiscoveringPolymorphicTypes.cs
+++ b/tests/Alis.Reactive.UnitTests/Schema/WhenDiscoveringPolymorphicTypes.cs
@@ -1,0 +1,103 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Alis.Reactive.Descriptors.Commands;
+using Alis.Reactive.Descriptors.Guards;
+using Alis.Reactive.Descriptors.Mutations;
+using Alis.Reactive.Descriptors.Reactions;
+using Alis.Reactive.Descriptors.Requests;
+using Alis.Reactive.Descriptors.Sources;
+using Alis.Reactive.Descriptors.Triggers;
+
+namespace Alis.Reactive.UnitTests;
+
+/// <summary>
+/// Discovers all sealed subclasses of every polymorphic descriptor base type via reflection
+/// and asserts that each subclass's Kind value has a matching definition in the JSON schema.
+/// Catches schema drift — a new subclass without a schema definition is a silent bug because
+/// WriteOnlyPolymorphicConverter serializes any subclass via reflection.
+/// </summary>
+[TestFixture]
+public class WhenDiscoveringPolymorphicTypes
+{
+    private static readonly Type[] PolymorphicBaseTypes =
+    [
+        typeof(Command),
+        typeof(Trigger),
+        typeof(Reaction),
+        typeof(Mutation),
+        typeof(MethodArg),
+        typeof(BindSource),
+        typeof(Guard),
+        typeof(GatherItem)
+    ];
+
+    private static IEnumerable<TestCaseData> PolymorphicBaseTypeCases()
+    {
+        foreach (var baseType in PolymorphicBaseTypes)
+            yield return new TestCaseData(baseType)
+                .SetName($"All_{baseType.Name}_subclasses_have_schema_definitions");
+    }
+
+    [TestCaseSource(nameof(PolymorphicBaseTypeCases))]
+    public void Every_kind_has_a_matching_schema_definition(Type baseType)
+    {
+        var subclasses = baseType.Assembly.GetTypes()
+            .Where(t => t.IsSealed && !t.IsAbstract && baseType.IsAssignableFrom(t))
+            .ToList();
+
+        Assert.That(subclasses, Is.Not.Empty,
+            $"No sealed subclasses found for {baseType.Name}");
+
+        var schemaKinds = GetSchemaKindsFor(baseType.Name);
+
+        foreach (var subclass in subclasses)
+        {
+            var kindProp = subclass.GetProperty("Kind");
+            Assert.That(kindProp, Is.Not.Null,
+                $"{subclass.Name} is a sealed subclass of {baseType.Name} but has no Kind property");
+
+            var instance = RuntimeHelpers.GetUninitializedObject(subclass);
+            var kind = (string)kindProp!.GetValue(instance)!;
+
+            Assert.That(schemaKinds, Does.Contain(kind),
+                $"{subclass.Name} has Kind=\"{kind}\" but no matching definition exists in " +
+                $"schema $defs.{baseType.Name}.oneOf. Schema kinds: [{string.Join(", ", schemaKinds)}]");
+        }
+    }
+
+    private static HashSet<string> GetSchemaKindsFor(string baseTypeName)
+    {
+        var schemaPath = Path.Combine(
+            TestContext.CurrentContext.TestDirectory,
+            "Schemas",
+            "reactive-plan.schema.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(schemaPath));
+        var defs = doc.RootElement.GetProperty("$defs");
+
+        Assert.That(defs.TryGetProperty(baseTypeName, out var unionDef), Is.True,
+            $"Schema $defs does not contain '{baseTypeName}'");
+
+        var kinds = new HashSet<string>();
+
+        if (!unionDef.TryGetProperty("oneOf", out var oneOf))
+            return kinds;
+
+        foreach (var refEntry in oneOf.EnumerateArray())
+        {
+            if (!refEntry.TryGetProperty("$ref", out var refVal))
+                continue;
+
+            var defName = refVal.GetString()!.Split('/').Last();
+
+            if (defs.TryGetProperty(defName, out var concreteDef) &&
+                concreteDef.TryGetProperty("properties", out var props) &&
+                props.TryGetProperty("kind", out var kindDef) &&
+                kindDef.TryGetProperty("const", out var constVal))
+            {
+                kinds.Add(constVal.GetString()!);
+            }
+        }
+
+        return kinds;
+    }
+}

--- a/tests/Alis.Reactive.UnitTests/Schema/WhenDiscoveringPolymorphicTypes.cs
+++ b/tests/Alis.Reactive.UnitTests/Schema/WhenDiscoveringPolymorphicTypes.cs
@@ -57,7 +57,11 @@ public class WhenDiscoveringPolymorphicTypes
                 $"{subclass.Name} is a sealed subclass of {baseType.Name} but has no Kind property");
 
             var instance = RuntimeHelpers.GetUninitializedObject(subclass);
-            var kind = (string)kindProp!.GetValue(instance)!;
+            var kind = (string?)kindProp!.GetValue(instance);
+            Assert.That(kind, Is.Not.Null,
+                $"{subclass.Name}.Kind returned null — Kind must be an expression-bodied " +
+                $"property (e.g. public string Kind => \"my-kind\"), not constructor-initialized. " +
+                $"GetUninitializedObject bypasses constructors, so constructor-set Kind will be null.");
 
             Assert.That(schemaKinds, Does.Contain(kind),
                 $"{subclass.Name} has Kind=\"{kind}\" but no matching definition exists in " +


### PR DESCRIPTION
## Summary

- **Schema-kind consistency test**: Reflection-based test discovers all 26 sealed subclasses of 8 polymorphic base types and asserts each `Kind` has a matching JSON schema definition. Catches schema drift immediately.
- **`ComponentEventTrigger.For<TComponent>()` factory**: Resolves `Vendor` and `ReadExpr` from `IComponent`/`IInputComponent` via `new()` constraint — reduces 5-arg constructor to 3 args across all 22 ReactiveExtensions files.
- **`ReactiveWiringHelper.Wire()` internal helper**: Extracts shared PipelineBuilder/trigger/entry wiring from every `.Reactive()` extension. Each file reduced from ~10 lines of body to ~3 lines. Net: -322 lines, +217 lines.

Zero plan JSON shape changes. Zero TS runtime changes. Zero public API changes. All 2,178 tests passing.

## Test plan

- [x] New `WhenDiscoveringPolymorphicTypes` test passes (8 parameterized cases, 26 subclasses verified)
- [x] All C# unit tests pass (302)
- [x] All Native unit tests pass (73)
- [x] All Fusion unit tests pass (103)
- [x] All FluentValidator unit tests pass (73)
- [x] All TS unit tests pass (1,071)
- [x] All Playwright browser tests pass (556)
- [x] Zero snapshot changes — plan JSON shape identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)