### PR TITLE
feat: bundle Roslyn analyzers in core NuGet package

### DIFF
--- a/Alis.Reactive/Alis.Reactive.csproj
+++ b/Alis.Reactive/Alis.Reactive.csproj
@@ -29,6 +29,14 @@
         <None Include="build\AlisReactive.targets" Pack="true" PackagePath="build\" />
     </ItemGroup>
 
+    <!-- Bundle Roslyn analyzers so consumers get compile-time DSL checks (ALIS001-ALIS008) -->
+    <ItemGroup>
+        <None Include="..\Alis.Reactive.Analyzers\bin\$(Configuration)\netstandard2.0\Alis.Reactive.Analyzers.dll"
+              Pack="true"
+              PackagePath="analyzers/dotnet/cs"
+              Visible="false" />
+    </ItemGroup>
+
     <ItemGroup>
         <InternalsVisibleTo Include="Alis.Reactive.Fusion" />
         <InternalsVisibleTo Include="Alis.Reactive.Native" />


### PR DESCRIPTION
## Summary
- Bundles `Alis.Reactive.Analyzers.dll` inside the `AlisReactive` NuGet package at `analyzers/dotnet/cs/`
- Consumers get 8 compile-time DSL checks (ALIS001-ALIS008) automatically when installing the package
- Analyzers project stays `IsPackable=false` — ships bundled, not standalone

## Why
The analyzers enforce framework usage patterns that the DSL can't prevent at compile time (incomplete conditional chains, control flow in callbacks, server-only validation rules, etc.). MVC project consumers need these checks.

## Verified
- `dotnet pack` produces package with `analyzers/dotnet/cs/Alis.Reactive.Analyzers.dll` (29KB)
- Full solution builds with 0 errors
- 128/128 unit tests pass

## Test plan
- [x] `unzip -l` confirms analyzer DLL in package
- [x] Build clean
- [x] Unit tests pass
- [ ] CI publish succeeds (no more 403 — Analyzers not pushed standalone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)