### PR TITLE
fix: add coverage completeness gate to review process

### DIFF
--- a/.claude/rules/agent-dispatch.md
+++ b/.claude/rules/agent-dispatch.md
@@ -127,6 +127,12 @@ Output design:
 - Stop when remaining findings add no meaningful value.
 - Verify against actual code before accepting any finding.
 
+Coverage completeness (MANDATORY for test suite reviews):
+- List every item in the scope (schema $defs, TS exports, API members, etc.)
+- Map each to the test that covers it — by name, not by assumption
+- Report uncovered items as findings ranked by risk
+- "All tests pass" is not a sign-off. "All items are covered or justified" is.
+
 5 documented false alarms confirm: the code is the authority, not the review.
 ```
 
@@ -136,6 +142,15 @@ Task: Review PR #42 — CoerceResult extraction
 Layers touched by PR: 3 | Skills: solid-ts-audit
 Input: git diff main...fix/coerce-extraction
 Output: ranked findings with file:line evidence, most impactful first
+```
+
+**Example — Test Suite Review (with coverage gate):**
+```
+Task: Review drift detection test suite for completeness
+Scope: all $defs in reactive-plan.schema.json (51 definitions)
+Input: tests/Alis.Reactive.DriftDetection.Tests/**/*.cs
+Output: coverage matrix (definition → test name), uncovered items ranked by risk
+Sign-off requires: every definition mapped to a test or justified as untestable
 ```
 
 ## Template 4: BDD Agent

--- a/.claude/rules/process-task-types.md
+++ b/.claude/rules/process-task-types.md
@@ -77,10 +77,30 @@ If TS changes seem needed, the plan is missing information — fix the C# descri
 |-----------|-------|---------|
 | C# unit (VerifyJson) | 1 | Snapshot + schema validation |
 | C# unit (BDD) | 1 | Public DSL only |
+| Drift detection | 1→2 | Coverage matrix against schema `$defs` |
 | TS vitest | 3 | `boot()` in jsdom |
 | Playwright | 4 | 5 BDD rules + blind review |
 
 Arrange using public DSL: `Html.On`, `CreatePlan()`, `Trigger()`, builders.
+
+### Coverage Completeness Gate
+
+A test suite is not complete until every item in its scope is either tested or explicitly
+justified as untestable. "Tests pass" proves quality of what exists — not completeness.
+
+**Before any test suite is declared done:**
+1. List every item in scope (schema `$defs`, TS exports, public API members, etc.)
+2. Map each item to the test that covers it — by name, not by assumption
+3. Items with zero coverage must be marked with a justification and tracked as a gap
+4. Produce the coverage matrix BEFORE requesting review
+
+**Reviewers MUST verify the matrix** — not just the tests. If the matrix is missing,
+the review is incomplete. This gate exists because drift detection PR #76 shipped
+59 passing tests while 16/51 schema definitions (31%) had zero coverage, and two
+full review rounds missed it.
+
+Why: Reviewing what IS written is necessary. Checking what is NOT written catches
+the gaps that passing tests hide.
 
 ## Writing Docs (Layers 4→5)
 
@@ -97,6 +117,10 @@ For each layer the PR touches:
 2. Confirm each boundary crossing was driven by a failing test.
 3. Apply 9-point evidence criteria to every finding.
 4. Trace actual runtime paths — both SF and native components.
+5. **Verify coverage completeness** — list every item in scope, map each to a test.
+   Report uncovered items. "Tests pass" is not sign-off; "all items covered or justified" is.
+   Why: PR #76 shipped 59 passing tests with 31% of schema definitions uncovered.
+   Two review rounds checked test quality but never asked what was missing.
 
 ## Agent Dispatch Template
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ If touching an unexpected layer, the plan or task is wrong. Stop, save learnings
 - [ ] Each boundary crossing driven by a failing test?
 - [ ] Root cause fixed, not a patch? No code smells?
 - [ ] Output evidence: what proves this change is correct?
+- [ ] Coverage matrix: every item in scope mapped to a test or justified as untestable?
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Reviews checked test quality but never asked what was missing
- PR #76 shipped 59 passing drift detection tests with 16/51 schema definitions (31%) having zero coverage — two full review rounds missed it
- Adds a mandatory coverage completeness gate: every item in scope must be mapped to a test or justified as untestable before sign-off

## Changes
- **CLAUDE.md**: post-flight checklist — added coverage matrix checkpoint
- **process-task-types.md**: new "Coverage Completeness Gate" section under Writing Tests, step 5 added to Code Review with PR #76 evidence
- **agent-dispatch.md**: Review Agent template mandates coverage matrix for test suite reviews, added test completeness review example

## The Rule
> A test suite is not done until every item in scope is mapped to a test or explicitly justified as untestable. Reviewers must verify the matrix, not just the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)