### PR TITLE
feat: ALIS005/ALIS006 analyzers for validation extraction gaps

### DIFF
--- a/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
@@ -73,8 +73,7 @@ namespace Alis.Reactive.Analyzers.ConditionalChain
             if (string.IsNullOrEmpty(path)) return false;
 
             return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsDanglingBuilderType(

--- a/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
@@ -20,7 +20,8 @@ namespace Alis.Reactive.Analyzers.ConditionalChain
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "A conditional or guard chain was started but never completed with .Then(). " +
-                         "The condition will not be included in the plan.");
+                         "The condition will not be included in the plan.",
+            helpLinkUri: "");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);

--- a/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Alis.Reactive.Analyzers.ConditionalChain
             isEnabledByDefault: true,
             description: "A conditional or guard chain was started but never completed with .Then(). " +
                          "The condition will not be included in the plan.",
-            helpLinkUri: "");
+            helpLinkUri: null);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);
@@ -31,10 +31,27 @@ namespace Alis.Reactive.Analyzers.ConditionalChain
             context.ConfigureGeneratedCodeAnalysis(
                 GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(AnalyzeExpressionStatement, SyntaxKind.ExpressionStatement);
+
+            context.RegisterCompilationStartAction(compilationCtx =>
+            {
+                var guardBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.Conditions.GuardBuilder`1");
+                var conditionSourceBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.Conditions.ConditionSourceBuilder`2");
+
+                if (guardBuilderType == null && conditionSourceBuilderType == null)
+                    return;
+
+                compilationCtx.RegisterSyntaxNodeAction(
+                    nodeCtx => AnalyzeExpressionStatement(nodeCtx, guardBuilderType, conditionSourceBuilderType),
+                    SyntaxKind.ExpressionStatement);
+            });
         }
 
-        private static void AnalyzeExpressionStatement(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeExpressionStatement(
+            SyntaxNodeAnalysisContext context,
+            INamedTypeSymbol? guardBuilderType,
+            INamedTypeSymbol? conditionSourceBuilderType)
         {
             var statement = (ExpressionStatementSyntax)context.Node;
             if (!IsRazorGeneratedFile(statement.SyntaxTree))
@@ -45,8 +62,7 @@ namespace Alis.Reactive.Analyzers.ConditionalChain
 
             if (type == null) return;
 
-            // Check if the return type is GuardBuilder<> or ConditionSourceBuilder<,>
-            if (!IsDanglingBuilderType(type)) return;
+            if (!IsDanglingBuilderType(type, guardBuilderType, conditionSourceBuilderType)) return;
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, statement.Expression.GetLocation()));
         }
@@ -61,16 +77,20 @@ namespace Alis.Reactive.Analyzers.ConditionalChain
                 || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool IsDanglingBuilderType(ITypeSymbol type)
+        private static bool IsDanglingBuilderType(
+            ITypeSymbol type,
+            INamedTypeSymbol? guardBuilderType,
+            INamedTypeSymbol? conditionSourceBuilderType)
         {
             if (type is not INamedTypeSymbol named) return false;
             if (!named.IsGenericType) return false;
 
             var original = named.ConstructedFrom;
-            var fullName = original.ToDisplayString();
 
-            return fullName == "Alis.Reactive.Builders.Conditions.GuardBuilder<TModel>"
-                || fullName == "Alis.Reactive.Builders.Conditions.ConditionSourceBuilder<TModel, TProp>";
+            return (guardBuilderType != null
+                    && SymbolEqualityComparer.Default.Equals(original, guardBuilderType))
+                || (conditionSourceBuilderType != null
+                    && SymbolEqualityComparer.Default.Equals(original, conditionSourceBuilderType));
         }
     }
 }

--- a/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ConditionalChain/IncompleteConditionalChainAnalyzer.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 
-namespace Alis.Reactive.Analyzers
+namespace Alis.Reactive.Analyzers.ConditionalChain
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class IncompleteConditionalChainAnalyzer : DiagnosticAnalyzer

--- a/Alis.Reactive.Analyzers/ControlFlow/ControlFlowInReactiveCallbackAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ControlFlow/ControlFlowInReactiveCallbackAnalyzer.cs
@@ -68,7 +68,8 @@ namespace Alis.Reactive.Analyzers.ControlFlow
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "Reactive callbacks build descriptors at render time \u2014 they do not execute at runtime. " +
-                         "Use p.When(...).Then(...).Else(...) for conditions.");
+                         "Use p.When(...).Then(...).Else(...) for conditions.",
+            helpLinkUri: "");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);

--- a/Alis.Reactive.Analyzers/ControlFlow/ControlFlowInReactiveCallbackAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ControlFlow/ControlFlowInReactiveCallbackAnalyzer.cs
@@ -201,8 +201,7 @@ namespace Alis.Reactive.Analyzers.ControlFlow
             if (string.IsNullOrEmpty(path)) return false;
 
             return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Alis.Reactive.Analyzers/ControlFlow/ControlFlowInReactiveCallbackAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ControlFlow/ControlFlowInReactiveCallbackAnalyzer.cs
@@ -69,7 +69,7 @@ namespace Alis.Reactive.Analyzers.ControlFlow
             isEnabledByDefault: true,
             description: "Reactive callbacks build descriptors at render time \u2014 they do not execute at runtime. " +
                          "Use p.When(...).Then(...).Else(...) for conditions.",
-            helpLinkUri: "");
+            helpLinkUri: null);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);

--- a/Alis.Reactive.Analyzers/HttpPipeline/DuplicateChainedRequestAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/HttpPipeline/DuplicateChainedRequestAnalyzer.cs
@@ -93,8 +93,7 @@ namespace Alis.Reactive.Analyzers.HttpPipeline
             if (string.IsNullOrEmpty(path)) return false;
 
             return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Alis.Reactive.Analyzers/HttpPipeline/DuplicateChainedRequestAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/HttpPipeline/DuplicateChainedRequestAnalyzer.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Alis.Reactive.Analyzers.HttpPipeline
+{
+    /// <summary>
+    /// Error when .Chained() is called more than once on the same ResponseBuilder fluent chain.
+    /// Only the last .Chained() survives — earlier ones are silently overwritten.
+    ///
+    /// Catches:
+    ///   .Response(r => r.Chained(c => c.Post("/step-1")).Chained(c => c.Post("/step-2")))
+    ///   .Response(r => r.Chained(...).OnSuccess(...).Chained(...))
+    ///
+    /// Does NOT flag:
+    ///   Single .Chained() on a ResponseBuilder chain
+    ///   .Chained() on separate ResponseBuilder chains (separate .Response() calls)
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DuplicateChainedRequestAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ALIS007";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            title: "Duplicate .Chained() call on ResponseBuilder",
+            messageFormat: "Duplicate .Chained() call — only the last chained request survives. Use a single .Chained() with the final request.",
+            category: "Alis.Reactive.HttpPipeline",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "Each ResponseBuilder chain should have at most one .Chained() call. Multiple calls silently overwrite — only the last one takes effect.",
+            helpLinkUri: "");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(
+                GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+
+            if (!IsRazorGeneratedFile(invocation.SyntaxTree))
+                return;
+
+            if (!IsChainedCall(invocation))
+                return;
+
+            // Walk the receiver chain backwards — if another .Chained() exists earlier, flag this one
+            var current = GetReceiverInvocation(invocation);
+
+            while (current != null)
+            {
+                if (IsChainedCall(current))
+                {
+                    // Report at the ".Chained" method name location
+                    var memberAccess = (MemberAccessExpressionSyntax)invocation.Expression;
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(Rule, memberAccess.Name.GetLocation()));
+                    return;
+                }
+                current = GetReceiverInvocation(current);
+            }
+        }
+
+        private static bool IsChainedCall(InvocationExpressionSyntax invocation)
+        {
+            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+                return memberAccess.Name.Identifier.Text == "Chained";
+            return false;
+        }
+
+        private static InvocationExpressionSyntax? GetReceiverInvocation(InvocationExpressionSyntax invocation)
+        {
+            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Expression is InvocationExpressionSyntax receiver)
+                return receiver;
+            return null;
+        }
+
+        private static bool IsRazorGeneratedFile(SyntaxTree tree)
+        {
+            var path = tree.FilePath;
+            if (string.IsNullOrEmpty(path)) return false;
+
+            return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Alis.Reactive.Analyzers/HttpPipeline/DuplicateChainedRequestAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/HttpPipeline/DuplicateChainedRequestAnalyzer.cs
@@ -32,7 +32,7 @@ namespace Alis.Reactive.Analyzers.HttpPipeline
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "Each ResponseBuilder chain should have at most one .Chained() call. Multiple calls silently overwrite — only the last one takes effect.",
-            helpLinkUri: "");
+            helpLinkUri: null);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);

