### PR TITLE
fix: extract handleVisible/handleHidden from loader init (S3776)

### DIFF
--- a/Alis.Reactive.SandboxApp/Scripts/components/native/loader.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/components/native/loader.ts
@@ -3,44 +3,48 @@
 // Plan-driven show/hide uses existing native mutations (AddClass/RemoveClass).
 export {}; // Module marker — prevents TS global-scope collisions
 
+function handleVisible(loader: HTMLElement): void {
+  const targetId = loader.getAttribute("data-target");
+  if (targetId) {
+    const target = document.getElementById(targetId);
+    if (target) {
+      target.style.position = "relative";
+      target.appendChild(loader);
+    }
+  }
+
+  const timeout = loader.getAttribute("data-timeout");
+  if (timeout) {
+    const ms = parseInt(timeout, 10);
+    if (ms > 0) {
+      setTimeout(() => {
+        loader.classList.remove("alis-loader--visible");
+        loader.setAttribute("aria-hidden", "true");
+      }, ms);
+    }
+  }
+}
+
+function handleHidden(loader: HTMLElement): void {
+  if (loader.parentElement !== document.body) {
+    document.body.appendChild(loader);
+  }
+  loader.removeAttribute("data-target");
+  loader.removeAttribute("data-timeout");
+  const msg = document.getElementById("alis-loader-message");
+  if (msg) msg.textContent = "";
+}
+
 function init(): void {
   const loader = document.getElementById("alis-loader");
   if (!loader) return;
 
   const observer = new MutationObserver(() => {
     const visible = loader.classList.contains("alis-loader--visible");
-
     if (visible) {
-      // Target: move loader inside target element
-      const targetId = loader.getAttribute("data-target");
-      if (targetId) {
-        const target = document.getElementById(targetId);
-        if (target) {
-          target.style.position = "relative";
-          target.appendChild(loader);
-        }
-      }
-
-      // Timeout: auto-hide after N ms
-      const timeout = loader.getAttribute("data-timeout");
-      if (timeout) {
-        const ms = parseInt(timeout, 10);
-        if (ms > 0) {
-          setTimeout(() => {
-            loader.classList.remove("alis-loader--visible");
-            loader.setAttribute("aria-hidden", "true");
-          }, ms);
-        }
-      }
+      handleVisible(loader);
     } else {
-      // Cleanup: move back to body, clear message, clear data attrs
-      if (loader.parentElement !== document.body) {
-        document.body.appendChild(loader);
-      }
-      loader.removeAttribute("data-target");
-      loader.removeAttribute("data-timeout");
-      const msg = document.getElementById("alis-loader-message");
-      if (msg) msg.textContent = "";
+      handleHidden(loader);
     }
   });
 


### PR DESCRIPTION
## Summary
- Extract visible/hidden branches into `handleVisible()` and `handleHidden()` functions
- Drops cognitive complexity from 16 to within the SonarQube S3776 threshold

Closes #17

## Test plan
- [x] `npm test` passes (all 1092 vitest tests)
- [x] Pure refactor — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)