### PR TITLE
fix: extract nested ternary operations into readable statements (S3358)

### DIFF
--- a/Alis.Reactive.SandboxApp/Scripts/conditions/conditions.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/conditions/conditions.ts
@@ -97,9 +97,10 @@ function evaluateValueGuard(guard: ValueGuard, ctx?: ExecContext): boolean {
   const rawOp = guard.rightSource
     ? resolveSourceAs(guard.rightSource, opCoerceAs, ctx)
     : guard.operand;
-  const operand = rawOp != null && !guard.rightSource
-    ? (Array.isArray(rawOp) ? rawOp.map(v => coerce(v, opCoerceAs)) : coerce(rawOp, opCoerceAs))
-    : rawOp;
+  let operand: unknown = rawOp;
+  if (rawOp != null && !guard.rightSource) {
+    operand = Array.isArray(rawOp) ? rawOp.map(v => coerce(v, opCoerceAs)) : coerce(rawOp, opCoerceAs);
+  }
 
   // For array sources with element coercion: pre-coerce elements so switch cases stay pure.
   // For non-array operators elementCoerceAs is null → items is undefined → unused.

--- a/Alis.Reactive.SandboxApp/Scripts/execution/trigger.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/execution/trigger.ts
@@ -41,9 +41,12 @@ export function wireTrigger(
       const expr = trigger.readExpr;
       log.debug("component-event", { componentId: trigger.componentId, jsEvent: trigger.jsEvent, vendor: trigger.vendor });
       (root as EventTarget).addEventListener(trigger.jsEvent, (e: any) => {
-        const detail = trigger.vendor === "native"
-          ? (expr ? { [expr]: walk(el, expr), event: e } : { event: e })
-          : (e ?? {});
+        let detail: Record<string, unknown>;
+        if (trigger.vendor === "native") {
+          detail = expr ? { [expr]: walk(el, expr), event: e } : { event: e };
+        } else {
+          detail = e ?? {};
+        }
         executeReaction(reaction, { evt: detail, components }).catch(err => log.error("reaction failed", { error: String(err) }));
       }, opts);
       break;


### PR DESCRIPTION
## Summary
- conditions.ts: replace nested ternary in operand coercion with if/else
- trigger.ts: replace nested ternary in component event detail with if/else

Closes #33

## Test plan
- [x] npm test passes (1092 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)