--- a/Alis.Reactive.Analyzers/HttpPipeline/MultipleHttpRequestsInPipelineAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/HttpPipeline/MultipleHttpRequestsInPipelineAnalyzer.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Alis.Reactive.Analyzers.HttpPipeline
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MultipleHttpRequestsInPipelineAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ALIS008";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            title: "Multiple HTTP requests in one pipeline",
+            messageFormat: "Multiple HTTP requests in one pipeline — only the last request survives. Use Parallel(...) for concurrent requests or separate triggers for independent requests.",
+            category: "Alis.Reactive.HttpPipeline",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "When a PipelineBuilder lambda contains two or more top-level HTTP request statements " +
+                         "(Get/Post/Put/Delete), only the last one survives at runtime. " +
+                         "Use Parallel(...) for concurrent requests or separate triggers for independent requests.",
+            helpLinkUri: "");
+
+        private static readonly ImmutableHashSet<string> HttpMethodNames =
+            ImmutableHashSet.Create("Get", "Post", "Put", "Delete");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(
+                GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(compilationCtx =>
+            {
+                var pipelineBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.PipelineBuilder`1");
+
+                if (pipelineBuilderType == null)
+                    return;
+
+                compilationCtx.RegisterSyntaxNodeAction(
+                    nodeCtx => AnalyzeLambda(nodeCtx, pipelineBuilderType),
+                    SyntaxKind.SimpleLambdaExpression,
+                    SyntaxKind.ParenthesizedLambdaExpression);
+            });
+        }
+
+        private static void AnalyzeLambda(
+            SyntaxNodeAnalysisContext context,
+            INamedTypeSymbol pipelineBuilderType)
+        {
+            var lambda = (LambdaExpressionSyntax)context.Node;
+
+            if (!IsRazorGeneratedFile(lambda.SyntaxTree))
+                return;
+
+            // Only analyze lambdas whose parameter is PipelineBuilder<TModel>
+            var pipelineParamName = GetPipelineParameterName(
+                lambda, context.SemanticModel, pipelineBuilderType, context.CancellationToken);
+
+            if (pipelineParamName == null)
+                return;
+
+            // Only block-bodied lambdas can have multiple statements
+            if (!(lambda.Body is BlockSyntax block))
+                return;
+
+            // Count top-level expression statements that start an HTTP request chain on the pipeline parameter.
+            // Do NOT descend into nested lambdas — those belong to Response, Parallel, WhileLoading, etc.
+            var httpStatementCount = 0;
+            foreach (var statement in block.Statements)
+            {
+                if (!(statement is ExpressionStatementSyntax exprStatement))
+                    continue;
+
+                if (IsHttpRequestChainOnParameter(exprStatement.Expression, pipelineParamName,
+                    context.SemanticModel, pipelineBuilderType, context.CancellationToken))
+                {
+                    httpStatementCount++;
+                    if (httpStatementCount >= 2)
+                    {
+                        context.ReportDiagnostic(
+                            Diagnostic.Create(Rule, statement.GetLocation()));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Walks a fluent invocation chain (a.B().C().D()) to find the innermost invocation
+        /// that is a member access on the pipeline parameter, and checks if it is an HTTP method.
+        /// </summary>
+        private static bool IsHttpRequestChainOnParameter(
+            ExpressionSyntax expression,
+            string parameterName,
+            SemanticModel semanticModel,
+            INamedTypeSymbol pipelineBuilderType,
+            System.Threading.CancellationToken cancellationToken)
+        {
+            // Unwrap the fluent chain: a.Post("/url").Response(r => ...) is
+            // InvocationExpression(MemberAccess(InvocationExpression(MemberAccess(a, Post)), Response))
+            // We need to find the root of this chain.
+            var current = expression;
+
+            while (current is InvocationExpressionSyntax invocation)
+            {
+                if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+                {
+                    // Check if this specific invocation is an HTTP method on the pipeline parameter
+                    if (HttpMethodNames.Contains(memberAccess.Name.Identifier.Text))
+                    {
+                        // Verify the receiver is the pipeline parameter identifier
+                        if (memberAccess.Expression is IdentifierNameSyntax identifier
+                            && identifier.Identifier.Text == parameterName)
+                        {
+                            // Semantic check: confirm this method belongs to PipelineBuilder<TModel>
+                            var symbol = semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol;
+                            if (symbol is IMethodSymbol methodSymbol
+                                && SymbolEqualityComparer.Default.Equals(
+                                    methodSymbol.ContainingType.OriginalDefinition, pipelineBuilderType))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    // Descend into the receiver to find deeper in the chain
+                    current = memberAccess.Expression;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the name of the lambda parameter that is a PipelineBuilder, or null if none.
+        /// </summary>
+        private static string? GetPipelineParameterName(
+            LambdaExpressionSyntax lambda,
+            SemanticModel semanticModel,
+            INamedTypeSymbol pipelineBuilderType,
+            System.Threading.CancellationToken cancellationToken)
+        {
+            if (lambda is SimpleLambdaExpressionSyntax simple)
+            {
+                var symbol = semanticModel.GetDeclaredSymbol(simple.Parameter, cancellationToken);
+                if (symbol != null && IsPipelineBuilderType(symbol.Type, pipelineBuilderType))
+                    return simple.Parameter.Identifier.Text;
+            }
+
+            if (lambda is ParenthesizedLambdaExpressionSyntax parens)
+            {
+                foreach (var param in parens.ParameterList.Parameters)
+                {
+                    var symbol = semanticModel.GetDeclaredSymbol(param, cancellationToken);
+                    if (symbol != null && IsPipelineBuilderType(symbol.Type, pipelineBuilderType))
+                        return param.Identifier.Text;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsPipelineBuilderType(ITypeSymbol? type, INamedTypeSymbol pipelineBuilderType)
+        {
+            if (type is not INamedTypeSymbol named) return false;
+            if (!named.IsGenericType) return false;
+            return SymbolEqualityComparer.Default.Equals(named.ConstructedFrom, pipelineBuilderType);
+        }
+
+        private static bool IsRazorGeneratedFile(SyntaxTree tree)
+        {
+            var path = tree.FilePath;
+            if (string.IsNullOrEmpty(path)) return false;
+
+            return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Alis.Reactive.Analyzers/HttpPipeline/MultipleHttpRequestsInPipelineAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/HttpPipeline/MultipleHttpRequestsInPipelineAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Alis.Reactive.Analyzers.HttpPipeline
             description: "When a PipelineBuilder lambda contains two or more top-level HTTP request statements " +
                          "(Get/Post/Put/Delete), only the last one survives at runtime. " +
                          "Use Parallel(...) for concurrent requests or separate triggers for independent requests.",
-            helpLinkUri: "");
+            helpLinkUri: null);
 
         private static readonly ImmutableHashSet<string> HttpMethodNames =
             ImmutableHashSet.Create("Get", "Post", "Put", "Delete");

--- a/Alis.Reactive.Analyzers/HttpPipeline/MultipleHttpRequestsInPipelineAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/HttpPipeline/MultipleHttpRequestsInPipelineAnalyzer.cs
@@ -184,8 +184,7 @@ namespace Alis.Reactive.Analyzers.HttpPipeline
             if (string.IsNullOrEmpty(path)) return false;
 
             return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
@@ -169,8 +169,7 @@ namespace Alis.Reactive.Analyzers.NativeActionLink
             if (string.IsNullOrEmpty(path)) return false;
 
             return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase);
         }
 
         private readonly struct CachedTypes

--- a/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace Alis.Reactive.Analyzers
+namespace Alis.Reactive.Analyzers.NativeActionLink
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class NativeActionLinkSingleRequestAnalyzer : DiagnosticAnalyzer

--- a/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -20,7 +21,10 @@ namespace Alis.Reactive.Analyzers.NativeActionLink
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "NativeActionLink is limited to one existing HTTP request chain serialized through data-reactive-* attributes.",
-            helpLinkUri: "");
+            helpLinkUri: null);
+
+        private static readonly ImmutableHashSet<string> HttpMethodNames =
+            ImmutableHashSet.Create("Get", "Post", "Put", "Delete");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);
@@ -30,16 +34,46 @@ namespace Alis.Reactive.Analyzers.NativeActionLink
             context.ConfigureGeneratedCodeAnalysis(
                 GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(AnalyzeInvocation, Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
+
+            context.RegisterCompilationStartAction(compilationCtx =>
+            {
+                var actionLinkExtType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Native.Components.NativeActionLinkHtmlExtensions");
+                var pipelineBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.PipelineBuilder`1");
+                var parallelBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.ParallelBuilder`1");
+                var responseBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.Requests.ResponseBuilder`1");
+                var gatherBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.Requests.GatherBuilder`1");
+                var httpRequestBuilderType = compilationCtx.Compilation.GetTypeByMetadataName(
+                    "Alis.Reactive.Builders.Requests.HttpRequestBuilder`1");
+
+                if (actionLinkExtType == null || pipelineBuilderType == null)
+                    return;
+
+                var cachedTypes = new CachedTypes(
+                    actionLinkExtType,
+                    pipelineBuilderType,
+                    parallelBuilderType,
+                    responseBuilderType,
+                    gatherBuilderType,
+                    httpRequestBuilderType);
+
+                compilationCtx.RegisterSyntaxNodeAction(
+                    nodeCtx => AnalyzeInvocation(nodeCtx, cachedTypes),
+                    SyntaxKind.InvocationExpression);
+            });
         }
 
-        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, CachedTypes types)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (!IsRazorGeneratedFile(invocation.SyntaxTree))
                 return;
 
-            if (!IsNativeActionLinkInvocation(invocation, context.SemanticModel, context.CancellationToken))
+            if (!IsNativeActionLinkInvocation(invocation, context.SemanticModel, types, context.CancellationToken))
                 return;
 
             var lambda = invocation.ArgumentList.Arguments
@@ -50,21 +84,64 @@ namespace Alis.Reactive.Analyzers.NativeActionLink
             if (lambda == null)
                 return;
 
-            var descendantInvocations = lambda.DescendantNodes()
-                .OfType<InvocationExpressionSyntax>()
-                .ToArray();
+            var hasParallel = false;
+            var hasChained = false;
+            var hasIncludeAll = false;
+            var hasValidate = false;
+            var requestStartCount = 0;
 
-            if (descendantInvocations.Any(i => IsParallelInvocation(i, context.SemanticModel, context.CancellationToken))
-                || descendantInvocations.Any(i => IsChainedInvocation(i, context.SemanticModel, context.CancellationToken))
-                || descendantInvocations.Any(i => IsIncludeAllInvocation(i, context.SemanticModel, context.CancellationToken))
-                || descendantInvocations.Any(i => IsValidationInvocation(i, context.SemanticModel, context.CancellationToken)))
+            foreach (var inv in lambda.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (context.SemanticModel.GetSymbolInfo(inv, context.CancellationToken).Symbol
+                    is not IMethodSymbol sym)
+                    continue;
+
+                var containingType = sym.ContainingType.OriginalDefinition;
+
+                if (sym.Name == "Parallel"
+                    && types.ParallelBuilderType != null
+                    && SymbolEqualityComparer.Default.Equals(containingType, types.PipelineBuilderType))
+                {
+                    hasParallel = true;
+                    break;
+                }
+
+                if (sym.Name == "Chained"
+                    && types.ResponseBuilderType != null
+                    && SymbolEqualityComparer.Default.Equals(containingType, types.ResponseBuilderType))
+                {
+                    hasChained = true;
+                    break;
+                }
+
+                if (sym.Name == "IncludeAll"
+                    && types.GatherBuilderType != null
+                    && SymbolEqualityComparer.Default.Equals(containingType, types.GatherBuilderType))
+                {
+                    hasIncludeAll = true;
+                    break;
+                }
+
+                if (sym.Name == "Validate"
+                    && types.HttpRequestBuilderType != null
+                    && SymbolEqualityComparer.Default.Equals(containingType, types.HttpRequestBuilderType))
+                {
+                    hasValidate = true;
+                    break;
+                }
+
+                if (HttpMethodNames.Contains(sym.Name)
+                    && SymbolEqualityComparer.Default.Equals(containingType, types.PipelineBuilderType))
+                {
+                    requestStartCount++;
+                }
+            }
+
+            if (hasParallel || hasChained || hasIncludeAll || hasValidate)
             {
                 context.ReportDiagnostic(Diagnostic.Create(Rule, lambda.GetLocation()));
                 return;
             }
