### PR TITLE
fix: Playwright report viewable at permanent URL on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-docs:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -55,8 +55,10 @@ jobs:
 
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: docs-dist
           path: docs-site/dist
 
   playwright:
@@ -109,11 +111,30 @@ jobs:
           retention-days: 14
 
   deploy:
-    needs: build
+    needs: [build-docs, playwright]
+    if: always() && needs.build-docs.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Download docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-dist
+          path: site
+
+      - name: Download Playwright report
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: playwright-report
+          path: site/reports/playwright
+
+      - name: Upload merged Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Playwright HTML report now served at a permanent URL on GitHub Pages
- Report URL: `https://marafiq.github.io/alis-reactive/reports/playwright/TestResults/playwright-report.html`

## Pipeline structure
```
build-docs ──┐
             ├──> deploy (merge artifacts → Pages)
playwright ──┘
```
- Both jobs run in parallel
- Deploy waits for both, merges docs + report into one Pages deployment
- Deploy proceeds even if Playwright fails (only requires docs build success)

## Test plan
- [x] Previous run (#56) confirmed all Playwright steps pass
- [ ] This run should produce a viewable report at the URL above

🤖 Generated with [Claude Code](https://claude.com/claude-code)