### PR TITLE
fix: use .dataset API for data-* attribute access (S7761)

### DIFF
--- a/Alis.Reactive.SandboxApp/Scripts/components/native/loader.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/components/native/loader.ts
@@ -12,7 +12,7 @@ function init(): void {
 
     if (visible) {
       // Target: move loader inside target element
-      const targetId = loader.getAttribute("data-target");
+      const targetId = loader.dataset.target;
       if (targetId) {
         const target = document.getElementById(targetId);
         if (target) {
@@ -22,7 +22,7 @@ function init(): void {
       }
 
       // Timeout: auto-hide after N ms
-      const timeout = loader.getAttribute("data-timeout");
+      const timeout = loader.dataset.timeout;
       if (timeout) {
         const ms = parseInt(timeout, 10);
         if (ms > 0) {
@@ -37,8 +37,8 @@ function init(): void {
       if (loader.parentElement !== document.body) {
         document.body.appendChild(loader);
       }
-      loader.removeAttribute("data-target");
-      loader.removeAttribute("data-timeout");
+      delete loader.dataset.target;
+      delete loader.dataset.timeout;
       const msg = document.getElementById("alis-loader-message");
       if (msg) msg.textContent = "";
     }

--- a/Alis.Reactive.SandboxApp/Scripts/components/native/native-action-link.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/components/native/native-action-link.ts
@@ -47,7 +47,7 @@ function handleClick(event: MouseEvent): void {
 }
 
 function decodePayload(anchor: HTMLAnchorElement): NativeActionLinkPayload {
-  const raw = anchor.getAttribute("data-reactive-link");
+  const raw = anchor.dataset.reactiveLink;
   if (!raw) {
     throw new Error("NativeActionLink is missing data-reactive-link.");
   }

--- a/Alis.Reactive.SandboxApp/Scripts/root.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/root.ts
@@ -20,7 +20,7 @@ const planEls = document.querySelectorAll<HTMLElement>("[data-reactive-plan]");
 const plans: Plan[] = [];
 
 for (const el of planEls) {
-  const traceLevel = el.getAttribute("data-trace") as TraceLevel | null;
+  const traceLevel = el.dataset.trace as TraceLevel | undefined;
   if (traceLevel) trace.setLevel(traceLevel);
 
   try {

--- a/Alis.Reactive.SandboxApp/Scripts/validation/error-display.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/validation/error-display.ts
@@ -49,7 +49,7 @@ export function clearAllInline(formId: string, fields: ValidationField[]): void 
 
 export function addToSummary(summaryEl: HTMLElement, fieldName: string, message: string): void {
   const item = document.createElement("div");
-  item.setAttribute("data-valmsg-summary-for", fieldName);
+  item.dataset.valmsgSummaryFor = fieldName;
   item.textContent = message;
   summaryEl.appendChild(item);
 }


### PR DESCRIPTION
## Summary
- Replace getAttribute/setAttribute/removeAttribute with .dataset for all data-* attributes
- 6 occurrences across 4 files: loader.ts, error-display.ts, native-action-link.ts, root.ts

Closes #32

## Test plan
- [x] npm test passes (1092 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)