### PR TITLE
fix: mark _el and _input as readonly in TestWidget (S2933)

### DIFF
--- a/Alis.Reactive.SandboxApp/Scripts/components/lab/test-widget.ts
+++ b/Alis.Reactive.SandboxApp/Scripts/components/lab/test-widget.ts
@@ -13,8 +13,8 @@
  */
 
 export class TestWidget {
-  private _el: HTMLElement;
-  private _input: HTMLInputElement;
+  private readonly _el: HTMLElement;
+  private readonly _input: HTMLInputElement;
   private _value: string;
   private _items: unknown[];
   private _focused: boolean;


### PR DESCRIPTION
## Summary
- Mark `_el` and `_input` as `private readonly` — assigned in constructor, never reassigned

Closes #37

## Test plan
- [x] npm test passes (1092 tests)
- [x] readonly has zero runtime effect — compile-time safety only

🤖 Generated with [Claude Code](https://claude.com/claude-code)