-
-            var requestStartCount = descendantInvocations.Count(i =>
-                IsPipelineRequestStart(i, context.SemanticModel, context.CancellationToken));
 
             if (requestStartCount != 1)
             {
@@ -75,81 +152,15 @@ namespace Alis.Reactive.Analyzers.NativeActionLink
         private static bool IsNativeActionLinkInvocation(
             InvocationExpressionSyntax invocation,
             SemanticModel semanticModel,
+            CachedTypes types,
             System.Threading.CancellationToken cancellationToken)
         {
             if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
                 return false;
 
             return symbol.Name == "NativeActionLink"
-                && symbol.ContainingType.OriginalDefinition.ToDisplayString()
-                    == "Alis.Reactive.Native.Components.NativeActionLinkHtmlExtensions";
-        }
-
-        private static bool IsPipelineRequestStart(
-            InvocationExpressionSyntax invocation,
-            SemanticModel semanticModel,
-            System.Threading.CancellationToken cancellationToken)
-        {
-            if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
-                return false;
-
-            if (!(symbol.Name == "Get" || symbol.Name == "Post" || symbol.Name == "Put" || symbol.Name == "Delete"))
-                return false;
-
-            return symbol.ContainingType.OriginalDefinition.ToDisplayString()
-                == "Alis.Reactive.Builders.PipelineBuilder<TModel>";
-        }
-
-        private static bool IsParallelInvocation(
-            InvocationExpressionSyntax invocation,
-            SemanticModel semanticModel,
-            System.Threading.CancellationToken cancellationToken)
-        {
-            if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
-                return false;
-
-            return symbol.Name == "Parallel"
-                && symbol.ContainingType.OriginalDefinition.ToDisplayString()
-                    == "Alis.Reactive.Builders.PipelineBuilder<TModel>";
-        }
-
-        private static bool IsChainedInvocation(
-            InvocationExpressionSyntax invocation,
-            SemanticModel semanticModel,
-            System.Threading.CancellationToken cancellationToken)
-        {
-            if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
-                return false;
-
-            return symbol.Name == "Chained"
-                && symbol.ContainingType.OriginalDefinition.ToDisplayString()
-                    == "Alis.Reactive.Builders.Requests.ResponseBuilder<TModel>";
-        }
-
-        private static bool IsIncludeAllInvocation(
-            InvocationExpressionSyntax invocation,
-            SemanticModel semanticModel,
-            System.Threading.CancellationToken cancellationToken)
-        {
-            if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
-                return false;
-
-            return symbol.Name == "IncludeAll"
-                && symbol.ContainingType.OriginalDefinition.ToDisplayString()
-                    == "Alis.Reactive.Builders.Requests.GatherBuilder<TModel>";
-        }
-
-        private static bool IsValidationInvocation(
-            InvocationExpressionSyntax invocation,
-            SemanticModel semanticModel,
-            System.Threading.CancellationToken cancellationToken)
-        {
-            if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
-                return false;
-
-            return symbol.Name == "Validate"
-                && symbol.ContainingType.OriginalDefinition.ToDisplayString()
-                    == "Alis.Reactive.Builders.Requests.HttpRequestBuilder<TModel>";
+                && SymbolEqualityComparer.Default.Equals(
+                    symbol.ContainingType.OriginalDefinition, types.ActionLinkExtType);
         }
 
         private static bool IsRazorGeneratedFile(SyntaxTree tree)
@@ -160,6 +171,32 @@ namespace Alis.Reactive.Analyzers.NativeActionLink
             return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
                 || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
                 || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private readonly struct CachedTypes
+        {
+            public readonly INamedTypeSymbol ActionLinkExtType;
+            public readonly INamedTypeSymbol PipelineBuilderType;
+            public readonly INamedTypeSymbol? ParallelBuilderType;
+            public readonly INamedTypeSymbol? ResponseBuilderType;
+            public readonly INamedTypeSymbol? GatherBuilderType;
+            public readonly INamedTypeSymbol? HttpRequestBuilderType;
+
+            public CachedTypes(
+                INamedTypeSymbol actionLinkExtType,
+                INamedTypeSymbol pipelineBuilderType,
+                INamedTypeSymbol? parallelBuilderType,
+                INamedTypeSymbol? responseBuilderType,
+                INamedTypeSymbol? gatherBuilderType,
+                INamedTypeSymbol? httpRequestBuilderType)
+            {
+                ActionLinkExtType = actionLinkExtType;
+                PipelineBuilderType = pipelineBuilderType;
+                ParallelBuilderType = parallelBuilderType;
+                ResponseBuilderType = responseBuilderType;
+                GatherBuilderType = gatherBuilderType;
+                HttpRequestBuilderType = httpRequestBuilderType;
+            }
         }
     }
 }

--- a/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/NativeActionLink/NativeActionLinkSingleRequestAnalyzer.cs
@@ -19,7 +19,8 @@ namespace Alis.Reactive.Analyzers.NativeActionLink
             category: "Alis.Reactive",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "NativeActionLink is limited to one existing HTTP request chain serialized through data-reactive-* attributes.");
+            description: "NativeActionLink is limited to one existing HTTP request chain serialized through data-reactive-* attributes.",
+            helpLinkUri: "");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);

--- a/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
@@ -121,8 +121,7 @@ namespace Alis.Reactive.Analyzers.ReactiveEvent
             if (string.IsNullOrEmpty(path)) return false;
 
             return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -32,7 +33,8 @@ namespace Alis.Reactive.Analyzers.ReactiveEvent
             category: "Alis.Reactive",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "Each component event should have exactly one .Reactive() call per builder chain. Multiple calls for the same event create redundant plan entries.");
+            description: "Each component event should have exactly one .Reactive() call per builder chain. Multiple calls for the same event create redundant plan entries.",
+            helpLinkUri: "");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);
@@ -118,9 +120,9 @@ namespace Alis.Reactive.Analyzers.ReactiveEvent
             var path = tree.FilePath;
             if (string.IsNullOrEmpty(path)) return false;
 
-            return path.EndsWith(".cshtml", System.StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".cshtml.g.cs", System.StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".g.cs", System.StringComparison.OrdinalIgnoreCase);
+            return path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Alis.Reactive.Analyzers.ReactiveEvent
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "Each component event should have exactly one .Reactive() call per builder chain. Multiple calls for the same event create redundant plan entries.",
-            helpLinkUri: "");
+            helpLinkUri: null);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);

--- a/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/ReactiveEvent/DuplicateReactiveEventAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace Alis.Reactive.Analyzers
+namespace Alis.Reactive.Analyzers.ReactiveEvent
 {
     /// <summary>
     /// Error when .Reactive() is called multiple times for the same event on the same builder chain.

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
@@ -1,0 +1,138 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Alis.Reactive.Analyzers.Validation
+{
+    /// <summary>
+    /// Warning when FluentValidation's <c>.When()</c> or <c>.Unless()</c> is used inside a
+    /// <c>ReactiveValidator&lt;T&gt;</c>. These are server-only conditions (arbitrary C#
+    /// lambdas that cannot serialize to JSON). Use <c>WhenField()</c> instead.
+    ///
+    /// Catches:
+    ///   <c>RuleFor(x =&gt; x.Name).NotEmpty().When(x =&gt; x.IsActive)</c>
+    ///   <c>RuleFor(x =&gt; x.Name).NotEmpty().Unless(x =&gt; x.IsAdmin)</c>
+    ///
+    /// Does NOT flag:
+    ///   <c>p.When(args, a =&gt; a.Value).Eq("Custom")</c> — framework's When() on PipelineBuilder.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ServerOnlyConditionAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ALIS006";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            title: "FV condition is server-only in ReactiveValidator",
+            messageFormat: "FV .{0}() is server-only in ReactiveValidator \u2014 use WhenField() for client-side conditional validation",
+            category: "Alis.Reactive.Validation",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "FluentValidation's .When()/.Unless() conditions contain arbitrary C# predicates that cannot be " +
+                         "serialized for client-side execution. Use ReactiveValidator.WhenField() instead \u2014 it constrains " +
+                         "conditions to simple field comparisons (truthy, falsy, eq, neq) that the client runtime can evaluate.");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(
+                GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+
+            if (!(invocation.Expression is MemberAccessExpressionSyntax memberAccess))
+                return;
+
+            var methodName = memberAccess.Name.Identifier.Text;
+            if (methodName != "When" && methodName != "Unless")
+                return;
+
+            if (!IsOnRuleForChain(memberAccess.Expression))
+                return;
+
+            if (!IsInsideReactiveValidator(invocation))
+                return;
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+        }
+
+        /// <summary>
+        /// Walk the receiver chain (the expression before .When/.Unless) to find a
+        /// RuleFor or RuleForEach call. This distinguishes FV's .When() (on a RuleFor chain)
+        /// from the framework's .When() (on PipelineBuilder, which has no RuleFor ancestor).
+        /// </summary>
+        private static bool IsOnRuleForChain(ExpressionSyntax expression)
+        {
+            var current = expression;
+
+            while (current != null)
+            {
+                if (current is InvocationExpressionSyntax invocation)
+                {
+                    if (invocation.Expression is MemberAccessExpressionSyntax access)
+                    {
+                        var name = access.Name.Identifier.Text;
+                        if (name == "RuleFor" || name == "RuleForEach")
+                            return true;
+
+                        current = access.Expression;
+                        continue;
+                    }
+
+                    if (invocation.Expression is IdentifierNameSyntax identifier)
+                    {
+                        var name = identifier.Identifier.Text;
+                        if (name == "RuleFor" || name == "RuleForEach")
+                            return true;
+                    }
+
+                    break;
+                }
+
+                break;
+            }
+
+            return false;
+        }
+
+        private static bool IsInsideReactiveValidator(SyntaxNode node)
+        {
+            var current = node.Parent;
+
+            while (current != null)
+            {
+                if (current is ClassDeclarationSyntax classDecl)
+                    return HasReactiveValidatorBase(classDecl);
+
+                current = current.Parent;
+            }
+
+            return false;
+        }
+
+        private static bool HasReactiveValidatorBase(ClassDeclarationSyntax classDecl)
+        {
+            if (classDecl.BaseList == null)
+                return false;
+
+            foreach (var baseType in classDecl.BaseList.Types)
+            {
+                var typeName = baseType.Type.ToString();
+                if (typeName.Contains("ReactiveValidator"))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Alis.Reactive.Analyzers.Validation
             description: "FluentValidation's .When()/.Unless() conditions contain arbitrary C# predicates that cannot be " +
                          "serialized for client-side execution. Use ReactiveValidator.WhenField() instead \u2014 it constrains " +
                          "conditions to simple field comparisons (truthy, falsy, eq, neq) that the client runtime can evaluate.",
-            helpLinkUri: "");
+            helpLinkUri: null);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
@@ -65,7 +65,7 @@ namespace Alis.Reactive.Analyzers.Validation
                 return;
 
             context.ReportDiagnostic(
-                Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+                Diagnostic.Create(Rule, memberAccess.Name.GetLocation(), methodName));
         }
 
         /// <summary>

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyConditionAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -32,7 +33,8 @@ namespace Alis.Reactive.Analyzers.Validation
             isEnabledByDefault: true,
             description: "FluentValidation's .When()/.Unless() conditions contain arbitrary C# predicates that cannot be " +
                          "serialized for client-side execution. Use ReactiveValidator.WhenField() instead \u2014 it constrains " +
-                         "conditions to simple field comparisons (truthy, falsy, eq, neq) that the client runtime can evaluate.");
+                         "conditions to simple field comparisons (truthy, falsy, eq, neq) that the client runtime can evaluate.",
+            helpLinkUri: "");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);
@@ -128,7 +130,9 @@ namespace Alis.Reactive.Analyzers.Validation
             foreach (var baseType in classDecl.BaseList.Types)
             {
                 var typeName = baseType.Type.ToString();
-                if (typeName.Contains("ReactiveValidator"))
+                // Check for ReactiveValidator<...> pattern — base type starts with "ReactiveValidator<"
+                // or equals "ReactiveValidator" (raw, non-generic, unlikely but safe)
+                if (typeName.StartsWith("ReactiveValidator<", StringComparison.Ordinal) || typeName == "ReactiveValidator")
                     return true;
             }
 

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
@@ -29,7 +29,8 @@ namespace Alis.Reactive.Analyzers.Validation
             description: "This FluentValidation rule type cannot be serialized to JSON for client-side execution. " +
                          "It will only run during server-side validation. If you need client-side validation, use " +
                          "supported rules (NotEmpty, MinLength, MaxLength, EmailAddress, Matches, InclusiveBetween, " +
-                         "GreaterThan, LessThan, Equal, NotEqual, CreditCard).");
+                         "GreaterThan, LessThan, Equal, NotEqual, CreditCard).",
+            helpLinkUri: "");
 
         private static readonly ImmutableHashSet<string> ServerOnlyMethods =
             ImmutableHashSet.Create(StringComparer.Ordinal,
@@ -94,7 +95,9 @@ namespace Alis.Reactive.Analyzers.Validation
             foreach (var baseType in classDecl.BaseList.Types)
             {
                 var typeName = baseType.Type.ToString();
-                if (typeName.Contains("ReactiveValidator"))
+                // Check for ReactiveValidator<...> pattern — base type starts with "ReactiveValidator<"
+                // or equals "ReactiveValidator" (raw, non-generic, unlikely but safe)
+                if (typeName.StartsWith("ReactiveValidator<", StringComparison.Ordinal) || typeName == "ReactiveValidator")
                     return true;
             }
 

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Alis.Reactive.Analyzers.Validation
                          "It will only run during server-side validation. If you need client-side validation, use " +
                          "supported rules (NotEmpty, MinLength, MaxLength, EmailAddress, Matches, InclusiveBetween, " +
                          "GreaterThan, LessThan, Equal, NotEqual, CreditCard).",
-            helpLinkUri: "");
+            helpLinkUri: null);
 
         private static readonly ImmutableHashSet<string> ServerOnlyMethods =
             ImmutableHashSet.Create(StringComparer.Ordinal,

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Alis.Reactive.Analyzers.Validation
     /// inside a <c>ReactiveValidator&lt;T&gt;</c>. These rules cannot be extracted for
     /// client-side validation and will silently drop during extraction.
     ///
-    /// Detected methods: IsInEnum, Must, MustAsync, Custom, CustomAsync, SetValidator.
+    /// Detected methods: IsInEnum, Must, MustAsync, Custom, CustomAsync.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class ServerOnlyValidationRuleAnalyzer : DiagnosticAnalyzer
@@ -37,8 +37,7 @@ namespace Alis.Reactive.Analyzers.Validation
                 "Must",
                 "MustAsync",
                 "Custom",
-                "CustomAsync",
-                "SetValidator"
+                "CustomAsync"
             );
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>

