### PR TITLE
fix: add 7 missing cards to sandbox index pages

### DIFF
--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -306,6 +306,32 @@
                 Select files and see them uploaded via FormData POST, with reactive feedback on upload progress
             </p>
         </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+            <div class="flex items-start justify-between">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                    Grid
+                </h3>
+                <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+            </div>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Data grid with inline editing, sorting, and filtering — see row mutations gathered for batch operations
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Schedule" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+            <div class="flex items-start justify-between">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                    Schedule
+                </h3>
+                <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+            </div>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Calendar scheduler with event CRUD — create, drag, and resize appointments with reactive validation
+            </p>
+        </a>
     </div>
 </section>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Conditions/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Conditions/Index.cshtml
@@ -68,6 +68,19 @@
                     Conditions interleaved with HTTP across one page and two fixtures: trigger flows and real component reactive flows.
                 </p>
             </a>
+
+            <a asp-area="Sandbox" asp-controller="ResponseConditions" asp-action="Index"
+               class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+                <div class="flex items-start justify-between">
+                    <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                        Response Conditions
+                    </h3>
+                    <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+                </div>
+                <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                    Branch on HTTP response status codes — approve, deny, pending, fail — with status-driven DOM updates.
+                </p>
+            </a>
         </div>
     </section>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Validation/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Validation/Index.cshtml
@@ -58,3 +58,58 @@
         </p>
     </a>
 </div>
+
+<h2 class="text-lg font-semibold text-text-primary mt-10 mb-4">Nested &amp; Conditional</h2>
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <a asp-area="Sandbox" asp-controller="NestedBugs" asp-action="NestedCondition"
+       class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+        <div class="flex items-start justify-between">
+            <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                Nested Condition
+            </h3>
+            <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+        </div>
+        <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+            Nested model validation with SetValidator — address fields under a parent model with conditional visibility
+        </p>
+    </a>
+
+    <a asp-area="Sandbox" asp-controller="NestedBugs" asp-action="ParentChild"
+       class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+        <div class="flex items-start justify-between">
+            <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                Parent Child
+            </h3>
+            <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+        </div>
+        <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+            Parent-child form with nested property validation — tests field correlation across model hierarchies
+        </p>
+    </a>
+
+    <a asp-area="Sandbox" asp-controller="NestedBugs" asp-action="IncludeConditional"
+       class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+        <div class="flex items-start justify-between">
+            <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                Include Conditional
+            </h3>
+            <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+        </div>
+        <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+            Conditional Include — gather specific fields based on condition state, not the entire form
+        </p>
+    </a>
+
+    <a asp-area="Sandbox" asp-controller="NestedBugs" asp-action="OperatorConditions"
+       class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-[#7A2E3B]/20 hover:-translate-y-0.5 transition-all duration-200">
+        <div class="flex items-start justify-between">
+            <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-[#7A2E3B] transition-colors">
+                Operator Conditions
+            </h3>
+            <span class="text-text-muted group-hover:text-[#7A2E3B] transition-colors text-sm">&rarr;</span>
+        </div>
+        <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+            Validation rules that activate based on condition operators — WhenField toggles rule enforcement dynamically
+        </p>
+    </a>
+</div>


### PR DESCRIPTION
## Summary

- Add 7 missing navigation cards to 3 sandbox index pages
- Every child view now has a corresponding card in its section's landing page

## Changes

**Components/Index.cshtml** — 2 cards added to Fusion section:
- Grid — data grid with inline editing, sorting, filtering
- Schedule — calendar scheduler with event CRUD

**Conditions/Index.cshtml** — 1 card added to Syntax & Routing section:
- ResponseConditions — branch on HTTP response status codes

**Validation/Index.cshtml** — 4 cards in new "Nested & Conditional" section:
- NestedCondition — nested model validation with SetValidator
- ParentChild — parent-child form with nested property validation
- IncludeConditional — conditional Include gather
- OperatorConditions — WhenField-driven rule enforcement

## Test plan

- [ ] Navigate to `/Sandbox/Components` — Grid and Schedule cards visible and clickable
- [ ] Navigate to `/Sandbox/Conditions` — Response Conditions card visible and clickable
- [ ] Navigate to `/Sandbox/Validation` — all 4 Nested & Conditional cards visible and clickable
- [ ] All card links resolve to working pages (no 404s)
- [ ] Card markup matches existing pattern (rounded-2xl, hover effects, arrow indicator)

https://claude.ai/code/session_01Bhoz3SzeBdMKm4EFYaLgUo