### PR TITLE
docs: HTTP Pipeline Extensions + Plugin System pages

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -68,6 +68,8 @@ export default defineConfig({
 								{ label: 'Component API', slug: 'csharp-modules/reactivity/component-api' },
 								{ label: 'Conditions', slug: 'csharp-modules/reactivity/conditions' },
 								{ label: 'HTTP Pipeline', slug: 'csharp-modules/reactivity/http-pipeline' },
+								{ label: 'HTTP Pipeline Extensions', slug: 'csharp-modules/reactivity/http-pipeline-extensions' },
+								{ label: 'Plugin System', slug: 'csharp-modules/reactivity/plugins' },
 								{ label: 'Validation', slug: 'csharp-modules/reactivity/validation' },
 							],
 						},

--- a/docs-site/src/content/docs/architecture/descriptors-and-plan.mdx
+++ b/docs-site/src/content/docs/architecture/descriptors-and-plan.mdx
@@ -81,7 +81,7 @@ Every object in the plan is self-describing. The runtime never guesses — it re
 
 ## The plan — collector and serializer
 
-`IReactivePlan<TModel>` has two responsibilities:
+`ReactivePlan<TModel>` has two responsibilities:
 
 **Collecting entries** — `Html.On()` calls `plan.AddEntry()`. `Html.InputField()` calls `plan.AddToComponentsMap()`. By the time `Html.RenderPlan(plan)` is called (which invokes `plan.Render()`), the plan holds every entry and every component registration.
 

--- a/docs-site/src/content/docs/architecture/onboarding-component.md
+++ b/docs-site/src/content/docs/architecture/onboarding-component.md
@@ -397,7 +397,7 @@ private static readonly FusionXxx Component = new();
 
 public static XxxBuilder Reactive<TModel, TArgs>(
     this XxxBuilder builder,
-    IReactivePlan<TModel> plan,
+    ReactivePlan<TModel> plan,
     Func<FusionXxxEvents, TypedEventDescriptor<TArgs>> eventSelector,
     Action<TArgs, PipelineBuilder<TModel>> pipeline)
     where TModel : class