--- a/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
+++ b/Alis.Reactive.Analyzers/Validation/ServerOnlyValidationRuleAnalyzer.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Alis.Reactive.Analyzers.Validation
+{
+    /// <summary>
+    /// Info diagnostic when FluentValidation methods that produce server-only rules are used
+    /// inside a <c>ReactiveValidator&lt;T&gt;</c>. These rules cannot be extracted for
+    /// client-side validation and will silently drop during extraction.
+    ///
+    /// Detected methods: IsInEnum, Must, MustAsync, Custom, CustomAsync, SetValidator.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ServerOnlyValidationRuleAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ALIS005";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            title: "Server-only validation rule in ReactiveValidator",
+            messageFormat: "'{0}' is server-only \u2014 not extractable for client-side validation in ReactiveValidator",
+            category: "Alis.Reactive.Validation",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "This FluentValidation rule type cannot be serialized to JSON for client-side execution. " +
+                         "It will only run during server-side validation. If you need client-side validation, use " +
+                         "supported rules (NotEmpty, MinLength, MaxLength, EmailAddress, Matches, InclusiveBetween, " +
+                         "GreaterThan, LessThan, Equal, NotEqual, CreditCard).");
+
+        private static readonly ImmutableHashSet<string> ServerOnlyMethods =
+            ImmutableHashSet.Create(StringComparer.Ordinal,
+                "IsInEnum",
+                "Must",
+                "MustAsync",
+                "Custom",
+                "CustomAsync",
+                "SetValidator"
+            );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(
+                GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+
+            if (!(invocation.Expression is MemberAccessExpressionSyntax memberAccess))
+                return;
+
+            var methodName = memberAccess.Name.Identifier.Text;
+
+            if (!ServerOnlyMethods.Contains(methodName))
+                return;
+
+            var classDecl = FindContainingClass(invocation);
+            if (classDecl == null)
+                return;
+
+            if (!ExtendsReactiveValidator(classDecl))
+                return;
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(Rule, memberAccess.Name.GetLocation(), methodName));
+        }
+
+        private static ClassDeclarationSyntax? FindContainingClass(SyntaxNode node)
+        {
+            var current = node.Parent;
+            while (current != null)
+            {
+                if (current is ClassDeclarationSyntax classDecl)
+                    return classDecl;
+                current = current.Parent;
+            }
+            return null;
+        }
+
+        private static bool ExtendsReactiveValidator(ClassDeclarationSyntax classDecl)
+        {
+            if (classDecl.BaseList == null)
+                return false;
+
+            foreach (var baseType in classDecl.BaseList.Types)
+            {
+                var typeName = baseType.Type.ToString();
+                if (typeName.Contains("ReactiveValidator"))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/tests/Alis.Reactive.Analyzers.Tests/ConditionalChain/WhenDetectingIncompleteConditionalChains.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/ConditionalChain/WhenDetectingIncompleteConditionalChains.cs
@@ -2,9 +2,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using NUnit.Framework;
-using Alis.Reactive.Analyzers;
+using Alis.Reactive.Analyzers.ConditionalChain;
 
-namespace Alis.Reactive.Analyzers.Tests;
+namespace Alis.Reactive.Analyzers.Tests.ConditionalChain;
 
 [TestFixture]
 public class WhenDetectingIncompleteConditionalChains

--- a/tests/Alis.Reactive.Analyzers.Tests/ConditionalChain/WhenDetectingIncompleteConditionalChains.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/ConditionalChain/WhenDetectingIncompleteConditionalChains.cs
@@ -188,7 +188,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "ReactiveConditions.g.cs", ExpectALIS001(0)).RunAsync();
+        await CreateTest(source, "ReactiveConditions.cshtml.g.cs", ExpectALIS001(0)).RunAsync();
     }
 
     [Test]
@@ -206,7 +206,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "ReactiveConditions.g.cs", ExpectALIS001(0)).RunAsync();
+        await CreateTest(source, "ReactiveConditions.cshtml.g.cs", ExpectALIS001(0)).RunAsync();
     }
 
     [Test]
@@ -229,7 +229,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "ReactiveConditions.g.cs", ExpectALIS001(0), ExpectALIS001(1)).RunAsync();
+        await CreateTest(source, "ReactiveConditions.cshtml.g.cs", ExpectALIS001(0), ExpectALIS001(1)).RunAsync();
     }
 
     [Test]
@@ -273,6 +273,6 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "ReactiveConditions.g.cs", ExpectALIS001(0)).RunAsync();
+        await CreateTest(source, "ReactiveConditions.cshtml.g.cs", ExpectALIS001(0)).RunAsync();
     }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/ConditionalChain/WhenDetectingIncompleteConditionalChains.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/ConditionalChain/WhenDetectingIncompleteConditionalChains.cs
@@ -208,4 +208,71 @@ public class GeneratedView
 ";
         await CreateTest(source, "ReactiveConditions.g.cs", ExpectALIS001(0)).RunAsync();
     }
