### PR TITLE
fix: version property ordering in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.0.$(AlisReactivePatch)</VersionPrefix>
     <AlisReactivePatch Condition="'$(AlisReactivePatch)' == ''">0</AlisReactivePatch>
+    <VersionPrefix>0.0.$(AlisReactivePatch)</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
     <Authors>Alis Solutions</Authors>
     <Company>Alis Solutions</Company>


### PR DESCRIPTION
## Summary

- Fix property ordering bug: `AlisReactivePatch` default must be defined before `VersionPrefix` references it
- Without this fix, builds without `-p:AlisReactivePatch` produce invalid `0.0.-preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)