### PR TITLE
fix(ci): build before pack for bundled analyzer DLL

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -155,6 +155,9 @@ jobs:
           cp Alis.Reactive.SandboxApp/wwwroot/js/alis-reactive.js Alis.Reactive/assets/js/
           cp Alis.Reactive.SandboxApp/wwwroot/css/design-system.css Alis.Reactive/assets/css/
 
+      - name: Build all C# projects
+        run: dotnet build --configuration Release
+
       - name: Determine version suffix
         id: version
         run: |
@@ -168,7 +171,7 @@ jobs:
 
       - name: Pack NuGet packages
         run: |
-          PACK_ARGS="--configuration Release --output ./nupkgs"
+          PACK_ARGS="--configuration Release --no-build --output ./nupkgs"
           if [ -n "${{ steps.version.outputs.suffix }}" ]; then
             PACK_ARGS="$PACK_ARGS --version-suffix ${{ steps.version.outputs.suffix }}"
           fi


### PR DESCRIPTION
## Summary
- PR #104 bundled the analyzer DLL in the NuGet package but the CI workflow had no build step before pack
- The `None Include` path to `Alis.Reactive.Analyzers.dll` didn't exist at pack time → pack failed
- Fix: added `dotnet build --configuration Release` before the pack step, and `--no-build` on pack commands

## Test plan
- [ ] CI pack-and-publish succeeds
- [ ] `analyzers/dotnet/cs/Alis.Reactive.Analyzers.dll` present in published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)