### PR TITLE
fix(ci): set Analyzers IsPackable=false

### DIFF
--- a/Alis.Reactive.Analyzers/Alis.Reactive.Analyzers.csproj
+++ b/Alis.Reactive.Analyzers/Alis.Reactive.Analyzers.csproj
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-        <IsPackable>true</IsPackable>
+        <IsPackable>false</IsPackable>
         <DevelopmentDependency>true</DevelopmentDependency>
         <PackageDescription>Roslyn analyzers for Alis.Reactive — compile-time checks for correct DSL usage, API surface protection, and HTTP pipeline validation.</PackageDescription>
         <PackageTags>reactive;analyzers;roslyn;code-analysis</PackageTags>


### PR DESCRIPTION
## Summary
- `Alis.Reactive.Analyzers` had `IsPackable=true` which caused its nupkg to land in `./nupkgs/` during `dotnet pack`
- The wildcard `dotnet nuget push ./nupkgs/*.nupkg` then pushed it to NuGet.org where the API key returns 403 Forbidden
- Fix: `IsPackable=false` — Analyzers is a development-time dependency bundled inside the core package, not a standalone NuGet package

## Evidence
PR #100 and PR #102 both failed at the same step with:
```
Pushing Alis.Reactive.Analyzers.1.0.0-preview.9.nupkg to 'https://www.nuget.org/api/v2/package'...
error: Response status code does not indicate success: 403 (The specified API key is invalid, has expired, or does not have permission to access the specified package.)
```

## Test plan
- [x] No code change — only csproj metadata
- [ ] CI publish step succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)