### PR TITLE
fix: use optional chaining for array-contains guard (S6582)

### DIFF
--- a/Alis.Reactive.SandboxApp/Scripts/conditions/conditions.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/conditions/conditions.ts
@@ -131,7 +131,7 @@ function evaluateValueGuard(guard: ValueGuard, ctx?: ExecContext): boolean {
 
     // Array membership — elements and operand pre-coerced via elementCoerceAs above
     case "array-contains":
-      return items != null && items.includes(operand);
+      return items?.includes(operand) ?? false;
 
     // Text
     case "contains":


### PR DESCRIPTION
## Summary
- Replace `items != null && items.includes(operand)` with `items?.includes(operand) ?? false`

Closes #35

## Test plan
- [x] npm test passes (1092 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)