### PR TITLE
fix: collapse duplicate branches in firstMutationTarget (S1871)

### DIFF
--- a/Alis.Reactive.SandboxApp/Scripts/execution/retry-indicator.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/execution/retry-indicator.ts
@@ -13,8 +13,9 @@ const RETRY_ATTR = "data-alis-retry";
  */
 export function firstMutationTarget(reaction: Reaction): string | undefined {
   let commands: Command[] | undefined;
-  if (reaction.kind === "sequential") commands = reaction.commands;
-  else if (reaction.kind === "conditional") commands = reaction.commands;
+  if (reaction.kind === "sequential" || reaction.kind === "conditional") {
+    commands = reaction.commands;
+  }
 
   const cmd = commands?.find(c => c.kind === "mutate-element");
   return cmd?.kind === "mutate-element" ? cmd.target : undefined;


### PR DESCRIPTION
## Summary
- Collapse identical if/else-if branches into single condition with ||

Closes #34

## Test plan
- [x] npm test passes (1092 tests)
- [x] when-extracting-mutation-targets.test.ts covers both sequential and conditional

🤖 Generated with [Claude Code](https://claude.com/claude-code)