### PR TITLE
fix: ArgumentNullException.ThrowIfNull + SonarQube Won't Fix cleanup

### DIFF
--- a/Alis.Reactive.Native/Components/NativeActionLink/NativeActionLinkHtmlExtensions.cs
+++ b/Alis.Reactive.Native/Components/NativeActionLink/NativeActionLinkHtmlExtensions.cs
@@ -13,8 +13,8 @@ namespace Alis.Reactive.Native.Components
             Action<PipelineBuilder<TModel>> configure)
             where TModel : class
         {
-            if (html == null) throw new ArgumentNullException(nameof(html));
-            if (configure == null) throw new ArgumentNullException(nameof(configure));
+            ArgumentNullException.ThrowIfNull(html);
+            ArgumentNullException.ThrowIfNull(configure);
 
             var contract = NativeActionLinkSerializer.CreateContract(url, configure);
             var elementId = NativeActionLinkIdGenerator.Next<TModel>(html.ViewContext);


### PR DESCRIPTION
## Summary
- NativeActionLinkHtmlExtensions: `if (x == null) throw` → `ArgumentNullException.ThrowIfNull(x)` (CA1510)
- Bulk Won't Fix in SonarQube for by-design patterns:
  - S4136 (8): overloads grouped by semantics, not by name
  - S2094 (5): empty MVC model markers required for @model directive
  - S3267 (5): recursive validation tree walking — LINQ hurts readability
  - S1192 (4): plan contract strings (textContent, innerHTML) — not magic strings

## Test plan
- [x] 73 Native unit tests pass
- [x] Zero behavior change — ThrowIfNull produces identical exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)