+
+    [Test]
+    public async Task Multiple_dangling_chains_report_multiple_diagnostics()
+    {
+        const string source = @"
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Conditions;
+
+public class Payload { public string Value { get; set; } = """"; }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<GeneratedView>();
+        var args = new Payload();
+        {|#0:p.When(args, x => x.Value).Eq(""active"")|};
+        {|#1:p.When(args, x => x.Value).Eq(""pending"")|};
+    }
+}
+";
+        await CreateTest(source, "ReactiveConditions.g.cs", ExpectALIS001(0), ExpectALIS001(1)).RunAsync();
+    }
+
+    [Test]
+    public async Task Dangling_chain_in_cshtml_file_reports_ALIS001()
+    {
+        const string source = @"
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Conditions;
+
+public class Payload { public string Value { get; set; } = """"; }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<GeneratedView>();
+        var args = new Payload();
+        {|#0:p.When(args, x => x.Value).Eq(""active"")|};
+    }
+}
+";
+        await CreateTest(source, "ReactiveConditions.cshtml", ExpectALIS001(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Deeply_chained_guard_without_Then_reports_ALIS001()
+    {
+        const string source = @"
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Conditions;
+
+public class Payload { public string Value { get; set; } = """"; }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<GeneratedView>();
+        var args = new Payload();
+        {|#0:p.When(args, x => x.Value).Eq(""active"").And()|};
+    }
+}
+";
+        await CreateTest(source, "ReactiveConditions.g.cs", ExpectALIS001(0)).RunAsync();
+    }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/ControlFlow/WhenDetectingControlFlowInReactiveCallbacks.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/ControlFlow/WhenDetectingControlFlowInReactiveCallbacks.cs
@@ -160,7 +160,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -185,7 +185,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -209,7 +209,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -235,7 +235,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -259,7 +259,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -283,7 +283,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -309,7 +309,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0), ExpectALIS004(1)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0), ExpectALIS004(1)).RunAsync();
     }
 
     [Test]
@@ -333,7 +333,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -358,7 +358,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -383,7 +383,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -410,7 +410,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     // ── Flagged: Expression types ─────────────────────────────────
@@ -437,7 +437,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -463,7 +463,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     // ── Flagged: Scenarios ────────────────────────────────────────
@@ -490,7 +490,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0), ExpectALIS004(1)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0), ExpectALIS004(1)).RunAsync();
     }
 
     [Test]
@@ -516,7 +516,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -542,7 +542,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -565,7 +565,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     // ── Allowed: DSL usage ────────────────────────────────────────
@@ -593,7 +593,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -621,7 +621,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -649,7 +649,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -679,7 +679,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -702,7 +702,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -724,7 +724,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -751,7 +751,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     // ── Scope: Nested lambdas ─────────────────────────────────────
@@ -780,7 +780,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -807,7 +807,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     [Test]
@@ -837,7 +837,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -864,7 +864,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     // ── Scope: File type ──────────────────────────────────────────
@@ -919,7 +919,7 @@ public class GeneratedView
 }
 ";
         // Only 1 diagnostic — the if statement. The ternary inside is NOT double-reported.
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -945,7 +945,7 @@ public class GeneratedView
 }
 ";
         // Only 1 diagnostic — the switch statement. The nested switch expression is NOT double-reported.
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     // ── Review fixes: additional statement types ──────────────────
@@ -972,7 +972,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -998,7 +998,7 @@ public class GeneratedView
 }
 ";
         // LocalFunctionStatement is flagged; the Helper() call is an ExpressionStatement (allowed)
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     // ── Review fixes: additional scope tests ──────────────────────
@@ -1028,7 +1028,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 
     [Test]
@@ -1059,6 +1059,6 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS004(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS004(0)).RunAsync();
     }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingDuplicateChainedRequests.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingDuplicateChainedRequests.cs
@@ -40,7 +40,7 @@ namespace Alis.Reactive.Builders
 ";
 
     private static CSharpAnalyzerTest<DuplicateChainedRequestAnalyzer, DefaultVerifier> CreateTest(
-        string source, string fileName = "View.g.cs", params DiagnosticResult[] expected)
+        string source, string fileName = "View.cshtml.g.cs", params DiagnosticResult[] expected)
     {
         var test = new CSharpAnalyzerTest<DuplicateChainedRequestAnalyzer, DefaultVerifier>
         {
@@ -48,7 +48,7 @@ namespace Alis.Reactive.Builders
         };
 
         test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
-        if (fileName == "View.g.cs")
+        if (fileName == "View.cshtml.g.cs")
         {
             test.TestCode = string.Empty;
             test.TestState.Sources.Add((fileName, source));

--- a/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingDuplicateChainedRequests.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingDuplicateChainedRequests.cs
@@ -16,13 +16,15 @@ namespace Alis.Reactive.Builders.Requests
 {
     public class ResponseBuilder<TModel> where TModel : class
     {
-        public ResponseBuilder<TModel> OnSuccess(Action<ResponseBuilder<TModel>> configure) => this;
-        public ResponseBuilder<TModel> OnError(Action<ResponseBuilder<TModel>> configure) => this;
-        public ResponseBuilder<TModel> Chained(Action<PipelineBuilder<TModel>> configure) => this;
+        public ResponseBuilder<TModel> OnSuccess(Action<PipelineBuilder<TModel>> configure) => this;
+        public ResponseBuilder<TModel> OnError(int statusCode, Action<PipelineBuilder<TModel>> configure) => this;
+        public ResponseBuilder<TModel> Chained(Action<HttpRequestBuilder<TModel>> configure) => this;
     }
 
     public class HttpRequestBuilder<TModel> where TModel : class
     {
+        public HttpRequestBuilder<TModel> Post(string url) => this;
+        public HttpRequestBuilder<TModel> Get(string url) => this;
         public HttpRequestBuilder<TModel> Response(Action<ResponseBuilder<TModel>> configure) => this;
     }
 }
@@ -108,7 +110,7 @@ public class GeneratedView
         p.Post(""/api/start"")
          .Response(r => r
              .OnSuccess(s => {})
-             .OnError(e => {}));
+             .OnError(400, e => {}));
     }
 }
 ";
@@ -220,5 +222,31 @@ public class GeneratedView
 }
 ";
         await CreateTest(source, expected: ExpectALIS007(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Three_Chained_reports_on_second_and_third()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Requests;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<MyModel>();
+        p.Post(""/api/start"")
+         .Response(r => r
+             .Chained(c => c.Post(""/api/step-1""))
+             .{|#0:Chained|}(c => c.Post(""/api/step-2""))
+             .{|#1:Chained|}(c => c.Post(""/api/step-3"")));
+    }
+}
+";
+        await CreateTest(source, expected: new[] { ExpectALIS007(0), ExpectALIS007(1) }).RunAsync();
     }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingDuplicateChainedRequests.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingDuplicateChainedRequests.cs
@@ -1,0 +1,224 @@
+using Alis.Reactive.Analyzers.HttpPipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Alis.Reactive.Analyzers.Tests.HttpPipeline;
+
+[TestFixture]
+public class WhenDetectingDuplicateChainedRequests
+{
+    private const string TypeStubs = @"
+using System;
+
+namespace Alis.Reactive.Builders.Requests
+{
+    public class ResponseBuilder<TModel> where TModel : class
+    {
+        public ResponseBuilder<TModel> OnSuccess(Action<ResponseBuilder<TModel>> configure) => this;
+        public ResponseBuilder<TModel> OnError(Action<ResponseBuilder<TModel>> configure) => this;
+        public ResponseBuilder<TModel> Chained(Action<PipelineBuilder<TModel>> configure) => this;
+    }
+
+    public class HttpRequestBuilder<TModel> where TModel : class
+    {
+        public HttpRequestBuilder<TModel> Response(Action<ResponseBuilder<TModel>> configure) => this;
+    }
+}
+
+namespace Alis.Reactive.Builders
+{
+    public class PipelineBuilder<TModel> where TModel : class
+    {
+        public Requests.HttpRequestBuilder<TModel> Post(string url) => new Requests.HttpRequestBuilder<TModel>();
+        public Requests.HttpRequestBuilder<TModel> Get(string url) => new Requests.HttpRequestBuilder<TModel>();
+    }
+}
+";
+
+    private static CSharpAnalyzerTest<DuplicateChainedRequestAnalyzer, DefaultVerifier> CreateTest(
+        string source, string fileName = "View.g.cs", params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<DuplicateChainedRequestAnalyzer, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
+        if (fileName == "View.g.cs")
+        {
+            test.TestCode = string.Empty;
+            test.TestState.Sources.Add((fileName, source));
+        }
+        else
+        {
+            test.TestCode = source;
+        }
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test;
+    }
+
+    private static DiagnosticResult ExpectALIS007(int markupKey)
+        => new DiagnosticResult(DuplicateChainedRequestAnalyzer.DiagnosticId, DiagnosticSeverity.Error)
+            .WithLocation(markupKey);
+
+    // -- Clean cases ----------------------------------------------------------
+
+    [Test]
+    public async Task Single_Chained_does_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Requests;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<MyModel>();
+        p.Post(""/api/start"")
+         .Response(r => r
+             .OnSuccess(s => {})
+             .Chained(c => c.Post(""/api/step-2"")));
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    [Test]
+    public async Task No_Chained_at_all_does_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Requests;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<MyModel>();
+        p.Post(""/api/start"")
+         .Response(r => r
+             .OnSuccess(s => {})
+             .OnError(e => {}));
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    [Test]
+    public async Task Chained_in_plain_cs_file_does_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Requests;
+
+public class MyModel { }
+
+public class NotRazor
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<MyModel>();
+        p.Post(""/api/start"")
+         .Response(r => r
+             .Chained(c => c.Post(""/api/step-1""))
+             .Chained(c => c.Post(""/api/step-2"")));
+    }
+}
+";
+        await CreateTest(source, fileName: "Service.cs").RunAsync();
+    }
+
+    [Test]
+    public async Task Chained_on_different_ResponseBuilder_chains_does_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Requests;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<MyModel>();
+
+        p.Post(""/api/first"")
+         .Response(r => r
+             .Chained(c => c.Post(""/api/step-a"")));
+
+        p.Post(""/api/second"")
+         .Response(r => r
+             .Chained(c => c.Post(""/api/step-b"")));
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    // -- Flagged cases --------------------------------------------------------
+
+    [Test]
+    public async Task Duplicate_Chained_on_same_chain_reports_ALIS007()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Requests;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<MyModel>();
+        p.Post(""/api/start"")
+         .Response(r => r
+             .Chained(c => c.Post(""/api/step-1""))
+             .{|#0:Chained|}(c => c.Post(""/api/step-2"")));
+    }
+}
+";
+        await CreateTest(source, expected: ExpectALIS007(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task OnSuccess_between_two_Chained_still_reports()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Builders.Requests;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var p = new PipelineBuilder<MyModel>();
+        p.Post(""/api/start"")
+         .Response(r => r
+             .Chained(c => c.Post(""/api/step-1""))
+             .OnSuccess(s => {})
+             .{|#0:Chained|}(c => c.Post(""/api/step-2"")));
+    }
+}
+";
+        await CreateTest(source, expected: ExpectALIS007(0)).RunAsync();
+    }
+}

--- a/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingMultipleHttpRequestsInPipeline.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingMultipleHttpRequestsInPipeline.cs
@@ -136,7 +136,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     // ── Flagged: two HTTP requests ───────────────────────────────
@@ -165,7 +165,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS008(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS008(0)).RunAsync();
     }
 
     // ── Clean: Parallel requests ─────────────────────────────────
@@ -194,7 +194,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     // ── Clean: Chained request ───────────────────────────────────
@@ -221,7 +221,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     // ── Scope: plain .cs file ────────────────────────────────────
@@ -280,7 +280,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS008(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS008(0)).RunAsync();
     }
 
     // ── Multiple: three HTTP requests reports on second and third ─
@@ -310,7 +310,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS008(0), ExpectALIS008(1)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS008(0), ExpectALIS008(1)).RunAsync();
     }
 
     // ── Clean: HTTP inside nested lambdas not counted ────────────
@@ -340,7 +340,7 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs").RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs").RunAsync();
     }
 
     // ── Mixed HTTP methods ───────────────────────────────────────
@@ -368,6 +368,6 @@ public class GeneratedView
     }
 }
 ";
-        await CreateTest(source, "View.g.cs", ExpectALIS008(0)).RunAsync();
+        await CreateTest(source, "View.cshtml.g.cs", ExpectALIS008(0)).RunAsync();
     }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingMultipleHttpRequestsInPipeline.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingMultipleHttpRequestsInPipeline.cs
@@ -1,0 +1,373 @@
+using Alis.Reactive.Analyzers.HttpPipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Alis.Reactive.Analyzers.Tests.HttpPipeline;
+
+[TestFixture]
+public class WhenDetectingMultipleHttpRequestsInPipeline
+{
+    private const string TypeStubs = @"
+using System;
+
+namespace Alis.Reactive.Builders
+{
+    public class TriggerBuilder<TModel> where TModel : class
+    {
+        public TriggerBuilder<TModel> DomReady(Action<PipelineBuilder<TModel>> configure) => this;
+        public TriggerBuilder<TModel> CustomEvent(string name, Action<PipelineBuilder<TModel>> configure) => this;
+    }
+
+    public class PipelineBuilder<TModel> where TModel : class
+    {
+        public HttpRequestBuilder<TModel> Get(string url) => new HttpRequestBuilder<TModel>();
+        public HttpRequestBuilder<TModel> Post(string url) => new HttpRequestBuilder<TModel>();
+        public HttpRequestBuilder<TModel> Post(string url, Action<GatherBuilder<TModel>> gather) => new HttpRequestBuilder<TModel>();
+        public HttpRequestBuilder<TModel> Put(string url, Action<GatherBuilder<TModel>> gather) => new HttpRequestBuilder<TModel>();
+        public HttpRequestBuilder<TModel> Delete(string url) => new HttpRequestBuilder<TModel>();
+        public ParallelBuilder<TModel> Parallel(params Action<HttpRequestBuilder<TModel>>[] branches) => new ParallelBuilder<TModel>();
+        public ElementBuilder<TModel> Element(string id) => new ElementBuilder<TModel>(this);
+        public PipelineBuilder<TModel> Dispatch(string name) => this;
+    }
+
+    public class ElementBuilder<TModel> where TModel : class
+    {
+        private readonly PipelineBuilder<TModel> _pb;
+        public ElementBuilder(PipelineBuilder<TModel> pb) { _pb = pb; }
+        public PipelineBuilder<TModel> Show() => _pb;
+        public PipelineBuilder<TModel> Hide() => _pb;
+    }
+
+    public class ParallelBuilder<TModel> where TModel : class
+    {
+        public PipelineBuilder<TModel> Done() => new PipelineBuilder<TModel>();
+    }
+
+    public class HttpRequestBuilder<TModel> where TModel : class
+    {
+        public HttpRequestBuilder<TModel> Get(string url) => this;
+        public HttpRequestBuilder<TModel> Post(string url) => this;
+        public HttpRequestBuilder<TModel> Put(string url) => this;
+        public HttpRequestBuilder<TModel> Delete(string url) => this;
+        public HttpRequestBuilder<TModel> Response(Action<ResponseBuilder<TModel>> configure) => this;
+        public HttpRequestBuilder<TModel> WhileLoading(Action<PipelineBuilder<TModel>> configure) => this;
+        public HttpRequestBuilder<TModel> Gather(Action<GatherBuilder<TModel>> configure) => this;
+    }
+
+    public class ResponseBuilder<TModel> where TModel : class
+    {
+        public ResponseBuilder<TModel> OnSuccess(Action<PipelineBuilder<TModel>> configure) => this;
+        public ResponseBuilder<TModel> OnError(int statusCode, Action<PipelineBuilder<TModel>> configure) => this;
+        public ResponseBuilder<TModel> Chained(Action<HttpRequestBuilder<TModel>> configure) => this;
+    }
+
+    public class GatherBuilder<TModel> where TModel : class
+    {
+        public GatherBuilder<TModel> IncludeAll() => this;
+        public GatherBuilder<TModel> Static(string key, object value) => this;
+    }
+}
+
+namespace Alis.Reactive
+{
+    public class ReactivePlan<TModel> where TModel : class { }
+
+    public static class HtmlOnExtensions
+    {
+        public static void On<TModel>(
+            object html,
+            ReactivePlan<TModel> plan,
+            Action<Alis.Reactive.Builders.TriggerBuilder<TModel>> configure)
+            where TModel : class
+        { }
+    }
+}
+";
+
+    private static CSharpAnalyzerTest<MultipleHttpRequestsInPipelineAnalyzer, DefaultVerifier> CreateTest(
+        string source, string fileName = "Test0.cs", params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<MultipleHttpRequestsInPipelineAnalyzer, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
+        if (fileName == "Test0.cs")
+        {
+            test.TestCode = source;
+        }
+        else
+        {
+            test.TestCode = string.Empty;
+            test.TestState.Sources.Add((fileName, source));
+        }
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test;
+    }
+
+    private static DiagnosticResult ExpectALIS008(int markupKey)
+        => new DiagnosticResult(MultipleHttpRequestsInPipelineAnalyzer.DiagnosticId, DiagnosticSeverity.Error)
+            .WithLocation(markupKey);
+
+    // ── Clean: single HTTP request ───────────────────────────────
+
+    [Test]
+    public async Task Single_HTTP_request_does_not_report()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Post(""/api/save"", g => g.IncludeAll())
+             .Response(r => r.OnSuccess(s => s.Dispatch(""saved"")));
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs").RunAsync();
+    }
+
+    // ── Flagged: two HTTP requests ───────────────────────────────
+
+    [Test]
+    public async Task Two_HTTP_requests_in_same_lambda_reports_ALIS008_on_second()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Post(""/api/save"", g => g.IncludeAll())
+             .Response(r => r.OnSuccess(s => s.Dispatch(""saved"")));
+
+            {|#0:p.Post(""/api/other"", g => g.IncludeAll());|}
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs", ExpectALIS008(0)).RunAsync();
+    }
+
+    // ── Clean: Parallel requests ─────────────────────────────────
+
+    [Test]
+    public async Task Parallel_requests_do_not_report()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Parallel(
+                a => a.Get(""/api/one""),
+                b => b.Get(""/api/two"")
+            );
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs").RunAsync();
+    }
+
+    // ── Clean: Chained request ───────────────────────────────────
+
+    [Test]
+    public async Task Chained_request_does_not_report()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Post(""/api/first"", g => g.IncludeAll())
+             .Response(r => r.Chained(c => c.Post(""/api/second"")));
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs").RunAsync();
+    }
+
+    // ── Scope: plain .cs file ────────────────────────────────────
+
+    [Test]
+    public async Task HTTP_in_plain_cs_file_does_not_report()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class PlainClass
+{
+    public void Example()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Post(""/api/save"", g => g.IncludeAll());
+            p.Post(""/api/other"", g => g.IncludeAll());
+        }));
+    }
+}
+";
+        // Default fileName = "Test0.cs" — NOT a generated file
+        await CreateTest(source).RunAsync();
+    }
+
+    // ── Mixed: HTTP after non-HTTP commands ──────────────────────
+
+    [Test]
+    public async Task HTTP_after_non_HTTP_commands_then_another_HTTP_reports_correctly()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Get(""/api/data"")
+             .Response(r => r.OnSuccess(s => s.Element(""result"").Show()));
+
+            p.Element(""spinner"").Hide();
+
+            {|#0:p.Delete(""/api/cleanup"");|}
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs", ExpectALIS008(0)).RunAsync();
+    }
+
+    // ── Multiple: three HTTP requests reports on second and third ─
+
+    [Test]
+    public async Task Three_HTTP_requests_reports_on_second_and_third()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Get(""/api/one"");
+
+            {|#0:p.Post(""/api/two"", g => g.IncludeAll());|}
+
+            {|#1:p.Delete(""/api/three"");|}
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs", ExpectALIS008(0), ExpectALIS008(1)).RunAsync();
+    }
+
+    // ── Clean: HTTP inside nested lambdas not counted ────────────
+
+    [Test]
+    public async Task HTTP_inside_OnSuccess_lambda_does_not_count_as_top_level()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Post(""/api/save"", g => g.IncludeAll())
+             .Response(r => r.OnSuccess(s =>
+             {
+                 s.Dispatch(""saved"");
+             }));
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs").RunAsync();
+    }
+
+    // ── Mixed HTTP methods ───────────────────────────────────────
+
+    [Test]
+    public async Task Mixed_Get_and_Put_reports_ALIS008()
+    {
+        const string source = @"
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        HtmlOnExtensions.On(this, plan, t => t.DomReady(p =>
+        {
+            p.Get(""/api/data"");
+
+            {|#0:p.Put(""/api/update"", g => g.IncludeAll());|}
+        }));
+    }
+}
+";
+        await CreateTest(source, "View.g.cs", ExpectALIS008(0)).RunAsync();
+    }
+}

--- a/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingMultipleHttpRequestsInPipeline.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/HttpPipeline/WhenDetectingMultipleHttpRequestsInPipeline.cs
@@ -42,7 +42,7 @@ namespace Alis.Reactive.Builders
 
     public class ParallelBuilder<TModel> where TModel : class
     {
-        public PipelineBuilder<TModel> Done() => new PipelineBuilder<TModel>();
+        public ParallelBuilder<TModel> OnAllSettled(Action<PipelineBuilder<TModel>> configure) => this;
     }
 
     public class HttpRequestBuilder<TModel> where TModel : class

--- a/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
@@ -1,10 +1,10 @@
-using Alis.Reactive.Analyzers;
+using Alis.Reactive.Analyzers.NativeActionLink;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using NUnit.Framework;
 
-namespace Alis.Reactive.Analyzers.Tests;
+namespace Alis.Reactive.Analyzers.Tests.NativeActionLink;
 
 [TestFixture]
 public class WhenEnforcingNativeActionLinkSingleRequest

--- a/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
@@ -107,7 +107,7 @@ namespace Alis.Reactive.Native.Components
 }";
 
     private static CSharpAnalyzerTest<NativeActionLinkSingleRequestAnalyzer, DefaultVerifier> CreateTest(
-        string source, string fileName = "NativeActionLink.g.cs", params DiagnosticResult[] expected)
+        string source, string fileName = "NativeActionLink.cshtml.g.cs", params DiagnosticResult[] expected)
     {
         var test = new CSharpAnalyzerTest<NativeActionLinkSingleRequestAnalyzer, DefaultVerifier>
         {
@@ -178,7 +178,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.cshtml.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -204,7 +204,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.cshtml.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -230,7 +230,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.cshtml.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -283,7 +283,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.cshtml.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -310,7 +310,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.cshtml.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -365,6 +365,6 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.cshtml.g.cs", ExpectALIS002(0)).RunAsync();
     }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
@@ -107,7 +107,7 @@ namespace Alis.Reactive.Native.Components
 }";
 
     private static CSharpAnalyzerTest<NativeActionLinkSingleRequestAnalyzer, DefaultVerifier> CreateTest(
-        string source, params DiagnosticResult[] expected)
+        string source, string fileName = "NativeActionLink.g.cs", params DiagnosticResult[] expected)
     {
         var test = new CSharpAnalyzerTest<NativeActionLinkSingleRequestAnalyzer, DefaultVerifier>
         {
@@ -116,7 +116,7 @@ namespace Alis.Reactive.Native.Components
         };
 
         test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
-        test.TestState.Sources.Add(("NativeActionLink.g.cs", source));
+        test.TestState.Sources.Add((fileName, source));
         test.ExpectedDiagnostics.AddRange(expected);
         return test;
     }
@@ -178,7 +178,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -204,7 +204,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -230,7 +230,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -283,7 +283,7 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
     }
 
     [Test]
@@ -310,6 +310,35 @@ public class GeneratedView
     }
 }";
 
-        await CreateTest(source, ExpectALIS002(0)).RunAsync();
+        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Parallel_in_plain_cs_file_does_not_report()
+    {
+        const string source = @"
+using Alis.Reactive.Native.Components;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+public class PageModel { }
+
+public class GeneratedView
+{
+    public IHtmlHelper<PageModel> Html { get; set; } = default!;
+
+    public void Execute()
+    {
+        Html.NativeActionLink(""Delete"", ""/orders/delete/42"", p =>
+        {
+            p.Parallel(
+                a => a.Post(""/a""),
+                b => b.Post(""/b""))
+             .OnAllSettled(x => x.Element(""done"").Show());
+            p.Post(""/orders/delete/42"");
+        });
+    }
+}";
+
+        await CreateTest(source, "Service.cs").RunAsync();
     }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/NativeActionLink/WhenEnforcingNativeActionLinkSingleRequest.cs
@@ -341,4 +341,30 @@ public class GeneratedView
 
         await CreateTest(source, "Service.cs").RunAsync();
     }
+
+    [Test]
+    public async Task Two_top_level_requests_reports_ALIS002()
+    {
+        const string source = @"
+using Alis.Reactive.Native.Components;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+public class PageModel { }
+
+public class GeneratedView
+{
+    public IHtmlHelper<PageModel> Html { get; set; } = default!;
+
+    public void Execute()
+    {
+        Html.NativeActionLink(""Save"", ""/orders/save"", {|#0:p =>
+        {
+            p.Post(""/orders/save"");
+            p.Post(""/orders/notify"");
+        }|});
+    }
+}";
+
+        await CreateTest(source, "NativeActionLink.g.cs", ExpectALIS002(0)).RunAsync();
+    }
 }

--- a/tests/Alis.Reactive.Analyzers.Tests/ReactiveEvent/WhenDetectingDuplicateReactiveEvents.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/ReactiveEvent/WhenDetectingDuplicateReactiveEvents.cs
@@ -65,7 +65,7 @@ namespace Alis.Reactive.Components
 ";
 
     private static CSharpAnalyzerTest<DuplicateReactiveEventAnalyzer, DefaultVerifier> CreateTest(
-        string source, string fileName = "View.g.cs", params DiagnosticResult[] expected)
+        string source, string fileName = "View.cshtml.g.cs", params DiagnosticResult[] expected)
     {
         var test = new CSharpAnalyzerTest<DuplicateReactiveEventAnalyzer, DefaultVerifier>
         {
@@ -73,7 +73,7 @@ namespace Alis.Reactive.Components
         };
 
         test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
-        if (fileName == "View.g.cs")
+        if (fileName == "View.cshtml.g.cs")
         {
             test.TestCode = string.Empty;
             test.TestState.Sources.Add((fileName, source));

--- a/tests/Alis.Reactive.Analyzers.Tests/ReactiveEvent/WhenDetectingDuplicateReactiveEvents.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/ReactiveEvent/WhenDetectingDuplicateReactiveEvents.cs
@@ -1,0 +1,278 @@
+using Alis.Reactive.Analyzers.ReactiveEvent;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Alis.Reactive.Analyzers.Tests.ReactiveEvent;
+
+[TestFixture]
+public class WhenDetectingDuplicateReactiveEvents
+{
+    private const string TypeStubs = @"
+using System;
+
+namespace Alis.Reactive
+{
+    public class ReactivePlan<TModel> where TModel : class { }
+}
+
+namespace Alis.Reactive.Builders
+{
+    public class PipelineBuilder<TModel> where TModel : class
+    {
+        public PipelineBuilder<TModel> Dispatch(string name) => this;
+    }
+}
+
+namespace Alis.Reactive.Components
+{
+    public class ChangedArgs { }
+    public class ClickArgs { }
+    public class FocusArgs { }
+
+    public class TextBoxEvents
+    {
+        public static readonly TextBoxEvents Instance = new TextBoxEvents();
+        public ChangedArgs Changed => new ChangedArgs();
+        public FocusArgs Focus => new FocusArgs();
+    }
+
+    public class ButtonEvents
+    {
+        public static readonly ButtonEvents Instance = new ButtonEvents();
+        public ClickArgs Click => new ClickArgs();
+    }
+
+    public class TextBoxBuilder<TModel> where TModel : class
+    {
+        public TextBoxBuilder<TModel> Placeholder(string text) => this;
+
+        public TextBoxBuilder<TModel> Reactive<TArgs>(
+            ReactivePlan<TModel> plan,
+            Func<TextBoxEvents, TArgs> eventSelector,
+            Action<TArgs, Builders.PipelineBuilder<TModel>> pipeline) => this;
+    }
+
+    public class ButtonBuilder<TModel> where TModel : class
+    {
+        public ButtonBuilder<TModel> Reactive<TArgs>(
+            ReactivePlan<TModel> plan,
+            Func<ButtonEvents, TArgs> eventSelector,
+            Action<TArgs, Builders.PipelineBuilder<TModel>> pipeline) => this;
+    }
+}
+";
+
+    private static CSharpAnalyzerTest<DuplicateReactiveEventAnalyzer, DefaultVerifier> CreateTest(
+        string source, string fileName = "View.g.cs", params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<DuplicateReactiveEventAnalyzer, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
+        if (fileName == "View.g.cs")
+        {
+            test.TestCode = string.Empty;
+            test.TestState.Sources.Add((fileName, source));
+        }
+        else
+        {
+            test.TestCode = source;
+        }
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test;
+    }
+
+    private static DiagnosticResult ExpectALIS003(int markupKey)
+        => new DiagnosticResult(DuplicateReactiveEventAnalyzer.DiagnosticId, DiagnosticSeverity.Error)
+            .WithLocation(markupKey);
+
+    // -- Clean cases ----------------------------------------------------------
+
+    [Test]
+    public async Task Single_Reactive_call_does_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Components;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""x""); });
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    [Test]
+    public async Task Different_events_on_same_builder_do_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Components;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""a""); })
+            .Reactive(plan, evt => evt.Focus, (args, p) => { p.Dispatch(""b""); });
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    [Test]
+    public async Task Same_event_in_plain_cs_file_does_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Components;
+
+public class MyModel { }
+
+public class NotRazor
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""a""); })
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""b""); });
+    }
+}
+";
+        await CreateTest(source, fileName: "Service.cs").RunAsync();
+    }
+
+    [Test]
+    public async Task Different_builders_with_same_event_do_not_report()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Components;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+
+        new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""a""); });
+
+        new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""b""); });
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    // -- Flagged cases --------------------------------------------------------
+
+    [Test]
+    public async Task Duplicate_Reactive_for_same_event_reports_ALIS003()
+    {
+        // The diagnostic spans the entire InvocationExpressionSyntax (receiver chain + call).
+        const string source = @"
+using System;
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Components;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        {|#0:new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""a""); })
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""b""); })|};
+    }
+}
+";
+        await CreateTest(source, expected: ExpectALIS003(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Multiple_duplicates_report_multiple_diagnostics()
+    {
+        // Second and third .Reactive(Changed) both flag. The third invocation
+        // encompasses the entire chain, the second encompasses the first two calls.
+        const string source = @"
+using System;
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Components;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        {|#1:{|#0:new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""a""); })
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""b""); })|}
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""c""); })|};
+    }
+}
+";
+        await CreateTest(source, expected: new[] { ExpectALIS003(0), ExpectALIS003(1) }).RunAsync();
+    }
+
+    [Test]
+    public async Task Duplicate_separated_by_different_event_reports_ALIS003()
+    {
+        const string source = @"
+using System;
+using Alis.Reactive;
+using Alis.Reactive.Builders;
+using Alis.Reactive.Components;
+
+public class MyModel { }
+
+public class GeneratedView
+{
+    public void Execute()
+    {
+        var plan = new ReactivePlan<MyModel>();
+        {|#0:new TextBoxBuilder<MyModel>()
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""a""); })
+            .Reactive(plan, evt => evt.Focus, (args, p) => { p.Dispatch(""b""); })
+            .Reactive(plan, evt => evt.Changed, (args, p) => { p.Dispatch(""c""); })|};
+    }
+}
+";
+        await CreateTest(source, expected: ExpectALIS003(0)).RunAsync();
+    }
+}

--- a/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyConditions.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyConditions.cs
@@ -153,7 +153,7 @@ public class MyValidator : ReactiveValidator<MyModel>
 {
     public MyValidator()
     {
-        {|#0:RuleFor(x => x.Name).NotEmpty().When(x => x.IsActive)|};
+        RuleFor(x => x.Name).NotEmpty().{|#0:When|}(x => x.IsActive);
     }
 }
 ";
@@ -178,7 +178,7 @@ public class MyValidator : ReactiveValidator<MyModel>
 {
     public MyValidator()
     {
-        {|#0:RuleFor(x => x.Name).NotEmpty().Unless(x => x.IsAdmin)|};
+        RuleFor(x => x.Name).NotEmpty().{|#0:Unless|}(x => x.IsAdmin);
     }
 }
 ";
@@ -203,7 +203,7 @@ public class MyValidator : ReactiveValidator<MyModel>
 {
     public MyValidator()
     {
-        {|#0:RuleFor(x => x.Name).NotEmpty().MaximumLength(100).When(x => x.IsActive)|};
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100).{|#0:When|}(x => x.IsActive);
     }
 }
 ";
@@ -228,7 +228,7 @@ public class MyValidator : ReactiveValidator<MyModel>
 {
     public MyValidator()
     {
-        {|#0:RuleForEach(x => x.Tags).NotEmpty().When(x => x.RequireTags)|};
+        RuleForEach(x => x.Tags).NotEmpty().{|#0:When|}(x => x.RequireTags);
     }
 }
 ";
@@ -255,8 +255,8 @@ public class MyValidator : ReactiveValidator<MyModel>
 {
     public MyValidator()
     {
-        {|#0:RuleFor(x => x.Name).NotEmpty().When(x => x.IsActive)|};
-        {|#1:RuleFor(x => x.Email).NotEmpty().When(x => x.RequireEmail)|};
+        RuleFor(x => x.Name).NotEmpty().{|#0:When|}(x => x.IsActive);
+        RuleFor(x => x.Email).NotEmpty().{|#1:When|}(x => x.RequireEmail);
     }
 }
 ";

--- a/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyConditions.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyConditions.cs
@@ -1,0 +1,265 @@
+using Alis.Reactive.Analyzers.Validation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Alis.Reactive.Analyzers.Tests.Validation;
+
+[TestFixture]
+public class WhenDetectingServerOnlyConditions
+{
+    private const string TypeStubs = @"
+using System;
+using System.Linq.Expressions;
+
+namespace FluentValidation
+{
+    public abstract class AbstractValidator<T>
+    {
+        public IRuleBuilderInitial<T, TProperty> RuleFor<TProperty>(
+            Expression<Func<T, TProperty>> expression) => default!;
+        public IRuleBuilderInitial<T, TProperty> RuleForEach<TProperty>(
+            Expression<Func<T, TProperty>> expression) => default!;
+    }
+
+    public interface IRuleBuilderInitial<T, TProperty> : IRuleBuilderOptions<T, TProperty> { }
+
+    public interface IRuleBuilderOptions<T, TProperty>
+    {
+        IRuleBuilderOptions<T, TProperty> NotEmpty();
+        IRuleBuilderOptions<T, TProperty> MaximumLength(int max);
+        IRuleBuilderOptions<T, TProperty> When(Func<T, bool> predicate);
+        IRuleBuilderOptions<T, TProperty> Unless(Func<T, bool> predicate);
+    }
+}
+
+namespace Alis.Reactive.FluentValidator
+{
+    public abstract class ReactiveValidator<T> : FluentValidation.AbstractValidator<T> { }
+}
+
+namespace Alis.Reactive.Builders
+{
+    public class PipelineBuilder<TModel> where TModel : class
+    {
+        public ConditionSourceBuilder<TModel, TProp> When<TPayload, TProp>(
+            TPayload payload, Expression<Func<TPayload, TProp>> path)
+            => new ConditionSourceBuilder<TModel, TProp>();
+    }
+
+    public sealed class ConditionSourceBuilder<TModel, TProp> where TModel : class
+    {
+        public GuardBuilder<TModel> Eq(TProp value) => new GuardBuilder<TModel>();
+    }
+
+    public sealed class GuardBuilder<TModel> where TModel : class
+    {
+        public BranchBuilder<TModel> Then(Action<PipelineBuilder<TModel>> pipeline)
+            => new BranchBuilder<TModel>();
+    }
+
+    public sealed class BranchBuilder<TModel> where TModel : class { }
+}
+";
+
+    private static CSharpAnalyzerTest<ServerOnlyConditionAnalyzer, DefaultVerifier> CreateTest(
+        string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<ServerOnlyConditionAnalyzer, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode = string.Empty,
+        };
+
+        test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
+        test.TestState.Sources.Add(("Test0.cs", source));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test;
+    }
+
+    private static DiagnosticResult ExpectALIS006(int markupKey)
+        => new DiagnosticResult(ServerOnlyConditionAnalyzer.DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(markupKey);
+
+    // ── Clean cases ───────────────────────────────────────────
+
+    [Test]
+    public async Task When_in_AbstractValidator_does_not_report()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+    public bool IsActive { get; set; }
+}
+
+public class MyValidator : AbstractValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().When(x => x.IsActive);
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    [Test]
+    public async Task PipelineBuilder_When_does_not_report()
+    {
+        const string source = @"
+using System;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders;
+using Alis.Reactive.FluentValidator;
+
+public class Payload { public string Status { get; set; } = """"; }
+public class MyModel { }
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public void SomeMethod()
+    {
+        var pb = new PipelineBuilder<MyModel>();
+        var payload = new Payload();
+        pb.When(payload, x => x.Status).Eq(""active"");
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    // ── Flagged cases ─────────────────────────────────────────
+
+    [Test]
+    public async Task When_on_RuleFor_chain_in_ReactiveValidator_reports_ALIS006()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+    public bool IsActive { get; set; }
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        {|#0:RuleFor(x => x.Name).NotEmpty().When(x => x.IsActive)|};
+    }
+}
+";
+        await CreateTest(source, ExpectALIS006(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Unless_on_RuleFor_chain_in_ReactiveValidator_reports_ALIS006()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+    public bool IsAdmin { get; set; }
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        {|#0:RuleFor(x => x.Name).NotEmpty().Unless(x => x.IsAdmin)|};
+    }
+}
+";
+        await CreateTest(source, ExpectALIS006(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task When_on_deeply_chained_rule_reports_ALIS006()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+    public bool IsActive { get; set; }
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        {|#0:RuleFor(x => x.Name).NotEmpty().MaximumLength(100).When(x => x.IsActive)|};
+    }
+}
+";
+        await CreateTest(source, ExpectALIS006(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task When_on_RuleForEach_chain_reports_ALIS006()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Tags { get; set; } = """";
+    public bool RequireTags { get; set; }
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        {|#0:RuleForEach(x => x.Tags).NotEmpty().When(x => x.RequireTags)|};
+    }
+}
+";
+        await CreateTest(source, ExpectALIS006(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Multiple_When_calls_report_multiple_diagnostics()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+    public string Email { get; set; } = """";
+    public bool IsActive { get; set; }
+    public bool RequireEmail { get; set; }
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        {|#0:RuleFor(x => x.Name).NotEmpty().When(x => x.IsActive)|};
+        {|#1:RuleFor(x => x.Email).NotEmpty().When(x => x.RequireEmail)|};
+    }
+}
+";
+        await CreateTest(source, ExpectALIS006(0), ExpectALIS006(1)).RunAsync();
+    }
+}

--- a/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyValidationRules.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyValidationRules.cs
@@ -1,0 +1,304 @@
+using Alis.Reactive.Analyzers.Validation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Alis.Reactive.Analyzers.Tests.Validation;
+
+[TestFixture]
+public class WhenDetectingServerOnlyValidationRules
+{
+    private const string TypeStubs = @"
+using System;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FluentValidation
+{
+    public abstract class AbstractValidator<T>
+    {
+        public IRuleBuilderInitial<T, TProperty> RuleFor<TProperty>(
+            Expression<Func<T, TProperty>> expression) => default!;
+    }
+
+    public interface IRuleBuilderInitial<T, TProperty> : IRuleBuilderOptions<T, TProperty> { }
+
+    public interface IRuleBuilderOptions<T, TProperty>
+    {
+        IRuleBuilderOptions<T, TProperty> NotEmpty();
+        IRuleBuilderOptions<T, TProperty> MaximumLength(int max);
+        IRuleBuilderOptions<T, TProperty> IsInEnum();
+        IRuleBuilderOptions<T, TProperty> Must(Func<TProperty, bool> predicate);
+        IRuleBuilderOptions<T, TProperty> MustAsync(
+            Func<TProperty, CancellationToken, Task<bool>> predicate);
+        IRuleBuilderOptions<T, TProperty> Custom(Action<TProperty, object> action);
+        IRuleBuilderOptions<T, TProperty> CustomAsync(
+            Func<TProperty, object, CancellationToken, Task> action);
+        IRuleBuilderOptions<T, TProperty> SetValidator(AbstractValidator<TProperty> validator);
+    }
+}
+
+namespace Alis.Reactive.FluentValidator
+{
+    public abstract class ReactiveValidator<T> : FluentValidation.AbstractValidator<T> { }
+}
+";
+
+    private static CSharpAnalyzerTest<ServerOnlyValidationRuleAnalyzer, DefaultVerifier> CreateTest(
+        string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<ServerOnlyValidationRuleAnalyzer, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode = string.Empty,
+        };
+
+        test.TestState.Sources.Add(("TypeStubs.cs", TypeStubs));
+        test.TestState.Sources.Add(("Test0.cs", source));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test;
+    }
+
+    private static DiagnosticResult ExpectALIS005(int markupKey)
+        => new DiagnosticResult(ServerOnlyValidationRuleAnalyzer.DiagnosticId, DiagnosticSeverity.Info)
+            .WithLocation(markupKey);
+
+    // ── Clean cases ───────────────────────────────────────────
+
+    [Test]
+    public async Task Extractable_rules_in_ReactiveValidator_do_not_report()
+    {
+        const string source = @"
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty();
+        RuleFor(x => x.Name).MaximumLength(100);
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    [Test]
+    public async Task Server_only_rules_in_AbstractValidator_do_not_report()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+}
+
+public class MyValidator : AbstractValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Name).Must(x => x.Length > 0);
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
+    // ── Flagged cases ─────────────────────────────────────────
+
+    [Test]
+    public async Task IsInEnum_in_ReactiveValidator_reports_ALIS005()
+    {
+        const string source = @"
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public enum CareLevel { Independent, Assisted, Memory }
+
+public class MyModel
+{
+    public CareLevel Level { get; set; }
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Level).{|#0:IsInEnum|}();
+    }
+}
+";
+        await CreateTest(source, ExpectALIS005(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Must_in_ReactiveValidator_reports_ALIS005()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Name).{|#0:Must|}(x => x.StartsWith(""A""));
+    }
+}
+";
+        await CreateTest(source, ExpectALIS005(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task MustAsync_in_ReactiveValidator_reports_ALIS005()
+    {
+        const string source = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Email { get; set; } = """";
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Email).{|#0:MustAsync|}((email, ct) => Task.FromResult(true));
+    }
+}
+";
+        await CreateTest(source, ExpectALIS005(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Custom_in_ReactiveValidator_reports_ALIS005()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Name).{|#0:Custom|}((name, ctx) => { });
+    }
+}
+";
+        await CreateTest(source, ExpectALIS005(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task CustomAsync_in_ReactiveValidator_reports_ALIS005()
+    {
+        const string source = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Name).{|#0:CustomAsync|}((name, ctx, ct) => Task.CompletedTask);
+    }
+}
+";
+        await CreateTest(source, ExpectALIS005(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task SetValidator_in_ReactiveValidator_reports_ALIS005()
+    {
+        const string source = @"
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class Address
+{
+    public string Street { get; set; } = """";
+}
+
+public class AddressValidator : AbstractValidator<Address>
+{
+    public AddressValidator() { RuleFor(x => x.Street).NotEmpty(); }
+}
+
+public class MyModel
+{
+    public Address Address { get; set; } = new Address();
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Address).{|#0:SetValidator|}(new AddressValidator());
+    }
+}
+";
+        await CreateTest(source, ExpectALIS005(0)).RunAsync();
+    }
+
+    [Test]
+    public async Task Multiple_server_only_calls_report_multiple_diagnostics()
+    {
+        const string source = @"
+using System;
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public enum Status { Active, Inactive }
+
+public class MyModel
+{
+    public string Name { get; set; } = """";
+    public Status Status { get; set; }
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Name).{|#0:Must|}(x => x.Length > 0);
+        RuleFor(x => x.Status).{|#1:IsInEnum|}();
+    }
+}
+";
+        await CreateTest(source, ExpectALIS005(0), ExpectALIS005(1)).RunAsync();
+    }
+}

--- a/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyValidationRules.cs
+++ b/tests/Alis.Reactive.Analyzers.Tests/Validation/WhenDetectingServerOnlyValidationRules.cs
@@ -114,6 +114,41 @@ public class MyValidator : AbstractValidator<MyModel>
         await CreateTest(source).RunAsync();
     }
 
+    [Test]
+    public async Task SetValidator_in_ReactiveValidator_does_not_report()
+    {
+        // SetValidator is handled by FluentValidationAdapter (recurses into nested validator).
+        // It is not server-only — the adapter extracts nested rules.
+        const string source = @"
+using FluentValidation;
+using Alis.Reactive.FluentValidator;
+
+public class Address
+{
+    public string Street { get; set; } = """";
+}
+
+public class AddressValidator : AbstractValidator<Address>
+{
+    public AddressValidator() { RuleFor(x => x.Street).NotEmpty(); }
+}
+
+public class MyModel
+{
+    public Address Address { get; set; } = new Address();
+}
+
+public class MyValidator : ReactiveValidator<MyModel>
+{
+    public MyValidator()
+    {
+        RuleFor(x => x.Address).SetValidator(new AddressValidator());
+    }
+}
+";
+        await CreateTest(source).RunAsync();
+    }
+
     // ── Flagged cases ─────────────────────────────────────────
 
     [Test]
@@ -242,32 +277,23 @@ public class MyValidator : ReactiveValidator<MyModel>
     }
 
     [Test]
-    public async Task SetValidator_in_ReactiveValidator_reports_ALIS005()
+    public async Task Server_only_method_after_extractable_chain_reports_ALIS005()
     {
         const string source = @"
+using System;
 using FluentValidation;
 using Alis.Reactive.FluentValidator;
 
-public class Address
-{
-    public string Street { get; set; } = """";
-}
-
-public class AddressValidator : AbstractValidator<Address>
-{
-    public AddressValidator() { RuleFor(x => x.Street).NotEmpty(); }
-}
-
 public class MyModel
 {
-    public Address Address { get; set; } = new Address();
+    public string Name { get; set; } = """";
 }
 
 public class MyValidator : ReactiveValidator<MyModel>
 {
     public MyValidator()
     {
-        RuleFor(x => x.Address).{|#0:SetValidator|}(new AddressValidator());
+        RuleFor(x => x.Name).NotEmpty().{|#0:Must|}(x => x.StartsWith(""A""));
     }
 }
 ";


### PR DESCRIPTION
## Summary

Complete analyzer overhaul: 4 new analyzers (ALIS005-008), vertical slice reorganization of all 8 analyzers, quality hardening with CompilationStart caching, and 93 BDD tests — all reviewed in multiple rounds.

### New Analyzers

| ID | Severity | Domain | What it detects | Closes |
|----|----------|--------|-----------------|--------|
| **ALIS005** | Info | Validation | Server-only FV rules (`IsInEnum`, `Must`, `MustAsync`, `Custom`, `CustomAsync`) in `ReactiveValidator<T>` that silently drop during client-side extraction | — |
| **ALIS006** | Warning | Validation | FV's `.When()`/`.Unless()` on RuleFor chains in `ReactiveValidator<T>` — suggests `WhenField()` for extractable conditions. Does NOT flag framework's `PipelineBuilder.When()` | — |
| **ALIS007** | Error | HttpPipeline | Duplicate `.Chained()` calls on `ResponseBuilder` — only the last survives, earlier ones silently overwrite | #74 |
| **ALIS008** | Error | HttpPipeline | Multiple HTTP requests (`Get`/`Post`/`Put`/`Delete`) in the same pipeline callback — second silently overwrites the first. Uses semantic analysis to exclude `Parallel()` and `Chained()` patterns | #75 |

### Existing Analyzer Improvements

| ID | Domain | Changes |
|----|--------|---------|
| **ALIS001** | ConditionalChain | Moved to vertical slice. Refactored to `RegisterCompilationStartAction` + `SymbolEqualityComparer` (was `ToDisplayString()` per-node). 3 new tests (multiple violations, `.cshtml` filename, deeply chained guard). |
| **ALIS002** | NativeActionLink | Moved to vertical slice. `CompilationStart` type caching, `ImmutableHashSet` for HTTP methods, single-pass `foreach` replacing 5 `.Any()`/`.Count()` passes. 2 new tests (wrong file type, two top-level requests). |
| **ALIS003** | ReactiveEvent | Moved to vertical slice. 7 new BDD tests (was 0). |
| **ALIS004** | ControlFlow | Moved to vertical slice (was already in folder from PR #70). No code changes — already high quality. |

### Vertical Slice Structure

```
Alis.Reactive.Analyzers/
├── ConditionalChain/           ← ALIS001 (semantic)
├── NativeActionLink/           ← ALIS002 (semantic)
├── ReactiveEvent/              ← ALIS003 (syntax-only)
├── ControlFlow/                ← ALIS004 (semantic)
├── Validation/                 ← ALIS005, ALIS006 (syntax-only)
└── HttpPipeline/               ← ALIS007 (syntax-only), ALIS008 (semantic)

tests/Alis.Reactive.Analyzers.Tests/
├── ConditionalChain/           (9 tests)
├── NativeActionLink/           (9 tests)
├── ReactiveEvent/              (7 tests)
├── ControlFlow/                (35 tests)
├── Validation/                 (17 tests)
└── HttpPipeline/               (16 tests)
```

Each domain has its own namespace. Tests mirror the structure.

### Quality Process

1. **Code review round 1** — 4 parallel review agents (one per domain cluster), findings ranked by severity
2. **False positive audit** — Read ALL `.cshtml` views and `ReactiveValidator` classes in the codebase. Zero false positives on current code across all 8 analyzers.
3. **Round 1 fixes** — ALIS006 diagnostic location narrowed to method name, ALIS007 TypeStubs corrected to match real `ResponseBuilder` signatures, ALIS008 fictional stub removed
4. **Performance hardening** — ALIS001/002 refactored to `RegisterCompilationStartAction` with `SymbolEqualityComparer.Default` (eliminates per-node `ToDisplayString()` calls). ALIS002 single-pass scan replaces 5 `.Any()` iterations.
5. **BDD review** — All 8 test files graded A. 93 tests, ~40% are false-positive protection tests. Zero "scoring points" tests detected.

### Skill Created

`~/.claude/skills/roslyn-analyzer.md` — Project-specific guide for writing Roslyn analyzers covering: vertical slice structure, ALIS ID scheme, syntax-only vs semantic decision tree, analyzer template, test template with TypeStubs, 6-point coverage checklist, anti-patterns.

### Validation Skill Updated

`~/.claude/skills/validation-rules-alis-reactive.md` — Added analyzer warnings (ALIS005/006), coercion table, known gaps, expanded anti-patterns.

## Test plan

- [x] `dotnet test tests/Alis.Reactive.Analyzers.Tests` — 93 tests pass (was 48)
- [x] `dotnet build` — 0 errors
- [x] False positive audit against all `.cshtml` views — 0 false positives
- [x] BDD quality review — all 8 test files graded A
- [ ] Verify analyzers fire in Rider on a real `ReactiveValidator<T>` subclass
- [ ] Verify ALIS007/008 fire in Rider on duplicate patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)