### PR TITLE
fix: CI Playwright job — correct npm paths

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -74,14 +74,12 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: Alis.Reactive.SandboxApp/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install npm dependencies
-        working-directory: Alis.Reactive.SandboxApp
         run: npm ci
 
       - name: Build JS + CSS bundles
-        working-directory: Alis.Reactive.SandboxApp
         run: npm run build:all
 
       - name: Build all C# projects


### PR DESCRIPTION
## Summary
- Fix `cache-dependency-path` from `Alis.Reactive.SandboxApp/package-lock.json` (doesn't exist) to `package-lock.json` (root)
- Fix `npm ci` and `npm run build:all` working directory from `Alis.Reactive.SandboxApp` to root (where `package.json` lives)

## Test plan
- [ ] CI Playwright job should pass npm install + build steps (may still fail on Playwright browser install if .NET 10 preview isn't available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)