@@ -894,7 +894,7 @@ public static class FusionXxxHtmlExtensions
 {
     public static FusionXxxBuilder<TModel> FusionXxx<TModel>(
         this IHtmlHelper<TModel> html,
-        IReactivePlan<TModel> plan,
+        ReactivePlan<TModel> plan,
         string elementId,
         Action<XxxBuilder> build)
         where TModel : class
@@ -912,7 +912,7 @@ public static class FusionXxxHtmlExtensions
 **Key differences from input component factory:**
 - Takes `IHtmlHelper<TModel>` directly (not `InputBoundField`)
 - Takes explicit `string elementId` (not model-expression-derived)
-- Takes `IReactivePlan<TModel>` for passing to `.Reactive()`
+- Takes `ReactivePlan<TModel>` for passing to `.Reactive()`
 - NO `plan.AddToComponentsMap()` call
 - Returns a builder that wraps the SF content + allows `.Reactive()` chaining
 

--- a/docs-site/src/content/docs/architecture/the-contract.mdx
+++ b/docs-site/src/content/docs/architecture/the-contract.mdx
@@ -237,10 +237,12 @@ Two primitives. The [Runtime](../runtime/) page explains how they execute via br
 
 ## Sources — where values come from
 
-| Kind | Plan shape |
-|------|-----------|
-| `event` | `{ "path": "evt.address.city" }` |
-| `component` | `{ "componentId": "Country", "vendor": "fusion", "readExpr": "value" }` |
+| Kind | Plan shape | What it reads |
+|------|-----------|---------------|
+| `event` | `{ "path": "evt.address.city" }` | Event payload, HTTP response |
+| `component` | `{ "componentId": "Country", "vendor": "fusion", "readExpr": "value" }` | DOM element or vendor component |
+| `url` | `{ "param": "tab" }` | Browser URL query string |
+| `plugin` | `{ "plugin": "array", "member": "count", "args": [...] }` | User-registered JS plugin object |
 
 How these resolve at runtime is covered in [Runtime — Value resolution](../runtime/#value-resolution--resolverts--walkts).
 
@@ -252,6 +254,10 @@ How these resolve at runtime is covered in [Runtime — Value resolution](../run
 | `static` | `{ "kind": "static", "param": "action", "value": "create" }` | Fixed value |
 | `component` | `{ "kind": "component", "componentId": "...", "vendor": "...", "readExpr": "..." }` | One component's live value |
 | `event` | `{ "kind": "event", "param": "q", "path": "evt.text" }` | Value from event payload |
+| `url` | `{ "kind": "url", "param": "tab" }` | URL query parameter |
+| `plugin` | `{ "kind": "plugin", "plugin": "...", "member": "...", "args": [...] }` | Plugin method result |
+| `header` | `{ "name": "X-Api-Key", "value": "..." }` | Custom HTTP request header |
+| `route-param` | `{ "name": "id", "value": ... }` | URL template substitution |
 
 `all` is a placeholder — expanded at C# render time to concrete `component` items from the plan's ComponentsMap.
 
@@ -279,8 +285,8 @@ Every plan is checked against a JSON Schema in unit tests. If a builder produces
 | Reactions | `sequential`, `conditional`, `http`, `parallel-http` |
 | Commands | `mutate-element`, `dispatch`, `mutate-event`, `validation-errors`, `into` |
 | Mutations | `set-prop`, `call` |
-| Sources | `event`, `component` |
-| Gather | `all`, `static`, `component`, `event` |
+| Sources | `event`, `component`, `url`, `plugin` |
+| Gather | `all`, `static`, `component`, `event`, `url`, `plugin`, `header`, `route-param` |
 
 If you need a new capability — say a new mutation kind — it goes into the schema first. The schema is the gatekeeper. The plan is the contract. Both sides (C# and JS) agree on its shape, and neither reaches beyond it.
 

--- a/docs-site/src/content/docs/csharp-modules/mental-model.mdx
+++ b/docs-site/src/content/docs/csharp-modules/mental-model.mdx
@@ -307,6 +307,14 @@ pipeline.When(comp.Value()).Gt(0m)                   test component value agains
     .Then(then => { ... })
     .Else(otherwise => { ... });
 
+§ From URL query parameter:
+pipeline.When(pipeline.FromUrl<int>("page")).Gt(1)
+    .Then(then => { ... });
+
+§ From plugin read:
+pipeline.When(pipeline.Plugin<int>("arr", "count").Arg(src)).Gt(0)
+    .Then(then => { ... });
+
 § Operators — 21 total, typed to the source:
 ├── .Eq(val) / .NotEq(val)                           equality
 ├── .Truthy() / .Falsy()                             presence (no operand)
@@ -349,7 +357,10 @@ pipeline.Delete(url)
 │   ├── g.IncludeAll()                               all registered components
 │   ├── g.Include<T, TModel>(m => m.Prop)             specific component
 │   ├── g.Static("key", value) / g.FromEvent(args, a => a.Prop, "param")
-│   └── ...                                          (more: Include by string ref)
+│   ├── g.Header("name", value)                      HTTP header
+│   ├── g.RouteParam("name", value)                  URL template param
+│   ├── g.FromUrl("param") / g.FromUrl<T>("param")   URL query param
+│   └── g.Plugin(pluginSource, "param")              plugin value
 │
 ├── .AsJson() (default) / .AsFormData()               content type
 ├── .Validate<TValidator>("formId")                  client-side validation gate
@@ -370,6 +381,20 @@ pipeline.Parallel(                                   § concurrent requests
     b => b.Post(url).Gather(...).Response(...)
 )
 └── .OnAllSettled(pipeline => { ... })               ↻ after all complete
+```
+
+#### Plugin
+
+Read values from registered JS plugins, or call void methods. Plugins are registered once via `plan.RegisterPlugin()`; their methods become sources anywhere in the pipeline.
+
+```
+pipeline.Plugin<T>("pluginName", "method")           § read → TypedPluginSource<T>
+├── .Arg(json, x => x.Items) / .Arg("literal")       response body, event, source, or literal
+└── (implicit conversion)                             use in SetText, When, Gather, Header
+
+pipeline.Plugin("pluginName", "method")              § void
+├── .Arg(...)                                         same arg overloads
+└── .Fire()                                           terminal — emits call
 ```
 
 ### Events and Typed Args
@@ -404,4 +429,6 @@ The following pages cover each module in detail:
 | 🧩 | [**Component API**](../reactivity/component-api/) | Targeting components — write, call, read values |
 | 🔀 | [**Conditions**](../reactivity/conditions/) | Branching — When/Then/ElseIf/Else, operators, composition |
 | 🌐 | [**HTTP Pipeline**](../reactivity/http-pipeline/) | Server communication — gather, validate, post, handle response |
+| 🔗 | [**HTTP Pipeline Extensions**](../reactivity/http-pipeline-extensions/) | Headers, URL templates, URL query params, method arguments |
+| 🔌 | [**Plugin System**](../reactivity/plugins/) | JS plugin registration, method reads, void calls, nesting |
 | 🏷️ | **Tag Helpers** | Layout primitives — headings, cards, stacks, grids |

--- a/docs-site/src/content/docs/csharp-modules/reactivity/conditions.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/conditions.md
@@ -70,6 +70,37 @@ pipeline.When(careLevel.Value()).Eq("memory-care")
 
 `.Value()` gives you typed access to the component's live value -- the runtime reads it when evaluating the condition.
 
+### From a URL query parameter
+
+Read the browser's current URL to branch on a query parameter:
+
+```csharp
+pipeline.When(pipeline.FromUrl("tab")).Eq("medications")
+    .Then(then => then.Element("med-panel").Show())
+    .Else(else_ => else_.Element("med-panel").Hide());
+```
+
+`pipeline.FromUrl<int>("page")` provides typed access for numeric comparisons:
+
+```csharp
+pipeline.When(pipeline.FromUrl<int>("page")).Gt(1)
+    .Then(then => then.Element("prev-btn").Show())
+    .Else(else_ => else_.Element("prev-btn").Hide());
+```
+
+### From a plugin read
+
+Read a plugin method's return value to branch on the result:
+
+```csharp
+var hasCritical = pipeline.Plugin<bool>("array", "some")
+    .Arg(json, x => x.Items).Arg("status").Arg("critical");
+pipeline.When(hasCritical).Truthy()
+    .Then(then => then.Element("alert").Show());
+```
+
+`pipeline.Plugin<T>()` returns a typed source that works with all operators.
+
 ## What operators are available?
 
 ### Comparison operators

--- a/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline-extensions.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline-extensions.md
@@ -1,0 +1,197 @@
+---
+title: HTTP Pipeline Extensions
+description: Custom headers, URL templates with route parameters, URL query parameters, and method arguments for advanced HTTP requests.
+sidebar:
+  order: 6
+---
+
+These features extend the [HTTP Pipeline](../http-pipeline/). If you haven't read that page yet, start there — it covers GET/POST/PUT/DELETE, gather, response handlers, and parallel requests.
+
+## How do I add custom headers to a request?
+
+Pass a literal string value:
+
+```csharp
+.Gather(g => g.Header("X-Api-Key", "my-key"))
+```
+
+The header is added to the HTTP request alongside any gather items.
+
+### What if the header value comes from a component?
+
+Pass any typed source — a component read, a URL param, or a plugin result:
+
+```csharp
+var tenant = pipeline.Component<FusionDropDownList>(m => m.TenantId);
+.Gather(g => g.Header("X-Tenant", tenant.Value()))
+```
+
+### What if it comes from the event that triggered this pipeline?
+
+Use the event args expression:
+
+```csharp
+.Gather(g => g.Header("X-Correlation", args, x => x.CorrelationId))
+```
+
+### What types can I use for header values?
+
+Headers must be scalar — string, int, or bool. Arrays and objects are rejected at build time with a clear error message.
+
+## How do I use route parameters in a URL?
+
+Put placeholders in the URL with `{name}`, then supply values via `RouteParam`:
+
+```csharp
+pipeline.Put("/api/residents/{id}", g => g.RouteParam("id", 42))
+    .Response(r => r.OnSuccess(s => s.Element("status").SetText("Updated")));
+```
+
+### What if the route value comes from a form field?
+
+Pass a typed source:
+
+```csharp
+var residentId = pipeline.Component<FusionDropDownList>(m => m.ResidentId);
+g.RouteParam("id", residentId.Value());
+```
+
+### What if it comes from event args?
+
+```csharp
+g.RouteParam("id", args, x => x.ResidentId)
+```
+
+### Can I have multiple route parameters?
+
+Yes — each placeholder gets its own `RouteParam`:
+
+```csharp
+pipeline.Get("/api/facilities/{facilityId}/residents/{residentId}")
+    .Gather(g =>
+    {
+        g.RouteParam("facilityId", 7);
+        g.RouteParam("residentId", 99);
+    })
+    .Response(r => r.OnSuccess(s => s.Element("result").SetText("Loaded")));
+```
+
+### What happens if I forget a route parameter?
+
+Every `{placeholder}` must have a matching `RouteParam`, and every `RouteParam` must match a `{placeholder}`. Both directions are validated at build time — mismatches throw immediately.
+
+## How do I read a URL query parameter?
+
+The simplest case — forward the browser's `?tab=medications` into a gather:
+
+```csharp
+g.FromUrl("tab")
+```
+
+This reads the `tab` query parameter and sends it as the request key `"tab"`.
+
+### What if I need a typed value?
+
+```csharp
+g.FromUrl<int>("page")
+```
+
+Type conversion is automatic — the runtime coerces the URL string to the target type.
+
+### What if I want a different request parameter name?
+
+```csharp
+g.FromUrl("q", "searchTerm")
+```
+
+Reads `?q=smith` from the URL, sends it as `"searchTerm"` in the request.
+
+### Can I branch on a URL parameter?
+
+Yes — use `pipeline.FromUrl()` in a condition:
+
+```csharp
+pipeline.When(pipeline.FromUrl("tab")).Eq("medications")
+    .Then(then => then.Element("med-panel").Show())
+    .Else(else_ => else_.Element("med-panel").Hide());
+```
+
+For typed comparisons:
+
+```csharp
+pipeline.When(pipeline.FromUrl<int>("page")).Gt(1)
+    .Then(then => then.Element("prev-btn").Show())
+    .Else(else_ => else_.Element("prev-btn").Hide());
+```
+
+### Can I display a URL parameter?
+
+```csharp
+pipeline.Element("current-tab").SetText(pipeline.FromUrl("tab"));
+pipeline.Element("current-facility").SetText(pipeline.FromUrl("facilityId"));
+```
+
+### Can I combine URL params with headers and route params?
+
+Yes — all gather strategies compose freely:
+
+```csharp
+pipeline.Put("/api/residents/{id}")
+    .Gather(g =>
+    {
+        g.RouteParam("id", 42);
+        g.Header("X-Tab", pipeline.FromUrl("tab"));
+        g.FromUrl("facilityId", "facility");
+    })
+    .Response(r => r.OnSuccess(s => s.Element("status").SetText("Saved")));
+```
+
+## How do I pass arguments to a method read?
+
+The most common case — pass a response body property to a plugin method:
+
+```csharp
+var count = pipeline.Plugin<int>("array", "count").Arg(json, x => x.Items);
+s.Element("total").SetText(count);
+```
+
+The result converts to a typed source automatically — no `.Build()` needed.
+
+### What if the argument comes from event args?
+
+```csharp
+pipeline.Plugin<int>("array", "count").Arg(args, x => x.ResidentId)
+```
+
+### What about a component value or a literal?
+
+```csharp
+.Arg(tenant.Value())    // from a component
+.Arg("active")          // string literal
+.Arg(42)                // int literal
+```
+
+Arguments chain — call `.Arg()` multiple times to pass multiple values to the JS method.
+
+### Where can I use the result?
+
+Anywhere a typed source is accepted:
+
+```csharp
+// In SetText
+s.Element("count").SetText(count);
+
+// In a condition
+pipeline.When(count).Gt(0)
+    .Then(then => then.Element("results").Show());
+
+// In a header
+g.Header("X-Count", count);
+
+// In a gather
+g.Plugin(count, "totalCount");
+```
+
+**Previous:** [HTTP Pipeline](../http-pipeline/) — GET/POST/PUT/DELETE, gather, loading states, typed responses, and chained/parallel requests.
+
+**Next:** [Plugin System](../plugins/) — register JS plugins, read method results, call void methods, and compose plugin chains.

--- a/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline-extensions.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline-extensions.md
@@ -136,8 +136,7 @@ pipeline.Element("current-facility").SetText(pipeline.FromUrl("facilityId"));
 Yes — all gather strategies compose freely:
 
 ```csharp
-pipeline.Put("/api/residents/{id}")
-    .Gather(g =>
+pipeline.Put("/api/residents/{id}", g =>
     {
         g.RouteParam("id", 42);
         g.Header("X-Tab", pipeline.FromUrl("tab"));

--- a/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline-extensions.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline-extensions.md
@@ -155,7 +155,7 @@ var count = pipeline.Plugin<int>("array", "count").Arg(json, x => x.Items);
 s.Element("total").SetText(count);
 ```
 
-The result converts to a typed source automatically — no `.Build()` needed.
+The result converts automatically — no `.Build()` needed.
 
 ### What if the argument comes from event args?
 

--- a/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/http-pipeline.md
@@ -15,7 +15,11 @@ pipeline.Get(url) / .Post(url) / .Put(url) / .Delete(url)  § start a request
 │   ├── g.Static("key", value)                              § fixed value
 │   ├── g.Include<TComp, TModel>(m => m.Prop)               § component value
 │   ├── g.IncludeAll()                                      § all registered components
-│   └── g.FromEvent(args, x => x.Prop, "paramName")         § event payload value
+│   ├── g.FromEvent(args, x => x.Prop, "paramName")         § event payload value
+│   ├── g.Header("name", value | source | args)             § custom HTTP header
+│   ├── g.RouteParam("name", value | source | args)         § URL template param
+│   ├── g.FromUrl("param") / g.FromUrl<T>("param")          § browser URL query param
+│   └── g.Plugin(pluginSource, "param")                     § plugin method result
 ├── .AsFormData()                                           § multipart content type
 ├── .Validate<TValidator>("formId")                         § client-side validation
 ├── .WhileLoading(l => { })                                 § commands during flight
@@ -487,4 +491,4 @@ This single pipeline handles confirmation, validation, loading state, success no
 
 **Previous:** [Conditions](../conditions/) -- runtime branching with When/Then/ElseIf/Else and guard composition.
 
-**Next:** [Validation](../validation/) -- client-side validation with FluentValidation extraction, 16 rule types, and fail-closed orchestration.
+**Next:** [HTTP Pipeline Extensions](../http-pipeline-extensions/) -- custom headers, route parameters, URL query parameters, and method arguments.

--- a/docs-site/src/content/docs/csharp-modules/reactivity/plugins.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/plugins.md
@@ -1,0 +1,203 @@
+---
+title: Plugin System
+description: Register JavaScript plugins, read their method results in the DSL, call void methods, chain plugin output as input, and use plugins in conditions and gather.
+sidebar:
+  order: 7
+---
+
+A plugin is a native JS object you expose to the C# DSL. You write the JavaScript implementation once, register it in C#, and the framework calls it at runtime. No `<script>` blocks in views.
+
+```csharp
+var count = pipeline.Plugin<int>("array", "count").Arg(json, x => x.Items);
+s.Element("total").SetText(count);
+```
+
+That's the end result — two lines to call a JS function from C#. The rest of this page shows how to get there.
+
+## How do I register a plugin?
+
+Two sides: C# declares the type metadata, JS provides the implementation.
+
+**C# — declare what the plugin offers:**
+
+```csharp
+plan.RegisterPlugin("array", p =>
+{
+    p.Method<int>("count");
+    p.Void("track");
+});
+```
+
+**JS — push the instance before the framework loads:**
+
+```javascript
+window.__alisPlugins ??= [];
+window.__alisPlugins.push({
+    name: "array",
+    instance: { count: (arr) => arr?.length ?? 0 }
+});
+```
+
+The runtime drains `window.__alisPlugins` at boot. Registration must happen before any `pipeline.Plugin()` reference in the plan.
+
+### What if my plugin has multiple methods?
+
+Add them in the same registration call:
+
+```csharp
+plan.RegisterPlugin("array", p =>
+{
+    p.Method<int>("count");
+    p.Method<object>("filter");
+    p.Method<int>("sum");
+    p.Method<bool>("some");
+    p.Void("track");
+});
+```
+
+`Method<T>()` declares a method that returns a typed value. `Void()` declares a method with no return value.
+
+## How do I read a plugin method's return value?
+
+Call `pipeline.Plugin<T>()` with the plugin name and method name:
+
+```csharp
+TypedPluginSource<int> countSrc = pipeline.Plugin<int>("array", "count")
+    .Arg(json, x => x.Items);
+s.Element("total").SetText(countSrc);
+```
+
+The result converts to a typed source automatically — no `.Build()` needed.
+
+### Where can I use the result?
+
+Anywhere a typed source is accepted — `SetText`, `When`, `Header`, `Gather`:
+
+```csharp
+s.Element("total").SetText(countSrc);
+```
+
+### How do I pass multiple arguments?
+
+Chain `.Arg()` calls:
+
+```csharp
+TypedPluginSource<string> pluckSrc = pipeline.Plugin<string>("array", "pluck")
+    .Arg(json, x => x.Items).Arg(0).Arg("name");
+s.Element("first-name").SetText(pluckSrc);
+```
+
+Each `.Arg()` accepts a response body expression, event args, a typed source, or a literal (string, int, bool, long).
+
+## How do I call a plugin method that returns nothing?
+
+Use the non-generic `pipeline.Plugin()` and end with `.Fire()`:
+
+```csharp
+s.Plugin("analytics", "track").Arg("array-sent").Fire();
+```
+
+`.Fire()` is the terminal method — it emits the call into the pipeline. No return value, no further chaining after `.Fire()`.
+
+## Can I pass one plugin's output to another?
+
+Yes. Each plugin read returns a typed source that `.Arg()` accepts:
+
+```csharp
+TypedPluginSource<object> filtered = pipeline.Plugin<object>("array", "filter")
+    .Arg(json, x => x.Items).Arg("status").Arg("active");
+TypedPluginSource<int> activeCount = pipeline.Plugin<int>("array", "count")
+    .Arg(filtered);
+s.Element("active-count").SetText(activeCount);
+```
+
+This calls `filter(items, "status", "active")`, then passes the result to `count()`.
+
+## Can I use a plugin result in a condition?
+
+Yes — plugin reads are typed sources, so they work with `When()`:
+
+```csharp
+TypedPluginSource<bool> someSrc = pipeline.Plugin<bool>("array", "some")
+    .Arg(json, x => x.Items).Arg("status").Arg("critical");
+s.When(someSrc).Truthy()
+    .Then(then => then.Element("alert").Show())
+    .Else(els => els.Element("no-alert").Show());
+```
+
+## How do I send a plugin result in a request?
+
+Include it in the gather:
+
+```csharp
+.Gather(g => g.Plugin(countSrc, "count"))
+```
+
+### Can I use a plugin value as a header?
+
+```csharp
+.Gather(g => g.Header("X-Array-Count", countSrc))
+```
+
+### Can I combine both?
+
+```csharp
+pipeline.Get("/api/echo")
+    .Gather(g => g
+        .Header("X-Array-Count", countSrc)
+        .Plugin(countSrc, "count"))
+    .Response(r => r.OnSuccess<EchoResponse>((json, s) =>
+    {
+        s.Element("echo-count").SetText(json, x => x.ReceivedCount);
+        s.Element("echo-header").SetText(json, x => x.ReceivedHeader);
+        s.Plugin("analytics", "track").Arg("array-sent").Fire();
+    }));
+```
+
+## What does a full plugin workflow look like?
+
+Here is a complete pipeline from the ArrayManager sandbox — register plugins, fetch data, compute with plugin methods, branch on results, and send computed values to the server:
+
+```csharp
+@{
+    var plan = Html.ReactivePlan<ArrayManagerModel>();
+
+    plan.RegisterPlugin("array", p =>
+    {
+        p.Method<int>("count");
+        p.Method<object>("filter");
+        p.Method<bool>("some");
+    });
+    plan.RegisterPlugin("analytics", p => p.Void("track"));
+
+    Html.On(plan, t => t.DomReady(pipeline =>
+        pipeline.Get("/api/residents")
+            .Response(r => r.OnSuccess<ResidentsResponse>((json, s) =>
+            {
+                // Count all items
+                var count = pipeline.Plugin<int>("array", "count")
+                    .Arg(json, x => x.Items);
+                s.Element("total").SetText(count);
+
+                // Filter → count active (nested composition)
+                var active = pipeline.Plugin<object>("array", "filter")
+                    .Arg(json, x => x.Items).Arg("status").Arg("active");
+                var activeCount = pipeline.Plugin<int>("array", "count")
+                    .Arg(active);
+                s.Element("active-count").SetText(activeCount);
+
+                // Branch on critical status
+                var hasCritical = pipeline.Plugin<bool>("array", "some")
+                    .Arg(json, x => x.Items).Arg("status").Arg("critical");
+                s.When(hasCritical).Truthy()
+                    .Then(then => then.Element("alert").Show())
+                    .Else(els => els.Element("alert").Hide());
+            }))));
+}
+```
+
+This single pipeline handles data fetch, array computation, nested plugin composition, and conditional UI — all described in the plan, executed by the runtime.
+
+**Previous:** [HTTP Pipeline Extensions](../http-pipeline-extensions/) — custom headers, route parameters, URL query parameters, and method arguments.
+
+**Next:** [Validation](../validation/) — client-side validation with FluentValidation extraction.

--- a/docs-site/src/content/docs/csharp-modules/reactivity/plugins.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/plugins.md
@@ -62,7 +62,7 @@ plan.RegisterPlugin("array", p =>
 Call `pipeline.Plugin<T>()` with the plugin name and method name:
 
 ```csharp
-TypedPluginSource<int> countSrc = pipeline.Plugin<int>("array", "count")
+var countSrc = pipeline.Plugin<int>("array", "count")
     .Arg(json, x => x.Items);
 s.Element("total").SetText(countSrc);
 ```
@@ -82,7 +82,7 @@ s.Element("total").SetText(countSrc);
 Chain `.Arg()` calls:
 
 ```csharp
-TypedPluginSource<string> pluckSrc = pipeline.Plugin<string>("array", "pluck")
+var pluckSrc = pipeline.Plugin<string>("array", "pluck")
     .Arg(json, x => x.Items).Arg(0).Arg("name");
 s.Element("first-name").SetText(pluckSrc);
 ```
@@ -97,16 +97,16 @@ Use the non-generic `pipeline.Plugin()` and end with `.Fire()`:
 s.Plugin("analytics", "track").Arg("array-sent").Fire();
 ```
 
-`.Fire()` is the terminal method — it emits the call into the pipeline. No return value, no further chaining after `.Fire()`.
+`.Fire()` executes the call. Nothing chains after it — it's the last step.
 
 ## Can I pass one plugin's output to another?
 
 Yes. Each plugin read returns a typed source that `.Arg()` accepts:
 
 ```csharp
-TypedPluginSource<object> filtered = pipeline.Plugin<object>("array", "filter")
+var filtered = pipeline.Plugin<object>("array", "filter")
     .Arg(json, x => x.Items).Arg("status").Arg("active");
-TypedPluginSource<int> activeCount = pipeline.Plugin<int>("array", "count")
+var activeCount = pipeline.Plugin<int>("array", "count")
     .Arg(filtered);
 s.Element("active-count").SetText(activeCount);
 ```
@@ -118,7 +118,7 @@ This calls `filter(items, "status", "active")`, then passes the result to `count
 Yes — plugin reads are typed sources, so they work with `When()`:
 
 ```csharp
-TypedPluginSource<bool> someSrc = pipeline.Plugin<bool>("array", "some")
+var someSrc = pipeline.Plugin<bool>("array", "some")
     .Arg(json, x => x.Items).Arg("status").Arg("critical");
 s.When(someSrc).Truthy()
     .Then(then => then.Element("alert").Show())

--- a/docs-site/src/content/docs/csharp-modules/reactivity/triggers-and-reactions.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/triggers-and-reactions.md
@@ -13,7 +13,7 @@ A trigger defines *when* a pipeline executes. Every reactive behavior starts wit
 
 ```csharp
 @{
-    IReactivePlan<MyModel> plan = new ReactivePlan<MyModel>();
+    var plan = Html.ReactivePlan<MyModel>();
 
     // These three calls can appear in any order — they all just add entries to `plan`
     Html.On(plan, t => t.DomReady(p => p.Dispatch("init")));

--- a/docs-site/src/content/docs/csharp-modules/reactivity/validation.md
+++ b/docs-site/src/content/docs/csharp-modules/reactivity/validation.md
@@ -2,7 +2,7 @@
 title: Validation
 description: Client-side validation with FluentValidation extraction — 16 rule types, 21 conditional operators, condition composition, cross-property comparisons, and fail-closed orchestration.
 sidebar:
-  order: 6
+  order: 8
 ---
 
 Validation lives inside the HTTP pipeline. You write a FluentValidation validator in C#, attach it to a request with `.Validate<T>()`, and the framework extracts rules to the JSON plan. The runtime evaluates those rules in the browser before the request fires.
@@ -416,4 +416,4 @@ For Syncfusion components, only blur/change is wired (Syncfusion does not expose
 
 Live clearing is wired automatically for all enriched fields — no additional configuration needed.
 
-**Previous:** [HTTP Pipeline](../http-pipeline/) — GET/POST/PUT/DELETE, gather, loading states, typed responses, and chained/parallel requests.
+**Previous:** [Plugin System](../plugins/) — register JS plugins, read method results, call void methods, and compose plugin chains.

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -105,6 +105,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		[Mutations](./csharp-modules/reactivity/element-mutations/) — Element, Component, source binding.
 		[Conditions](./csharp-modules/reactivity/conditions/) — When/Then/Else with 21 operators.
 		[HTTP Pipeline](./csharp-modules/reactivity/http-pipeline/) — GET/POST, Gather, Response, Parallel.
+		[HTTP Pipeline Extensions](./csharp-modules/reactivity/http-pipeline-extensions/) — Headers, URL Templates, URL Query Params.
+		[Plugin System](./csharp-modules/reactivity/plugins/) — JS plugin reads, void calls, nesting.
 	</Card>
 	<Card title="Components" icon="puzzle">
 		[Overview](./components/overview/) — vendor-agnostic component model.

--- a/docs-site/src/content/docs/testing/writing-tests.md
+++ b/docs-site/src/content/docs/testing/writing-tests.md
@@ -35,7 +35,7 @@ public class WhenDispatchingAnEvent : PlanTestBase
     public Task Payload_flows_when_provided() =>
         VerifyJson(Build(p => p.Dispatch("saved", new TestModel { Id = "abc" })).Render());
 
-    private static IReactivePlan<TestModel> Build(
+    private static ReactivePlan<TestModel> Build(
         Action<Builders.PipelineBuilder<TestModel>> configure)
     {
         var plan = CreatePlan();


### PR DESCRIPTION
## Summary

- **2 new DSL pages**: HTTP Pipeline Extensions (headers, URL templates, FromUrl, .Arg()) and Plugin System (registration, reads, void calls, nesting)
- **Fixed 6 stale `IReactivePlan` references** across 4 doc pages → `ReactivePlan<TModel>`
- **Expanded architecture tables** in the-contract.mdx with `url`, `plugin`, `header`, `route-param` kinds
- **Updated grammar trees** in 3 files (http-pipeline.md, conditions.md, mental-model.mdx)
- **Sidebar + navigation**: 2 new sidebar entries, full bidirectional Previous/Next chain, landing page links

## Review process

- 8 plan review rounds (Codex xhigh + code reviewer + independent 3rd)
- Content quality review on both new pages (tech writer + Codex accuracy)
- Post-implementation Gate 2: Codex xhigh SIGN-OFF + code reviewer SIGN-OFF
- Gate 3: `npm run build` = 40 pages, zero errors; `grep IReactivePlan` = 0

## Test plan

- [ ] `cd docs-site && npm run build` passes with zero errors
- [ ] `grep -r "IReactivePlan" docs-site/src/content/` returns zero
- [ ] Navigation chain: Conditions → HTTP Pipeline → Extensions → Plugin System → Validation (bidirectional)
- [ ] New pages render correctly in browser
- [ ] Sidebar shows HTTP Pipeline Extensions and Plugin System between HTTP Pipeline and Validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)