### PR TITLE
fix: rename parameters to match base class declarations (S927)

### DIFF
--- a/Alis.Reactive.SandboxApp/Hubs/RealTimeBroadcastService.cs
+++ b/Alis.Reactive.SandboxApp/Hubs/RealTimeBroadcastService.cs
@@ -20,17 +20,17 @@ public class RealTimeBroadcastService(
     private static readonly string[] CareLevels =
         ["Assisted Living", "Memory Care", "Independent", "Skilled Nursing", "Assisted Living"];
 
-    protected override async Task ExecuteAsync(CancellationToken ct)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var counter = 0;
 
-        while (!ct.IsCancellationRequested)
+        while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
-                await Task.Delay(2000, ct);
+                await Task.Delay(2000, stoppingToken);
             }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 break;
             }
@@ -46,7 +46,7 @@ public class RealTimeBroadcastService(
                     Count = counter,
                     Message = $"[{now}] #{counter} — {Residents[idx]} status update",
                     Priority = counter % 3 == 0 ? "high" : "normal"
-                }, ct);
+                }, stoppingToken);
 
                 await residentHub.Clients.All.SendAsync("StatusChanged", new ResidentStatusPayload
                 {
@@ -54,9 +54,9 @@ public class RealTimeBroadcastService(
                     Status = Statuses[idx],
                     CareLevel = CareLevels[idx],
                     UpdatedAt = DateTime.UtcNow
-                }, ct);
+                }, stoppingToken);
             }
-            catch (Exception ex) when (!ct.IsCancellationRequested)
+            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
             {
                 logger.LogWarning(ex, "Broadcast failed — will retry next cycle");
             }

--- a/Alis.Reactive/Serialization/WriteOnlyPolymorphicConverter.cs
+++ b/Alis.Reactive/Serialization/WriteOnlyPolymorphicConverter.cs
@@ -9,7 +9,7 @@ namespace Alis.Reactive.Serialization
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
             => JsonSerializer.Serialize(writer, value, value!.GetType(), options);
 
-        public override T Read(ref Utf8JsonReader reader, Type type, JsonSerializerOptions options)
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             => throw new NotSupportedException("Plan descriptors are write-only.");
     }
 }


### PR DESCRIPTION
## Summary
- Rename `ct` → `stoppingToken` in `RealTimeBroadcastService.ExecuteAsync` to match `BackgroundService` base class parameter name
- Rename `type` → `typeToConvert` in `WriteOnlyPolymorphicConverter.Read` to match `JsonConverter<T>` base class parameter name

Closes #20

## Test plan
- [x] dotnet test UnitTests passes (294 tests)
- [x] Zero behavior change — signature-only renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)