### PR TITLE
chore: test version auto-increment

### DIFF
--- a/Alis.Reactive/Alis.Reactive.csproj
+++ b/Alis.Reactive/Alis.Reactive.csproj
@@ -15,7 +15,7 @@
         <Content Include="Schemas\**\*.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
-    <!-- Ship JS/CSS as NuGet content files with configurable output path -->
+    <!-- Ship JS/CSS as NuGet content files with a configurable output path -->
     <ItemGroup>
         <None Include="assets\js\alis-reactive.js" Pack="true" PackagePath="buildTransitive\assets\js\" />
         <None Include="assets\css\design-system.css" Pack="true" PackagePath="buildTransitive\assets\css\" />


### PR DESCRIPTION
Trivial comment spelling fix to verify NuGet version auto-increments from `0.0.3-preview` to `0.0.4-preview` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)