### PR TITLE
feat: NuGet CI — publish 6 core packages on merge to main

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,111 @@
+name: Publish NuGet packages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Alis.Reactive/**'
+      - 'Alis.Reactive.Native/**'
+      - 'Alis.Reactive.Fusion/**'
+      - 'Alis.Reactive.FluentValidator/**'
+      - 'Alis.Reactive.Analyzers/**'
+      - 'Alis.Reactive.NativeTagHelpers/**'
+      - 'Directory.Build.props'
+      - '.github/workflows/nuget-publish.yml'
+  workflow_dispatch:
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build JS + CSS bundles
+        run: npm run build:all
+
+      - name: Build all C# projects
+        run: dotnet build --configuration Release
+
+      - name: Run unit tests
+        run: |
+          dotnet test tests/Alis.Reactive.UnitTests --configuration Release --no-build
+          dotnet test tests/Alis.Reactive.Native.UnitTests --configuration Release --no-build
+          dotnet test tests/Alis.Reactive.Fusion.UnitTests --configuration Release --no-build
+          dotnet test tests/Alis.Reactive.FluentValidator.UnitTests --configuration Release --no-build
+          dotnet test tests/Alis.Reactive.Analyzers.Tests --configuration Release --no-build
+          dotnet test tests/Alis.Reactive.NativeTagHelpers.Tests --configuration Release --no-build
+          dotnet test tests/Alis.Reactive.DesignSystem.Tests --configuration Release --no-build
+
+  pack-and-publish:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build JS + CSS bundles
+        run: npm run build:all
+
+      - name: Pack NuGet packages
+        run: |
+          dotnet pack Alis.Reactive/Alis.Reactive.csproj --configuration Release --output ./nupkgs
+          dotnet pack Alis.Reactive.Native/Alis.Reactive.Native.csproj --configuration Release --output ./nupkgs
+          dotnet pack Alis.Reactive.Fusion/Alis.Reactive.Fusion.csproj --configuration Release --output ./nupkgs
+          dotnet pack Alis.Reactive.FluentValidator/Alis.Reactive.FluentValidator.csproj --configuration Release --output ./nupkgs
+          dotnet pack Alis.Reactive.Analyzers/Alis.Reactive.Analyzers.csproj --configuration Release --output ./nupkgs
+          dotnet pack Alis.Reactive.NativeTagHelpers/Alis.Reactive.NativeTagHelpers.csproj --configuration Release --output ./nupkgs
+
+      - name: Upload NuGet artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./nupkgs/*.nupkg
+          retention-days: 30
+
+      - name: Publish to GitHub Packages
+        run: |
+          dotnet nuget push ./nupkgs/*.nupkg \
+            --source "https://nuget.pkg.github.com/marafiq/index.json" \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --skip-duplicate
+
+      - name: Publish to NuGet.org
+        if: ${{ vars.PUBLISH_TO_NUGET == 'true' }}
+        run: |
+          dotnet nuget push ./nupkgs/*.nupkg \
+            --source "https://api.nuget.org/v3/index.json" \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate

--- a/Alis.Reactive.Analyzers/Alis.Reactive.Analyzers.csproj
+++ b/Alis.Reactive.Analyzers/Alis.Reactive.Analyzers.csproj
@@ -5,6 +5,10 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <IsPackable>true</IsPackable>
+        <DevelopmentDependency>true</DevelopmentDependency>
+        <PackageDescription>Roslyn analyzers for Alis.Reactive — compile-time checks for correct DSL usage, API surface protection, and HTTP pipeline validation.</PackageDescription>
+        <PackageTags>reactive;analyzers;roslyn;code-analysis</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Alis.Reactive.FluentValidator/Alis.Reactive.FluentValidator.csproj
+++ b/Alis.Reactive.FluentValidator/Alis.Reactive.FluentValidator.csproj
@@ -5,6 +5,9 @@
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
+        <IsPackable>true</IsPackable>
+        <PackageDescription>FluentValidation integration for Alis.Reactive — server-side rules that automatically extract to client-side validation.</PackageDescription>
+        <PackageTags>reactive;aspnetcore;fluentvalidation;validation</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Alis.Reactive.Fusion/Alis.Reactive.Fusion.csproj
+++ b/Alis.Reactive.Fusion/Alis.Reactive.Fusion.csproj
@@ -5,6 +5,9 @@
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsPackable>true</IsPackable>
+        <PackageDescription>Syncfusion EJ2 component integration for Alis.Reactive — rich UI components through the reactive plan DSL.</PackageDescription>
+        <PackageTags>reactive;aspnetcore;syncfusion;ej2;components</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Alis.Reactive.Native/Alis.Reactive.Native.csproj
+++ b/Alis.Reactive.Native/Alis.Reactive.Native.csproj
@@ -5,6 +5,9 @@
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsPackable>true</IsPackable>
+        <PackageDescription>Native HTML components for Alis.Reactive — textboxes, checkboxes, dropdowns, and more with zero vendor dependencies.</PackageDescription>
+        <PackageTags>reactive;aspnetcore;native-components;html</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Alis.Reactive.NativeTagHelpers/Alis.Reactive.NativeTagHelpers.csproj
+++ b/Alis.Reactive.NativeTagHelpers/Alis.Reactive.NativeTagHelpers.csproj
@@ -5,6 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Alis.Reactive.NativeTagHelpers</RootNamespace>
     <AssemblyName>Alis.Reactive.NativeTagHelpers</AssemblyName>
+    <IsPackable>true</IsPackable>
+    <PackageDescription>ASP.NET Core Tag Helpers for Alis.Reactive native components — declarative HTML authoring with reactive plan integration.</PackageDescription>
+    <PackageTags>reactive;aspnetcore;taghelpers;native-components</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Alis.Reactive/Alis.Reactive.csproj
+++ b/Alis.Reactive/Alis.Reactive.csproj
@@ -6,6 +6,9 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsPackable>true</IsPackable>
+        <PackageDescription>Core reactive framework for building plan-driven browser UIs with C# fluent builders and JSON-serialized reactive plans.</PackageDescription>
+        <PackageTags>reactive;blazor;aspnetcore;fluent-api;plan-driven</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <Version>1.0.0</Version>
+    <Authors>Alis Solutions</Authors>
+    <Company>Alis Solutions</Company>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/marafiq/alis-reactive</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/marafiq/alis-reactive</PackageProjectUrl>
+    <Copyright>Copyright (c) Alis Solutions 2026</Copyright>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to build, test, and publish 6 NuGet packages on merge to main
- Add `Directory.Build.props` with shared package metadata (v1.0.0, MIT)
- Add `IsPackable`, `PackageDescription`, `PackageTags` to each library csproj

## Packages

`Alis.Reactive`, `Alis.Reactive.Native`, `Alis.Reactive.Fusion`, `Alis.Reactive.FluentValidator`, `Alis.Reactive.Analyzers`, `Alis.Reactive.NativeTagHelpers`

## Test plan

- [ ] Merge to main triggers `nuget-publish.yml` workflow
- [ ] All 7 unit test suites pass in CI
- [ ] 6 `.nupkg` artifacts uploaded
- [ ] Packages appear in GitHub Packages

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)