### PR TITLE
fix: replace hardcoded sandbox URLs with tag helpers

### DIFF
--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Cascading/CascadingController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Cascading/CascadingController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class CascadingController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.Countries = new List<CountryItem>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/CrossVendor/ArchitectureController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/CrossVendor/ArchitectureController.cs
@@ -7,7 +7,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class ArchitectureController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/AllModulesTogether/Architecture/Index.cshtml");

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/CrossVendor/TestWidgetController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/CrossVendor/TestWidgetController.cs
@@ -7,7 +7,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class TestWidgetController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/AllModulesTogether/TestWidget/Index.cshtml");

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/FormPatterns/IdGeneratorController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/FormPatterns/IdGeneratorController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class IdGeneratorController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/AllModulesTogether/IdGenerator/Index.cshtml", new IdGeneratorModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/ReactiveWiring/PlaygroundSyntaxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/ReactiveWiring/PlaygroundSyntaxController.cs
@@ -9,7 +9,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class PlaygroundSyntaxController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.StatusItems = new List<SelectListItem>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Workflows/BddExperimentController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Workflows/BddExperimentController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class BddExperimentController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index() => View("~/Areas/Sandbox/Views/AllModulesTogether/BddExperiment/Index.cshtml");
 
         [HttpPost("Submit")]

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Workflows/ComponentGatherController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Workflows/ComponentGatherController.cs
@@ -10,7 +10,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class ComponentGatherController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.MobilityOptions = new SelectListItem[]

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Workflows/TodoController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/AllModulesTogether/Workflows/TodoController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.AllModulesTogether.
     public class TodoController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/AllModulesTogether/Todo/Index.cshtml", new TodoModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/AppLevel/DrawerController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/AppLevel/DrawerController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.AppLevel
     public class DrawerController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/AppLevel/Drawer/Index.cshtml", new DrawerModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/AutoCompleteController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/AutoCompleteController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class AutoCompleteController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.Physicians = new List<PhysicianItem>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DateRangePickerController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DateRangePickerController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class DateRangePickerController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/DateRangePicker/Index.cshtml", new DateRangePickerModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DateTimePickerController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DateTimePickerController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class DateTimePickerController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/DateTimePicker/Index.cshtml", new DateTimePickerModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DropDownListController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DropDownListController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class DropDownListController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.Categories = new List<string> { "Electronics", "Clothing", "Food", "Books" };

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/FileUploadController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/FileUploadController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class FileUploadController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/FileUpload/Index.cshtml", new FileUploadModel { ResidentName = "Margaret Thompson" });

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/FusionDatePickerController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/FusionDatePickerController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class FusionDatePickerController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/FusionDatePicker/Index.cshtml", new FusionDatePickerModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/InputMaskController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/InputMaskController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class InputMaskController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/InputMask/Index.cshtml", new InputMaskModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MultiColumnComboBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MultiColumnComboBoxController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class MultiColumnComboBoxController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.Facilities = new List<FacilityItem>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MultiSelectController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MultiSelectController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class MultiSelectController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.Allergies = new List<AllergyItem>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/NumericTextBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/NumericTextBoxController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class NumericTextBoxController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/NumericTextBox/Index.cshtml", new NumericTextBoxModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/RichTextEditorController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/RichTextEditorController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class RichTextEditorController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/RichTextEditor/Index.cshtml", new RichTextEditorModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SwitchController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SwitchController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class SwitchController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/Switch/Index.cshtml", new SwitchModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/TimePickerController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/TimePickerController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class TimePickerController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/TimePicker/Index.cshtml", new TimePickerModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/CheckBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/CheckBoxController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class CheckBoxController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Native/CheckBox/Index.cshtml", new CheckBoxModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeButtonController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeButtonController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class NativeButtonController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Native/NativeButton/Index.cshtml", new NativeButtonModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeCheckListController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeCheckListController.cs
@@ -9,7 +9,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class NativeCheckListController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.AllergyItems = new[]

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeDropDownController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeDropDownController.cs
@@ -9,7 +9,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class NativeDropDownController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.CareLevelItems = new[]

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeHiddenFieldController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeHiddenFieldController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class NativeHiddenFieldController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Native/NativeHiddenField/Index.cshtml", new NativeHiddenFieldModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeRadioGroupController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeRadioGroupController.cs
@@ -9,7 +9,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class NativeRadioGroupController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.RoomTypeItems = new[]

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeTextAreaController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeTextAreaController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class NativeTextAreaController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Native/NativeTextArea/Index.cshtml", new NativeTextAreaModel { CareNotes = "Patient admitted. Initial assessment completed." });

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeTextBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/NativeTextBoxController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
     public class NativeTextBoxController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Native/NativeTextBox/Index.cshtml", new NativeTextBoxModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/AdmissionAssessmentController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/AdmissionAssessmentController.cs
@@ -21,7 +21,6 @@ public class AdmissionAssessmentController : Controller
     // ── GET Index ──────────────────────────────────────────────────────────────
 
     [HttpGet("")]
