### PR TITLE
docs: XML documentation for PlanModel contract types

### DIFF
--- a/Alis.Reactive/PlanModel/Condition.cs
+++ b/Alis.Reactive/PlanModel/Condition.cs
@@ -5,6 +5,9 @@ using Alis.Reactive.Serialization;
 
 namespace Alis.Reactive.PlanModel
 {
+    /// <summary>
+    /// Base class for conditional predicates evaluated when the plan executes. Not constructed in application code.
+    /// </summary>
     [JsonConverter(typeof(WriteOnlyPolymorphicConverter<Condition>))]
     public abstract class Condition
     {
@@ -26,13 +29,20 @@ namespace Alis.Reactive.PlanModel
             new ConfirmCondition(message);
     }
 
+    /// <summary>Compares two values using a relational operator.</summary>
     public sealed class CompareCondition : Condition
     {
+        /// <summary>Gets the kind. Always <c>"compare"</c>.</summary>
         public string Kind => "compare";
+        /// <summary>Gets the left-hand operand.</summary>
         public ValueProducer Left { get; }
+        /// <summary>Gets the comparison operator (eq, neq, gt, gte, lt, lte, truthy, empty, contains, startsWith, endsWith).</summary>
         public string Op { get; }
+        /// <summary>Gets the right-hand operand, or <see langword="null"/> for unary operators.</summary>
         public ValueProducer Right { get; }
+        /// <summary>Gets the expected type shape for comparison, or <see langword="null"/> when inferred.</summary>
         public Shape Shape { get; }
+        /// <summary>Gets the element type shape used by collection operators such as <c>contains</c>, or <see langword="null"/> for non-collection comparisons.</summary>
         public Shape ItemShape { get; }
 
         internal CompareCondition(ValueProducer left, string op, ValueProducer right, Shape shape, Shape itemShape)
@@ -45,9 +55,12 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Logical AND: all child conditions must be true.</summary>
     public sealed class AllCondition : Condition
     {
+        /// <summary>Gets the kind. Always <c>"all"</c>.</summary>
         public string Kind => "all";
+        /// <summary>Gets the child conditions that must all be true.</summary>
         public IReadOnlyList<Condition> Terms { get; }
 
         internal AllCondition(List<Condition> terms)
@@ -56,9 +69,12 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Logical OR: at least one child condition must be true.</summary>
     public sealed class AnyCondition : Condition
     {
+        /// <summary>Gets the kind. Always <c>"any"</c>.</summary>
         public string Kind => "any";
+        /// <summary>Gets the child conditions where at least one must be true.</summary>
         public IReadOnlyList<Condition> Terms { get; }
 
         internal AnyCondition(List<Condition> terms)
@@ -67,9 +83,12 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Logical NOT: inverts a single child condition.</summary>
     public sealed class NotCondition : Condition
     {
+        /// <summary>Gets the kind. Always <c>"not"</c>.</summary>
         public string Kind => "not";
+        /// <summary>Gets the condition to invert.</summary>
         public Condition Term { get; }
 
         internal NotCondition(Condition term)
@@ -78,9 +97,12 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Prompts the user for confirmation before the reaction proceeds.</summary>
     public sealed class ConfirmCondition : Condition
     {
+        /// <summary>Gets the kind. Always <c>"confirm"</c>.</summary>
         public string Kind => "confirm";
+        /// <summary>Gets the confirmation message shown to the user.</summary>
         public string Message { get; }
 
         internal ConfirmCondition(string message)

--- a/Alis.Reactive/PlanModel/Path.cs
+++ b/Alis.Reactive/PlanModel/Path.cs
@@ -24,13 +24,17 @@ namespace Alis.Reactive.PlanModel
             => throw new NotSupportedException("Plan types are write-only.");
     }
 
+    /// <summary>One step in a property navigation path: a property name or array index.</summary>
     public sealed class PathSegment
     {
+        /// <summary>Gets the segment kind (property or index).</summary>
         public string Kind { get; }
 
+        /// <summary>Gets the property name for property segments, or <see langword="null"/> for index segments.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Name { get; }
 
+        /// <summary>Gets the array index for index segments, or <see langword="null"/> for property segments.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? Index { get; }
 
@@ -48,11 +52,13 @@ namespace Alis.Reactive.PlanModel
             new PathSegment("index", null, index);
     }
 
+    /// <summary>An ordered sequence of segments for navigating nested properties on a value.</summary>
     [JsonConverter(typeof(PathJsonConverter))]
     public sealed class Path
     {
         internal static readonly Path None = new Path(Array.Empty<PathSegment>());
 
+        /// <summary>Gets the ordered path segments.</summary>
         [JsonIgnore]
         public IReadOnlyList<PathSegment> Segments { get; }
 

--- a/Alis.Reactive/PlanModel/Reaction.cs
+++ b/Alis.Reactive/PlanModel/Reaction.cs
@@ -5,6 +5,9 @@ using Alis.Reactive.Serialization;
 
 namespace Alis.Reactive.PlanModel
 {
+    /// <summary>
+    /// Base class for all executable actions in a reactive plan. Not constructed in application code.
+    /// </summary>
     [JsonConverter(typeof(WriteOnlyPolymorphicConverter<Reaction>))]
     public abstract class Reaction
     {
@@ -49,18 +52,25 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Executes a list of reactions in declaration order.</summary>
     public sealed class SequenceReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"sequence"</c>.</summary>
         public string Kind => "sequence";
+        /// <summary>Gets the ordered reactions to execute.</summary>
         public IReadOnlyList<Reaction> Steps { get; }
 
         internal SequenceReaction(List<Reaction> steps) { Steps = steps ?? throw new ArgumentNullException(nameof(steps)); }
     }
 
+    /// <summary>Executes a list of reactions concurrently.</summary>
     public sealed class ParallelReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"parallel"</c>.</summary>
         public string Kind => "parallel";
+        /// <summary>Gets the reactions to execute concurrently.</summary>
         public IReadOnlyList<Reaction> Steps { get; }
+        /// <summary>Gets the reaction to execute after all steps settle, or <see langword="null"/> if none.</summary>
         public Reaction? OnSettled { get; }
 
         internal ParallelReaction(List<Reaction> steps, Reaction? onSettled)
@@ -70,17 +80,23 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Evaluates conditions and executes the first matching case.</summary>
     public sealed class BranchReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"branch"</c>.</summary>
         public string Kind => "branch";
+        /// <summary>Gets the ordered cases to evaluate.</summary>
         public IReadOnlyList<BranchCase> Cases { get; }
 
         internal BranchReaction(List<BranchCase> cases) { Cases = cases ?? throw new ArgumentNullException(nameof(cases)); }
     }
 
+    /// <summary>Pairs an optional guard condition with a reaction to execute.</summary>
     public sealed class BranchCase
     {
+        /// <summary>Gets the guard condition, or <see langword="null"/> for the default (else) case.</summary>
         public Condition? When { get; }
+        /// <summary>Gets the reaction to execute when the condition is met.</summary>
         public Reaction Reaction { get; }
 
         internal BranchCase(Condition? when, Reaction reaction)
@@ -93,11 +109,16 @@ namespace Alis.Reactive.PlanModel
         internal static BranchCase Default(Reaction reaction) => new BranchCase(null, reaction);
     }
 
+    /// <summary>Sets a property value on a component or DOM element.</summary>
     public sealed class SetReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"set"</c>.</summary>
         public string Kind => "set";
+        /// <summary>Gets the target source to set the property on.</summary>
         public Source On { get; }
+        /// <summary>Gets the property name to set.</summary>
         public string Property { get; }
+        /// <summary>Gets the value to assign.</summary>
         public ValueProducer Value { get; }
 
         internal SetReaction(Source on, string property, ValueProducer value)
@@ -108,11 +129,16 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Calls a method on a component or DOM element.</summary>
     public sealed class CallReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"call"</c>.</summary>
         public string Kind => "call";
+        /// <summary>Gets the target source to call the method on.</summary>
         public Source On { get; }
+        /// <summary>Gets the method name to call.</summary>
         public string Method { get; }
+        /// <summary>Gets the method arguments, or <see langword="null"/> when the method takes no arguments.</summary>
         public IReadOnlyList<ValueProducer>? Args { get; }
 
         internal CallReaction(Source on, string method, List<ValueProducer>? args)
@@ -123,19 +149,27 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Sends an HTTP request as defined by the enclosed <see cref="PlanModel.Request"/>.</summary>
     public sealed class RequestReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"request"</c>.</summary>
         public string Kind => "request";
+        /// <summary>Gets the HTTP request definition.</summary>
         public new Request Request { get; }
 
         internal RequestReaction(Request request) { Request = request ?? throw new ArgumentNullException(nameof(request)); }
     }
 
+    /// <summary>Dispatches a custom browser event.</summary>
     public sealed class DispatchReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"dispatch"</c>.</summary>
         public string Kind => "dispatch";
+        /// <summary>Gets the event name to dispatch.</summary>
         public string Event { get; }
+        /// <summary>Gets the optional event payload, or <see langword="null"/> for no data.</summary>
         public ValueProducer? Data { get; }
+        /// <summary>Gets the optional payload type tag, or <see langword="null"/> when untyped.</summary>
         public string? PayloadType { get; }
 
         internal DispatchReaction(string eventName, ValueProducer? data, string? payloadType)
@@ -146,10 +180,14 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Injects a value into a named component.</summary>
     public sealed class InjectReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"inject"</c>.</summary>
         public string Kind => "inject";
+        /// <summary>Gets the target component name.</summary>
         public string Component { get; }
+        /// <summary>Gets the value to inject.</summary>
         public ValueProducer Value { get; }
 
         internal InjectReaction(string component, ValueProducer value)
@@ -159,9 +197,12 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Displays accumulated validation errors in the target container.</summary>
     public sealed class ShowValidationErrorsReaction : Reaction
     {
+        /// <summary>Gets the kind. Always <c>"show-validation-errors"</c>.</summary>
         public string Kind => "show-validation-errors";
+        /// <summary>Gets the element ID of the validation error container.</summary>
         public string Container { get; }
 
         internal ShowValidationErrorsReaction(string container)

--- a/Alis.Reactive/PlanModel/Request.cs
+++ b/Alis.Reactive/PlanModel/Request.cs
@@ -4,22 +4,30 @@ using Alis.Reactive.Serialization;
 
 namespace Alis.Reactive.PlanModel
 {
+    /// <summary>An HTTP request definition in the reactive plan.</summary>
     public sealed class Request
     {
+        /// <summary>Gets the HTTP method (GET, POST, PUT, DELETE, PATCH).</summary>
         public string Method { get; }
+        /// <summary>Gets the request URL, which may contain template placeholders like <c>{id}</c>.</summary>
         public string Url { get; }
+        /// <summary>Gets the DOM element ID where validation errors are displayed, or <see langword="null"/> when validation is not configured for this request.</summary>
         public string? Container { get; internal set; }
+        /// <summary>Gets the request body strategy, or <see langword="null"/> for bodiless requests.</summary>
         public RequestInput? Input { get; internal set; }
+        /// <summary>Gets reactions to execute before the request is sent, or <see langword="null"/> if none.</summary>
         public List<Reaction>? Before { get; internal set; }
+        /// <summary>Gets the success response handlers, or <see langword="null"/> if none.</summary>
         public List<ResponseHandler>? Success { get; internal set; }
+        /// <summary>Gets the error response handlers, or <see langword="null"/> if none.</summary>
         public List<ResponseHandler>? Error { get; internal set; }
+        /// <summary>Gets reactions to execute after the request completes regardless of outcome, or <see langword="null"/> if none.</summary>
         public List<Reaction>? Complete { get; internal set; }
+        /// <summary>Gets the chained follow-up request, or <see langword="null"/> if none.</summary>
         public Request? Next { get; internal set; }
-        /// <summary>Custom HTTP headers to send with this request. Each value is a ValueProducer
-        /// evaluated at request time — supports literals, component reads, and event args.</summary>
+        /// <summary>Gets the custom HTTP headers, or <see langword="null"/> if none. Each value is evaluated at request time.</summary>
         public Dictionary<string, ValueProducer>? Headers { get; internal set; }
-        /// <summary>URL template parameters. Each value is a ValueProducer evaluated at request time.
-        /// Placeholders like {id} in the URL are replaced with the evaluated, URI-encoded values.</summary>
+        /// <summary>Gets the URL template parameters, or <see langword="null"/> if none. Each value is evaluated and URI-encoded before replacing placeholders in the URL.</summary>
         public Dictionary<string, ValueProducer>? RouteParams { get; internal set; }
 
         internal Request(string method, string url)
@@ -38,6 +46,7 @@ namespace Alis.Reactive.PlanModel
         internal System.Type ValidatorType { get; set; }
     }
 
+    /// <summary>Base class for request body strategies. Not constructed in application code.</summary>
     [JsonConverter(typeof(WriteOnlyPolymorphicConverter<RequestInput>))]
     public abstract class RequestInput
     {
@@ -64,10 +73,14 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Sends a single evaluated value as the request body.</summary>
     public sealed class ValueInput : RequestInput
     {
+        /// <summary>Gets the kind. Always <c>"value"</c>.</summary>
         public string Kind => "value";
+        /// <summary>Gets the value expression to send as the body.</summary>
         public ValueProducer Value { get; }
+        /// <summary>Gets the transport format (json or form).</summary>
         public string Transport { get; }
 
         internal ValueInput(ValueProducer value, string transport)
@@ -77,8 +90,7 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
-    /// <summary>Maps an HTTP parameter name to a ValueProducer that reads the value at request time.
-    /// Uses the shared evaluateValue path — same concept as pipeline reads and validation.</summary>
+    /// <summary>Maps an HTTP parameter name to a value expression evaluated at request time.</summary>
     internal sealed class GatherField
     {
         /// <summary>HTTP parameter name (from model binding path or explicit override).</summary>
@@ -128,9 +140,12 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>Maps an optional HTTP status code to a reaction.</summary>
     public sealed class ResponseHandler
     {
+        /// <summary>Gets the HTTP status code to match, or <see langword="null"/> to match any status.</summary>
         public int? Status { get; internal set; }
+        /// <summary>Gets the reaction to execute when the status matches.</summary>
         public Reaction Reaction { get; }
 
         internal ResponseHandler(Reaction reaction)

--- a/Alis.Reactive/PlanModel/Shape.cs
+++ b/Alis.Reactive/PlanModel/Shape.cs
@@ -6,9 +6,8 @@ using System.Linq;
 namespace Alis.Reactive.PlanModel
 {
     /// <summary>
-    /// The type contract the plan expresses. Declares what a value IS and enables
-    /// Shape-to-Shape conversion. One shared type used everywhere: JsType properties,
-    /// ValueProducer reads, conditions, validation rules, gather.
+    /// Declares the expected type for a value in the plan (string, number, date, array, object, etc.).
+    /// Used across value expressions, conditions, and validation to ensure type consistency.
     /// </summary>
     public sealed class Shape : IEquatable<Shape>
     {
@@ -84,17 +83,22 @@ namespace Alis.Reactive.PlanModel
             return Any;
         }
 
+        /// <summary>Gets the shape kind (string, number, boolean, date, array, object, nullable, raw, any, or none).</summary>
         public string Kind { get; }
+        /// <summary>Gets the element shape for array shapes, or <see langword="null"/> for non-array shapes.</summary>
         public Shape Item { get; private set; }
+        /// <summary>Gets the wrapped shape for nullable shapes, or <see langword="null"/> for non-nullable shapes.</summary>
         public Shape Inner { get; private set; }
+        /// <summary>Gets the named field shapes for object shapes, or <see langword="null"/> for non-object shapes.</summary>
         public IReadOnlyDictionary<string, Shape> Fields { get; private set; }
+        /// <summary>Gets whether the object shape accepts properties beyond those listed in <see cref="Fields"/>. When true, the value may contain extra keys not declared in the shape.</summary>
         public bool? Additional { get; private set; }
 
         internal bool IsNone => Kind == "none";
 
         /// <summary>
         /// Returns true if this shape represents a value that can be meaningfully serialized
-        /// to a single string — suitable for HTTP headers, route params, and query strings.
+        /// to a single string. Suitable for HTTP headers, route params, and query strings.
         /// Scalars: string, number, boolean, date. Nullable wrapping a scalar is also scalar.
         /// Non-scalars: array, object, raw, any, none.
         /// </summary>
@@ -122,6 +126,9 @@ namespace Alis.Reactive.PlanModel
             Kind = kind;
         }
 
+        /// <summary>Determines whether two <see cref="Shape"/> instances represent the same type contract.</summary>
+        /// <param name="other">The shape to compare with.</param>
+        /// <returns><see langword="true"/> if the shapes are structurally equal.</returns>
         public bool Equals(Shape other)
         {
             if (other is null) return false;
@@ -141,8 +148,10 @@ namespace Alis.Reactive.PlanModel
             return true;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj) => Equals(obj as Shape);
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
 #if NET6_0_OR_GREATER
@@ -161,7 +170,9 @@ namespace Alis.Reactive.PlanModel
 #endif
         }
 
+        /// <summary>Returns <see langword="true"/> if both shapes are structurally equal.</summary>
         public static bool operator ==(Shape left, Shape right) => Equals(left, right);
+        /// <summary>Returns <see langword="true"/> if the shapes are not structurally equal.</summary>
         public static bool operator !=(Shape left, Shape right) => !Equals(left, right);
     }
 }

--- a/Alis.Reactive/PlanModel/Source.cs
+++ b/Alis.Reactive/PlanModel/Source.cs
@@ -3,15 +3,21 @@ using Alis.Reactive.Serialization;
 
 namespace Alis.Reactive.PlanModel
 {
+    /// <summary>
+    /// Base class for value source identifiers in a reactive plan. Not constructed in application code.
+    /// </summary>
     [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlyPolymorphicConverter<Source>))]
     public abstract class Source
     {
         private protected Source() { }
     }
 
+    /// <summary>Identifies a registered UI component as the value source.</summary>
     public sealed class ComponentSource : Source
     {
+        /// <summary>Gets the kind. Always <c>"component"</c>.</summary>
         public string Kind => "component";
+        /// <summary>Gets the registered component name.</summary>
         public string Component { get; }
 
         internal ComponentSource(string component)
@@ -22,10 +28,14 @@ namespace Alis.Reactive.PlanModel
         internal static ComponentSource Of(string component) => new ComponentSource(component);
     }
 
+    /// <summary>Reads from the event or response payload of the current trigger.</summary>
     public sealed class PayloadSource : Source
     {
+        /// <summary>Gets the kind. Always <c>"payload"</c>.</summary>
         public string Kind => "payload";
+        /// <summary>Gets the payload scope: event (trigger payload), success or error (HTTP response), request (outgoing body), dispatch (custom event data), or local (view model).</summary>
         public string Scope { get; }
+        /// <summary>Gets the optional payload type tag, or <see langword="null"/> when untyped.</summary>
         public string Type { get; }
 
         internal PayloadSource(string scope, string type = null)
@@ -42,11 +52,12 @@ namespace Alis.Reactive.PlanModel
         internal static PayloadSource Local() => new PayloadSource("local");
     }
 
-    /// <summary>Reads a value from a user-registered JS plugin object.
-    /// Carries the plugin name — the registry key for resolution.</summary>
+    /// <summary>Reads a value from a named plugin object registered by the application.</summary>
     public sealed class PluginSource : Source
     {
+        /// <summary>Gets the kind. Always <c>"plugin"</c>.</summary>
         public string Kind => "plugin";
+        /// <summary>Gets the plugin registry name.</summary>
         public string Name { get; }
         private PluginSource(string name)
         {
@@ -55,10 +66,10 @@ namespace Alis.Reactive.PlanModel
         internal static PluginSource Of(string name) => new PluginSource(name);
     }
 
-    /// <summary>Reads a value from the browser's current URL query string.
-    /// Singleton — no per-instance state. The query param name is the member on ReadProducer.</summary>
+    /// <summary>Reads a value from the browser's current URL query string.</summary>
     public sealed class UrlSource : Source
     {
+        /// <summary>Gets the kind. Always <c>"url"</c>.</summary>
         public string Kind => "url";
         private UrlSource() { }
         internal static UrlSource Instance { get; } = new UrlSource();

--- a/Alis.Reactive/PlanModel/ValueProducer.cs
+++ b/Alis.Reactive/PlanModel/ValueProducer.cs
@@ -5,6 +5,9 @@ using Alis.Reactive.Serialization;
 
 namespace Alis.Reactive.PlanModel
 {
+    /// <summary>
+    /// Base class for all value nodes in a reactive plan. Not constructed in application code.
+    /// </summary>
     [JsonConverter(typeof(WriteOnlyPolymorphicConverter<ValueProducer>))]
     public abstract class ValueProducer
     {
@@ -57,11 +60,18 @@ namespace Alis.Reactive.PlanModel
             new ArrayProducer(items, shape);
     }
 
+    /// <summary>A constant value embedded in the plan.</summary>
+    /// <remarks>
+    /// Created when a literal is passed to a builder such as <c>p.Element("id").SetText("hello")</c>.
+    /// </remarks>
     public sealed class LiteralProducer : ValueProducer
     {
+        /// <summary>Gets the kind. Always <c>"literal"</c>.</summary>
         public string Kind => "literal";
+        /// <summary>Gets the constant value embedded in the plan.</summary>
         [JsonInclude]
         public object Value { get; }
+        /// <summary>Gets the expected type shape, or <see langword="null"/> when not specified.</summary>
         public Shape Shape { get; }
 
         internal LiteralProducer(object value, Shape shape)
@@ -71,13 +81,26 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>A value read from a live source when the plan executes in the browser.</summary>
+    /// <remarks>
+    /// Created by source-reading builders such as <c>p.Plugin&lt;int&gt;("array", "count").Arg(json, x =&gt; x.Items)</c>.
+    /// </remarks>
     public sealed class ReadProducer : ValueProducer
     {
+        /// <summary>Gets the kind. Always <c>"read"</c>.</summary>
         public string Kind => "read";
+        /// <summary>
+        /// Gets the value source: <see cref="ComponentSource"/>, <see cref="PluginSource"/>,
+        /// <see cref="UrlSource"/>, or <see cref="PayloadSource"/>.
+        /// </summary>
         public Source From { get; }
+        /// <summary>Gets the property or method name to read on the source.</summary>
         public string Member { get; }
+        /// <summary>Gets the nested property path, or <see langword="null"/> for direct reads.</summary>
         public Path Path { get; }
+        /// <summary>Gets the expected type shape, or <see langword="null"/> when not specified.</summary>
         public Shape Shape { get; }
+        /// <summary>Gets optional method arguments, or <see langword="null"/> for property reads.</summary>
         public IReadOnlyList<ValueProducer> Args { get; }
 
         internal ReadProducer(Source from, string member, Path path, Shape shape, List<ValueProducer> args = null)
@@ -90,10 +113,14 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>A composite value built from named field expressions.</summary>
     public sealed class ObjectProducer : ValueProducer
     {
+        /// <summary>Gets the kind. Always <c>"object"</c>.</summary>
         public string Kind => "object";
+        /// <summary>Gets the named fields and their value expressions.</summary>
         public IReadOnlyDictionary<string, ValueProducer> Fields { get; }
+        /// <summary>Gets the expected type shape, or <see langword="null"/> when not specified.</summary>
         public Shape Shape { get; }
 
         internal ObjectProducer(Dictionary<string, ValueProducer> fields, Shape shape)
@@ -103,10 +130,14 @@ namespace Alis.Reactive.PlanModel
         }
     }
 
+    /// <summary>A composite value built from ordered item expressions.</summary>
     public sealed class ArrayProducer : ValueProducer
     {
+        /// <summary>Gets the kind. Always <c>"array"</c>.</summary>
         public string Kind => "array";
+        /// <summary>Gets the ordered item expressions.</summary>
         public IReadOnlyList<ValueProducer> Items { get; }
+        /// <summary>Gets the expected type shape, or <see langword="null"/> when not specified.</summary>
         public Shape Shape { get; }
 
         internal ArrayProducer(List<ValueProducer> items, Shape shape)


### PR DESCRIPTION
## Summary

- Add XML documentation to all public types and members across 7 PlanModel files
- ValueProducer, Source, Shape, Reaction, Condition, Request, Path
- These types are public for System.Text.Json polymorphic serialization but created internally by builders
- Eliminates CS1591 warnings for the PlanModel namespace
- Fix pre-existing em-dashes and jargon in existing docs (PluginSource, UrlSource, Headers, RouteParams, GatherField)

## Review Process

4 review rounds with 3 independent reviewers:
- **Tech Writer (Codex xhigh)**: Language quality, voice consistency, no jargon
- **Blind Developer**: Reads only XML docs, states understanding per member
- **Understanding Validator**: Compares blind dev understanding against actual code

17 findings across 4 rounds. All 17 resolved. Clean handoff: zero open findings.

## Test plan

- [ ] `dotnet build Alis.Reactive/Alis.Reactive.csproj 2>&1 | grep CS1591 | grep PlanModel` returns 0 lines
- [ ] IntelliSense shows docs correctly in Rider/VS

🤖 Generated with [Claude Code](https://claude.com/claude-code)