-    [HttpGet("Index")]
     public IActionResult Index([FromQuery] string? screeningId)
     {
         var id = screeningId ?? "";

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/AdmissionWizardController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/AdmissionWizardController.cs
@@ -54,7 +54,6 @@ public class AdmissionWizardController : Controller
     // ── GET Index — shell page, Step 1 loads on DomReady via Into() ──────────
 
     [HttpGet("")]
-    [HttpGet("Index")]
     public IActionResult Index([FromQuery] string? screeningId)
     {
         ViewBag.ScreeningId = screeningId ?? "";

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/CareLevelCascadeController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/CareLevelCascadeController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Conditions;
 public class CareLevelCascadeController : Controller
 {
     [HttpGet("")]
-    [HttpGet("Index")]
     public IActionResult Index()
     {
         ViewBag.CareLevels = new List<string>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/ConditionsController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/ConditionsController.cs
@@ -7,7 +7,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Conditions
     public class ConditionsController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Conditions/Guards/Index.cshtml");

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/HttpMixingController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/HttpMixingController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Conditions
     public class HttpMixingController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Conditions/HttpMixing/Index.cshtml", new HttpMixingModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/NumericConditionController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/NumericConditionController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Conditions;
 public class NumericConditionController : Controller
 {
     [HttpGet("")]
-    [HttpGet("Index")]
     public IActionResult Index()
     {
         return View("~/Areas/Sandbox/Views/Conditions/NumericCondition/Index.cshtml", new NumericConditionModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/VitalsAlertController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Conditions/VitalsAlertController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Conditions;
 public class VitalsAlertController : Controller
 {
     [HttpGet("")]
-    [HttpGet("Index")]
     public IActionResult Index()
     {
         return View("~/Areas/Sandbox/Views/Conditions/VitalsAlert/Index.cshtml", new VitalsAlertModel

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/CoreBehaviors/EventsController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/CoreBehaviors/EventsController.cs
@@ -7,7 +7,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.CoreBehaviors
     public class EventsController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/CoreBehaviors/Events/Index.cshtml");

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/CoreBehaviors/PayloadController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/CoreBehaviors/PayloadController.cs
@@ -7,7 +7,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.CoreBehaviors
     public class PayloadController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/CoreBehaviors/Payload/Index.cshtml");

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/HttpPipeline/ContentTypeController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/HttpPipeline/ContentTypeController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.HttpPipeline
     public class ContentTypeController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/HttpPipeline/ContentType/Index.cshtml");

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/HttpPipeline/HttpController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/HttpPipeline/HttpController.cs
@@ -17,7 +17,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.HttpPipeline
         private static HashSet<int> _deletedNativeActionLinkRows = new HashSet<int>();
 
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ResetNativeActionLinkRows();

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/HttpPipeline/RealTimeController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/HttpPipeline/RealTimeController.cs
@@ -21,7 +21,6 @@ public class RealTimeController : Controller
     }
 
     [HttpGet("")]
-    [HttpGet("Index")]
     public IActionResult Index() => View("~/Areas/Sandbox/Views/HttpPipeline/RealTime/Index.cshtml");
 
     [HttpGet("ResidentPanel")]

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/DateValidationController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/DateValidationController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Validation
     public class DateValidationController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Validation/DateRules/Index.cshtml", new DateValidationModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/NewRuleTypesController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/NewRuleTypesController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Validation
     public class NewRuleTypesController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Validation/SpecializedRules/Index.cshtml", new NewRuleTypesModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/ValidationContractController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/ValidationContractController.cs
@@ -8,7 +8,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Validation
     public class ValidationContractController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             ViewBag.CareLevels = new[] { "Independent", "Assisted Living", "Memory Care" };

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/ValidationController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Validation/ValidationController.cs
@@ -9,7 +9,6 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Validation
     public class ValidationController : Controller
     {
         [HttpGet("")]
-        [HttpGet("Index")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Validation/AllRules/Index.cshtml", new ValidationShowcaseModel());

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/AllModulesTogether/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/AllModulesTogether/Index.cshtml
@@ -12,7 +12,7 @@
         <h2 class="text-lg font-semibold text-text-primary">Cross Vendor</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="/Sandbox/AllModulesTogether/Architecture"
+        <a asp-area="Sandbox" asp-controller="Architecture" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -21,11 +21,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Vendor-agnostic architecture regression tests
+                End-to-end regression page: prop reads, prop writes, method calls, and event wiring tested across both native and Fusion vendors
             </p>
         </a>
 
-        <a href="/Sandbox/AllModulesTogether/TestWidget"
+        <a asp-area="Sandbox" asp-controller="TestWidget" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -34,7 +34,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Synthetic component API exercising all interaction types
+                Synthetic test component that mimics a vendor widget — interact with it to verify the runtime handles prop reads, writes, and method calls correctly
             </p>
         </a>
     </div>
@@ -47,7 +47,7 @@
         <h2 class="text-lg font-semibold text-text-primary">Cascading</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="/Sandbox/AllModulesTogether/Cascading"
+        <a asp-area="Sandbox" asp-controller="Cascading" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -56,7 +56,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Cascading dropdowns, dependent field updates
+                Select a country, see states load from the server, then select a state to load cities — full dependent chain
             </p>
         </a>
     </div>
@@ -69,7 +69,7 @@
         <h2 class="text-lg font-semibold text-text-primary">Reactive Wiring</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="/Sandbox/AllModulesTogether/PlaygroundSyntax"
+        <a asp-area="Sandbox" asp-controller="PlaygroundSyntax" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -78,7 +78,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                DSL syntax exploration, reactive condition patterns
+                Playground combining field wrappers, reactive event wiring, and cross-vendor components in a single view
             </p>
         </a>
     </div>
@@ -91,7 +91,7 @@
         <h2 class="text-lg font-semibold text-text-primary">Form Patterns</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="/Sandbox/AllModulesTogether/IdGenerator"
+        <a asp-area="Sandbox" asp-controller="IdGenerator" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -100,7 +100,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Plan-driven element ID generation
+                See how element IDs are auto-generated from model expressions — inspect DOM to verify deterministic IDs
             </p>
         </a>
     </div>
@@ -113,7 +113,7 @@
         <h2 class="text-lg font-semibold text-text-primary">Workflows</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="/Sandbox/AllModulesTogether/ComponentGather"
+        <a asp-area="Sandbox" asp-controller="ComponentGather" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -122,11 +122,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Gather values from multiple components into payload
+                Fill in multiple component types (text, numeric, dropdown, checkbox) then POST — see all values gathered into a single JSON payload
             </p>
         </a>
 
-        <a href="/Sandbox/AllModulesTogether/Todo"
+        <a asp-area="Sandbox" asp-controller="Todo" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -135,11 +135,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Full CRUD workflow with validation
+                Complete Todo app: add items, toggle done, delete — full create/read/update/delete with validation and server persistence
             </p>
         </a>
 
-        <a href="/Sandbox/AllModulesTogether/BddExperiment"
+        <a asp-area="Sandbox" asp-controller="BddExperiment" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -148,7 +148,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Resident admission workflow, BDD-driven design
+                Resident admission form designed BDD-first — fill fields, see conditions react, submit to see validation and server response
             </p>
         </a>
     </div>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -12,7 +12,7 @@
         <h2 class="text-lg font-semibold text-text-primary">Native</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        <a href="/Sandbox/Components/NativeButton"
+        <a asp-area="Sandbox" asp-controller="NativeButton" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -21,11 +21,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Click triggers, dispatch on click
+                Click a button, see it dispatch a custom event and trigger DOM mutations
             </p>
         </a>
 
-        <a href="/Sandbox/Components/NativeTextBox"
+        <a asp-area="Sandbox" asp-controller="NativeTextBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -34,11 +34,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Text input, reactive value binding
+                Type text and see value binding update other elements reactively via input events
             </p>
         </a>
 
-        <a href="/Sandbox/Components/CheckBox"
+        <a asp-area="Sandbox" asp-controller="CheckBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -47,11 +47,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Boolean checked binding, toggle behavior
+                Toggle a checkbox and see checked state read as boolean, driving show/hide and other reactions
             </p>
         </a>
 
-        <a href="/Sandbox/Components/NativeCheckList"
+        <a asp-area="Sandbox" asp-controller="NativeCheckList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -60,11 +60,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Multi-select checkbox group
+                Check multiple items from a group, see selected values gathered as an array for HTTP POST
             </p>
         </a>
 
-        <a href="/Sandbox/Components/NativeDropDown"
+        <a asp-area="Sandbox" asp-controller="NativeDropDown" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -73,11 +73,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Native select element, option binding
+                Pick from a native select element, see the selected value drive conditions and downstream mutations
             </p>
         </a>
 
-        <a href="/Sandbox/Components/NativeRadioGroup"
+        <a asp-area="Sandbox" asp-controller="NativeRadioGroup" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -86,11 +86,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Radio button group, single selection
+                Select one option from a radio group, see the chosen value reactively update the page
             </p>
         </a>
 
-        <a href="/Sandbox/Components/NativeTextArea"
+        <a asp-area="Sandbox" asp-controller="NativeTextArea" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -99,11 +99,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Multi-line text input
+                Type in a textarea and see value binding, useful for care notes and long-form input
             </p>
         </a>
 
-        <a href="/Sandbox/Components/NativeHiddenField"
+        <a asp-area="Sandbox" asp-controller="NativeHiddenField" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -112,7 +112,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Hidden form value, gather source
+                Invisible input that carries IDs and tokens — see it gathered into HTTP POST payloads alongside visible fields
             </p>
         </a>
     </div>
@@ -125,7 +125,7 @@
         <h2 class="text-lg font-semibold text-text-primary">Fusion</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        <a href="/Sandbox/Components/DropDownList"
+        <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -134,11 +134,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Syncfusion dropdown, value binding
+                Syncfusion dropdown — select a value and see it update other components and get included in form submissions
             </p>
         </a>
 
-        <a href="/Sandbox/Components/NumericTextBox"
+        <a asp-area="Sandbox" asp-controller="NumericTextBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -147,11 +147,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Numeric input with coercion
+                Enter a number and see it treated as a true numeric value — used in conditions and form submissions without type issues
             </p>
         </a>
 
-        <a href="/Sandbox/Components/AutoComplete"
+        <a asp-area="Sandbox" asp-controller="AutoComplete" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -160,11 +160,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Type-ahead suggestions, async filtering
+                Start typing to see async-filtered suggestions from the server, select one to fire change events
             </p>
         </a>
 
-        <a href="/Sandbox/Components/MultiSelect"
+        <a asp-area="Sandbox" asp-controller="MultiSelect" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -173,11 +173,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Multi-value selection dropdown
+                Pick multiple items from a dropdown, see selected array gathered for POST payloads
             </p>
         </a>
 
-        <a href="/Sandbox/Components/FusionDatePicker"
+        <a asp-area="Sandbox" asp-controller="FusionDatePicker" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -186,11 +186,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Date selection with calendar popup
+                Pick a date from the calendar popup, see it formatted as ISO for use in conditions and form submissions
             </p>
         </a>
 
-        <a href="/Sandbox/Components/DateTimePicker"
+        <a asp-area="Sandbox" asp-controller="DateTimePicker" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -199,11 +199,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Combined date and time selection
+                Pick date and time together — useful for medication schedules and appointment booking
             </p>
         </a>
 
-        <a href="/Sandbox/Components/TimePicker"
+        <a asp-area="Sandbox" asp-controller="TimePicker" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -212,11 +212,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Time-only selection
+                Pick a time value, see it bound reactively — useful for shift schedules and routine timing
             </p>
         </a>
 
-        <a href="/Sandbox/Components/DateRangePicker"
+        <a asp-area="Sandbox" asp-controller="DateRangePicker" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -225,11 +225,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Start/end date range selection
+                Select a start and end date range for billing periods or stay durations
             </p>
         </a>
 
-        <a href="/Sandbox/Components/MultiColumnComboBox"
+        <a asp-area="Sandbox" asp-controller="MultiColumnComboBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -238,11 +238,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Multi-column dropdown with grid display
+                Search and select from a multi-column grid dropdown showing structured data (name, code, description)
             </p>
         </a>
 
-        <a href="/Sandbox/Components/InputMask"
+        <a asp-area="Sandbox" asp-controller="InputMask" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -251,11 +251,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Masked input with format enforcement
+                Type into a masked field (phone, SSN format) — input is constrained to the mask pattern automatically
             </p>
         </a>
 
-        <a href="/Sandbox/Components/RichTextEditor"
+        <a asp-area="Sandbox" asp-controller="RichTextEditor" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -264,11 +264,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                WYSIWYG HTML editor
+                Rich text editor with toolbar — type formatted content, see HTML value gathered for POST
             </p>
         </a>
 
-        <a href="/Sandbox/Components/Switch"
+        <a asp-area="Sandbox" asp-controller="Switch" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -277,11 +277,11 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Toggle switch, boolean binding
+                Flip the toggle switch and see its boolean state drive conditions and update other components
             </p>
         </a>
 
-        <a href="/Sandbox/Components/FileUpload"
+        <a asp-area="Sandbox" asp-controller="FileUpload" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -290,7 +290,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                File upload with validation
+                Select files and see them uploaded via FormData POST, with reactive feedback on upload progress
             </p>
         </a>
     </div>
@@ -303,7 +303,7 @@
         <h2 class="text-lg font-semibold text-text-primary">App Level</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        <a href="/Sandbox/Components/Drawer"
+        <a asp-area="Sandbox" asp-controller="Drawer" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
             <div class="flex items-start justify-between">
                 <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -312,7 +312,7 @@
                 <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
             </div>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Slide-out panel, partial content loading
+                Click to open a slide-out drawer panel, see partial HTML loaded into it via Into()
             </p>
         </a>
     </div>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Conditions/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Conditions/Index.cshtml
@@ -6,7 +6,7 @@
 <p class="text-text-secondary mb-8">Guard evaluation and branching</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-    <a href="/Sandbox/Conditions/Guards"
+    <a asp-area="Sandbox" asp-controller="Conditions" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -15,11 +15,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            All 20 operators, AND/OR composition, NOT inversion, per-action When guards
+            Interactive demo of all 20 condition operators, AND/OR/NOT composition, Confirm dialog, and per-action When guards — click buttons to see guards evaluate
         </p>
     </a>
 
-    <a href="/Sandbox/Conditions/HttpMixing"
+    <a asp-area="Sandbox" asp-controller="HttpMixing" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -28,11 +28,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Conditions compose freely with HTTP blocks: after, between, inside OnSuccess/OnError, ElseIf chains, And guards
+            Conditions interleaved with HTTP requests: guards after POST, guards between chained requests, branching on success/error responses
         </p>
     </a>
 
-    <a href="/Sandbox/Conditions/NumericCondition"
+    <a asp-area="Sandbox" asp-controller="NumericCondition" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -41,11 +41,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Conditions with FusionNumericTextBox: simple Gt, ElseIf ladder, AND compound, cross-component source-vs-source
+            Type a number and watch conditions react: simple Gt threshold, ElseIf severity ladder, AND compound guards, cross-component source-vs-source comparisons
         </p>
     </a>
 
-    <a href="/Sandbox/Conditions/VitalsAlert"
+    <a asp-area="Sandbox" asp-controller="VitalsAlert" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -54,11 +54,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Condition-gated HTTP: comp.Value() > threshold → POST alert, ElseIf severity tiers, command sandwich
+            Enter vitals and see condition-gated HTTP fire: systolic > 140 posts a hypertension alert, severity tiers escalate, DOM updates wrap the request lifecycle
         </p>
     </a>
 
-    <a href="/Sandbox/Conditions/CareLevelCascade"
+    <a asp-area="Sandbox" asp-controller="CareLevelCascade" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -67,11 +67,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Condition → component mutation: dropdown cascade (SetValue), cross-component (SetChecked on switch), In() operator
+            Select a care level and watch components react: dropdown cascades set values, cross-component switch toggles, In() operator matches multiple values
         </p>
     </a>
 
-    <a href="/Sandbox/Conditions/AdmissionAssessment"
+    <a asp-area="Sandbox" asp-controller="AdmissionAssessment" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -80,7 +80,20 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Flagship: 4-step wizard, 33 fields, 17 conditions, 12 HTTP endpoints, 6 partials, validation
+            Single-page flagship: 33 fields across 6 partials, 17 reactive conditions showing/hiding sections, 12 HTTP endpoints, full validation — fill out a resident admission form
+        </p>
+    </a>
+
+    <a asp-area="Sandbox" asp-controller="AdmissionWizard" asp-action="Index"
+       class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+        <div class="flex items-start justify-between">
+            <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                Admission Wizard
+            </h3>
+            <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+        </div>
+        <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+            4-step server-side wizard: navigate forward/back with draft persistence, each step validates before advancing, final submit validates all steps together
         </p>
     </a>
 </div>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/CoreBehaviors/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/CoreBehaviors/Index.cshtml
@@ -6,7 +6,7 @@
 <p class="text-text-secondary mb-8">Plan execution fundamentals</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-    <a href="/Sandbox/CoreBehaviors/Events"
+    <a asp-area="Sandbox" asp-controller="Events" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -15,11 +15,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Three-hop dispatch chain, two-phase boot, payload
+            Live 3-hop event chain firing in sequence, DOM mutations on each hop, console trace output showing two-phase boot
         </p>
     </a>
 
-    <a href="/Sandbox/CoreBehaviors/Payload"
+    <a asp-area="Sandbox" asp-controller="Payload" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -28,7 +28,7 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Typed payload resolution, flat and nested dot-paths
+            Live display of all primitive types (int, string, bool) and nested objects (address.city, address.zip) resolved from event payload to DOM text
         </p>
     </a>
 </div>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/HttpPipeline/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/HttpPipeline/Index.cshtml
@@ -6,7 +6,7 @@
 <p class="text-text-secondary mb-8">Server communication patterns</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-    <a href="/Sandbox/HttpPipeline/Http"
+    <a asp-area="Sandbox" asp-controller="Http" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -15,11 +15,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            GET/POST verbs, chained requests, parallel pipelines
+            Click buttons to fire GET/POST requests with gather payloads, watch chained sequential requests cascade, and see parallel requests resolve concurrently
         </p>
     </a>
 
-    <a href="/Sandbox/HttpPipeline/ContentType"
+    <a asp-area="Sandbox" asp-controller="ContentType" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -28,11 +28,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            JSON vs HTML responses, content negotiation
+            Compare JSON responses (parsed into DOM mutations) vs HTML responses (injected via Into()), see how the runtime handles each content type
         </p>
     </a>
 
-    <a href="/Sandbox/HttpPipeline/RealTime"
+    <a asp-area="Sandbox" asp-controller="RealTime" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -41,7 +41,7 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            SSE streaming, live updates, retry indicators
+            Watch Server-Sent Events stream data in real time, see live DOM updates as events arrive, observe retry behavior on disconnection
         </p>
     </a>
 </div>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/SandboxHome/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/SandboxHome/Index.cshtml
@@ -24,7 +24,7 @@
 </div>
 
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-    <a href="/Sandbox/CoreBehaviors"
+    <a asp-area="Sandbox" asp-controller="CoreBehaviors" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -33,11 +33,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Plan execution: triggers, events, payload resolution
+            Watch a 3-hop event chain fire in sequence, and see typed payload values (int, string, nested objects) resolve into the page
         </p>
     </a>
 
-    <a href="/Sandbox/Conditions"
+    <a asp-area="Sandbox" asp-controller="ConditionsHome" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -46,11 +46,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Guard evaluation: operators, composition, branching
+            Interactive condition demos: toggle guards, threshold alerts, cascading dropdowns, and full admission forms with branching logic
         </p>
     </a>
 
-    <a href="/Sandbox/HttpPipeline"
+    <a asp-area="Sandbox" asp-controller="HttpPipeline" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -59,11 +59,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Server communication: verbs, chaining, responses
+            GET/POST with gather and chaining, JSON vs HTML response handling, and SSE real-time streaming
         </p>
     </a>
 
-    <a href="/Sandbox/Validation"
+    <a asp-area="Sandbox" asp-controller="ValidationHome" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -72,11 +72,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Form correctness: rules, contracts, live-clear
+            Every rule type live: required, range, regex, comparison, date, email, phone — with server-side contract integration and conditional fields
         </p>
     </a>
 
-    <a href="/Sandbox/Components"
+    <a asp-area="Sandbox" asp-controller="Components" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -85,11 +85,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Input vertical slices: Native, Fusion, AppLevel
+            Every input component: native (button, textbox, checkbox, dropdown) and Fusion (numeric, date, autocomplete, RTE, file upload) — each with its own interactive demo
         </p>
     </a>
 
-    <a href="/Sandbox/AllModulesTogether"
+    <a asp-area="Sandbox" asp-controller="AllModulesTogether" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -98,7 +98,7 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Integration tests: cross-vendor, workflows
+            Full integration scenarios: cascading dropdowns, multi-component forms, a complete Todo app, and cross-vendor architecture verification
         </p>
     </a>
 </div>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Validation/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Validation/Index.cshtml
@@ -6,7 +6,7 @@
 <p class="text-text-secondary mb-8">Form correctness and rule enforcement</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-    <a href="/Sandbox/Validation/AllRules"
+    <a asp-area="Sandbox" asp-controller="Validation" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -15,11 +15,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Complete rule showcase: required, range, regex, comparison
+            Interactive form with every rule type: required, min/max length, range, regex, comparison (equalTo, greaterThan) — submit to see errors, fix fields to see live-clear
         </p>
     </a>
 
-    <a href="/Sandbox/Validation/Contract"
+    <a asp-area="Sandbox" asp-controller="ValidationContract" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -28,11 +28,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            FluentValidation contracts, server-side merge, conditional hide
+            Full resident admission form: FluentValidation rules extracted to client-side, server-side error merge on submit, conditional field visibility tied to validation
         </p>
     </a>
 
-    <a href="/Sandbox/Validation/DateRules"
+    <a asp-area="Sandbox" asp-controller="DateValidation" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -41,11 +41,11 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Date-specific validation: past, future, range constraints
+            Date picker fields with past/future constraints, date range validation, and relative date rules — pick dates to see validation fire in real time
         </p>
     </a>
 
-    <a href="/Sandbox/Validation/SpecializedRules"
+    <a asp-area="Sandbox" asp-controller="NewRuleTypes" asp-action="Index"
        class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
         <div class="flex items-start justify-between">
             <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -54,7 +54,7 @@
             <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
         </div>
         <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-            Email, phone, credit card, URL, and custom rule types
+            Specialized input validation: email format, phone pattern, credit card (Luhn), URL format — type invalid values to see immediate feedback
         </p>
     </a>
 </div>

--- a/Alis.Reactive.SandboxApp/Views/Home/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <native-heading level="H2">Core Primitives</native-heading>
         </div>
         <native-grid cols="C3" gap="Base">
-            <a href="/Sandbox/CoreBehaviors/Events"
+            <a asp-area="Sandbox" asp-controller="Events" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -45,7 +45,7 @@
                 </p>
             </a>
 
-            <a href="/Sandbox/CoreBehaviors/Payload"
+            <a asp-area="Sandbox" asp-controller="Payload" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -58,7 +58,7 @@
                 </p>
             </a>
 
-            <a href="/Sandbox/Conditions/Guards"
+            <a asp-area="Sandbox" asp-controller="Conditions" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
@@ -80,7 +80,7 @@
             <native-heading level="H2">Native Components</native-heading>
         </div>
         <native-grid cols="C3" gap="Base">
-            <a href="/Sandbox/Components/NativeButton"
+            <a asp-area="Sandbox" asp-controller="NativeButton" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeButton</h3>
@@ -88,7 +88,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Native HTML button with click events and reactive wiring.</p>
             </a>
-            <a href="/Sandbox/Components/CheckBox"
+            <a asp-area="Sandbox" asp-controller="CheckBox" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeCheckBox</h3>
@@ -96,7 +96,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Native checkbox with checked state binding and change events.</p>
             </a>
-            <a href="/Sandbox/Components/NativeTextBox"
+            <a asp-area="Sandbox" asp-controller="NativeTextBox" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeTextBox</h3>
@@ -104,7 +104,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Native text input with value binding and input events.</p>
             </a>
-            <a href="/Sandbox/Components/NativeDropDown"
+            <a asp-area="Sandbox" asp-controller="NativeDropDown" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeDropDown</h3>
@@ -112,7 +112,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Native select element with option binding and change events.</p>
             </a>
-            <a href="/Sandbox/Components/NativeRadioGroup"
+            <a asp-area="Sandbox" asp-controller="NativeRadioGroup" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeRadioGroup</h3>
@@ -120,7 +120,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Native radio button group with single selection and change events.</p>
             </a>
-            <a href="/Sandbox/Components/NativeCheckList"
+            <a asp-area="Sandbox" asp-controller="NativeCheckList" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeCheckList</h3>
@@ -128,7 +128,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Native checkbox list with multi-select array values and change events.</p>
             </a>
-            <a href="/Sandbox/Components/NativeTextArea"
+            <a asp-area="Sandbox" asp-controller="NativeTextArea" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeTextArea</h3>
@@ -136,7 +136,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Native textarea for care notes and incident descriptions.</p>
             </a>
-            <a href="/Sandbox/Components/NativeHiddenField"
+            <a asp-area="Sandbox" asp-controller="NativeHiddenField" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#059669]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#059669] transition-colors">NativeHiddenField</h3>
@@ -154,7 +154,7 @@
             <native-heading level="H2">Fusion Components</native-heading>
         </div>
         <native-grid cols="C3" gap="Base">
-            <a href="/Sandbox/Components/NumericTextBox"
+            <a asp-area="Sandbox" asp-controller="NumericTextBox" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionNumericTextBox</h3>
@@ -162,7 +162,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion numeric input with value coercion and change events.</p>
             </a>
-            <a href="/Sandbox/Components/DropDownList"
+            <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionDropDownList</h3>
@@ -170,7 +170,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion dropdown with item binding and selection events.</p>
             </a>
-            <a href="/Sandbox/Components/AutoComplete"
+            <a asp-area="Sandbox" asp-controller="AutoComplete" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionAutoComplete</h3>
@@ -178,7 +178,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion autocomplete with filtering, selection, and source binding.</p>
             </a>
-            <a href="/Sandbox/Components/FusionDatePicker"
+            <a asp-area="Sandbox" asp-controller="FusionDatePicker" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionDatePicker</h3>
@@ -186,7 +186,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion date picker with value binding and change events.</p>
             </a>
-            <a href="/Sandbox/Components/TimePicker"
+            <a asp-area="Sandbox" asp-controller="TimePicker" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionTimePicker</h3>
@@ -194,7 +194,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion time picker with value binding and change events.</p>
             </a>
-            <a href="/Sandbox/Components/MultiColumnComboBox"
+            <a asp-area="Sandbox" asp-controller="MultiColumnComboBox" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionMultiColumnComboBox</h3>
@@ -202,7 +202,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Multi-column combo box with structured item display and selection.</p>
             </a>
-            <a href="/Sandbox/Components/MultiSelect"
+            <a asp-area="Sandbox" asp-controller="MultiSelect" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionMultiSelect</h3>
@@ -210,7 +210,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion multi-select with array values, grouping, and gather.</p>
             </a>
-            <a href="/Sandbox/Components/DateTimePicker"
+            <a asp-area="Sandbox" asp-controller="DateTimePicker" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionDateTimePicker</h3>
@@ -218,7 +218,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion date+time picker for medication schedules and appointments.</p>
             </a>
-            <a href="/Sandbox/Components/DateRangePicker"
+            <a asp-area="Sandbox" asp-controller="DateRangePicker" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionDateRangePicker</h3>
@@ -226,7 +226,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion date range with startDate/endDate for billing periods and stays.</p>
             </a>
-            <a href="/Sandbox/Components/InputMask"
+            <a asp-area="Sandbox" asp-controller="InputMask" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionInputMask</h3>
@@ -234,7 +234,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion masked input for phone numbers, SSN, and insurance IDs.</p>
             </a>
-            <a href="/Sandbox/Components/RichTextEditor"
+            <a asp-area="Sandbox" asp-controller="RichTextEditor" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionRichTextEditor</h3>
@@ -242,7 +242,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion rich text editor for care plans and discharge summaries.</p>
             </a>
-            <a href="/Sandbox/Components/Switch"
+            <a asp-area="Sandbox" asp-controller="Switch" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionSwitch</h3>
@@ -250,7 +250,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Syncfusion toggle switch for notification and alert preferences.</p>
             </a>
-            <a href="/Sandbox/Components/FileUpload"
+            <a asp-area="Sandbox" asp-controller="FileUpload" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#2563EB]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#2563EB] transition-colors">FusionFileUpload</h3>
@@ -268,7 +268,7 @@
             <native-heading level="H2">HTTP &amp; Data</native-heading>
         </div>
         <native-grid cols="C3" gap="Base">
-            <a href="/Sandbox/HttpPipeline/Http"
+            <a asp-area="Sandbox" asp-controller="Http" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#D97706]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#D97706] transition-colors">HTTP Requests</h3>
@@ -276,7 +276,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">GET, POST with gather, chained sequential, and parallel concurrent requests.</p>
             </a>
-            <a href="/Sandbox/HttpPipeline/ContentType"
+            <a asp-area="Sandbox" asp-controller="ContentType" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#D97706]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#D97706] transition-colors">Content Types</h3>
@@ -284,7 +284,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">JSON and HTML response handling with Into() content injection.</p>
             </a>
-            <a href="/Sandbox/AllModulesTogether/Cascading"
+            <a asp-area="Sandbox" asp-controller="Cascading" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#D97706]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#D97706] transition-colors">Cascading DropDowns</h3>
@@ -292,7 +292,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Dependent dropdown chains with server-side data filtering.</p>
             </a>
-            <a href="/Sandbox/AllModulesTogether/ComponentGather"
+            <a asp-area="Sandbox" asp-controller="ComponentGather" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#D97706]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#D97706] transition-colors">Component Gather</h3>
@@ -310,7 +310,7 @@
             <native-heading level="H2">Validation</native-heading>
         </div>
         <native-grid cols="C3" gap="Base">
-            <a href="/Sandbox/Validation/AllRules"
+            <a asp-area="Sandbox" asp-controller="Validation" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#DC2626]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#DC2626] transition-colors">Validation Showcase</h3>
@@ -318,7 +318,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Full validation pipeline with FluentValidation rules and error display.</p>
             </a>
-            <a href="/Sandbox/Validation/Contract"
+            <a asp-area="Sandbox" asp-controller="ValidationContract" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#DC2626]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#DC2626] transition-colors">Scenario 1 — All Fields</h3>
@@ -326,7 +326,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Single page with all field types, conditional rules, and equalTo validation.</p>
             </a>
-            <a href="/Sandbox/Validation/Contract/ConditionalHide"
+            <a asp-area="Sandbox" asp-controller="ValidationContract" asp-action="ConditionalHide"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#DC2626]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#DC2626] transition-colors">Scenario 2 — Show/Hide</h3>
@@ -334,7 +334,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Conditional visibility aligned with validation conditions.</p>
             </a>
-            <a href="/Sandbox/Validation/Contract/ServerPartial"
+            <a asp-area="Sandbox" asp-controller="ValidationContract" asp-action="ServerPartial"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#DC2626]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#DC2626] transition-colors">Scenario 3a — Server Partials</h3>
@@ -342,7 +342,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Server-rendered partials with merged plans and own reactive behavior.</p>
             </a>
-            <a href="/Sandbox/Validation/Contract/AjaxPartial"
+            <a asp-area="Sandbox" asp-controller="ValidationContract" asp-action="AjaxPartial"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#DC2626]/20 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#DC2626] transition-colors">Scenario 3b — AJAX Partials</h3>
@@ -360,7 +360,7 @@
             <native-heading level="H2">Framework Infrastructure</native-heading>
         </div>
         <native-grid cols="C3" gap="Base">
-            <a href="/Sandbox/AllModulesTogether/IdGenerator"
+            <a asp-area="Sandbox" asp-controller="IdGenerator" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#6B7280]/30 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#4B5563] transition-colors">IdGenerator</h3>
@@ -368,7 +368,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Automatic element ID generation from model expressions.</p>
             </a>
-            <a href="/Sandbox/AllModulesTogether/Architecture"
+            <a asp-area="Sandbox" asp-controller="Architecture" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#6B7280]/30 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#4B5563] transition-colors">Architecture Regression</h3>
@@ -376,7 +376,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">End-to-end architecture test with TestWidget exercising all module paths.</p>
             </a>
-            <a href="/Sandbox/AllModulesTogether/PlaygroundSyntax"
+            <a asp-area="Sandbox" asp-controller="PlaygroundSyntax" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#6B7280]/30 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#4B5563] transition-colors">Reactive Wiring</h3>
@@ -384,7 +384,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Html.InputField() wrapping, .Reactive() on builders, cross-vendor custom events.</p>
             </a>
-            <a href="/Sandbox/AllModulesTogether/PlaygroundSyntax/ReactiveConditions"
+            <a asp-area="Sandbox" asp-controller="PlaygroundSyntax" asp-action="ReactiveConditions"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#6B7280]/30 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#4B5563] transition-colors">Reactive Conditions</h3>
@@ -392,7 +392,7 @@
                 </div>
                 <p class="mt-2 text-sm text-text-secondary leading-relaxed">Conditions inside .Reactive() with cross-vendor mutations and nested targeting.</p>
             </a>
-            <a href="/Sandbox/AllModulesTogether/TestWidget"
+            <a asp-area="Sandbox" asp-controller="TestWidget" asp-action="Index"
                class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#6B7280]/30 hover:-translate-y-0.5 transition-all duration-200">
                 <div class="flex items-start justify-between">
                     <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#4B5563] transition-colors">TestWidget</h3>

--- a/Alis.Reactive.SandboxApp/Views/Shared/_Layout.cshtml
+++ b/Alis.Reactive.SandboxApp/Views/Shared/_Layout.cshtml
@@ -38,11 +38,11 @@
 
                     <a href="@Url.Action("Index", "CoreBehaviors", new { area = "Sandbox" })"
                        class="px-3 py-1.5 rounded-md text-sm font-medium text-text-secondary hover:text-[#7A2E3B] hover:bg-[#7A2E3B]/5 transition-all whitespace-nowrap">Core</a>
-                    <a href="@Url.Action("Index", "Conditions", new { area = "Sandbox" })"
+                    <a href="@Url.Action("Index", "ConditionsHome", new { area = "Sandbox" })"
                        class="px-3 py-1.5 rounded-md text-sm font-medium text-text-secondary hover:text-[#7A2E3B] hover:bg-[#7A2E3B]/5 transition-all whitespace-nowrap">Conditions</a>
                     <a href="@Url.Action("Index", "HttpPipeline", new { area = "Sandbox" })"
                        class="px-3 py-1.5 rounded-md text-sm font-medium text-text-secondary hover:text-[#7A2E3B] hover:bg-[#7A2E3B]/5 transition-all whitespace-nowrap">HTTP</a>
-                    <a href="@Url.Action("Index", "Validation", new { area = "Sandbox" })"
+                    <a href="@Url.Action("Index", "ValidationHome", new { area = "Sandbox" })"
                        class="px-3 py-1.5 rounded-md text-sm font-medium text-text-secondary hover:text-[#7A2E3B] hover:bg-[#7A2E3B]/5 transition-all whitespace-nowrap">Validation</a>
                     <a href="@Url.Action("Index", "Components", new { area = "Sandbox" })"
                        class="px-3 py-1.5 rounded-md text-sm font-medium text-text-secondary hover:text-[#7A2E3B] hover:bg-[#7A2E3B]/5 transition-all whitespace-nowrap">Components</a>

--- a/Alis.Reactive.SandboxApp/Views/Shared/_SandboxBreadcrumb.cshtml
+++ b/Alis.Reactive.SandboxApp/Views/Shared/_SandboxBreadcrumb.cshtml
@@ -17,9 +17,9 @@
         var concerns = new Dictionary<string, (string Controller, string Display)>(StringComparer.OrdinalIgnoreCase)
         {
             ["CoreBehaviors"]     = ("CoreBehaviors", "Core Behaviors"),
-            ["Conditions"]        = ("Conditions", "Conditions"),
+            ["Conditions"]        = ("ConditionsHome", "Conditions"),
             ["HttpPipeline"]      = ("HttpPipeline", "HTTP Pipeline"),
-            ["Validation"]        = ("Validation", "Validation"),
+            ["Validation"]        = ("ValidationHome", "Validation"),
             ["Components"]        = ("Components", "Components"),
             ["AllModulesTogether"] = ("AllModulesTogether", "All Modules Together"),
         };


### PR DESCRIPTION
## Summary
- Replace all `href="/Sandbox/..."` with `asp-area`/`asp-controller`/`asp-action` tag helpers across 8 view files (~50 card links)
- Fix layout nav and breadcrumb to use correct controller names (`ConditionsHome`, `ValidationHome`)
- Remove redundant `[HttpGet("Index")]` from 46 controllers to produce clean URLs
- Add missing AdmissionWizard card to Conditions index
- Rewrite all card descriptions to tell users what they'll see/do when they click

## Test plan
- [x] All 57 sandbox URLs return HTTP 200
- [x] Nav links resolve correctly (Conditions → `/Sandbox/Conditions`, not `/Guards`)
- [x] Breadcrumbs work at all levels (Sandbox → Concern → Slice)
- [x] Clean URLs throughout (no `/Index` suffix)
- [x] Card descriptions reviewed for clarity — no jargon, no inventory lists
- [ ] Run full Playwright test suite to verify no navigation regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)