### PR TITLE
fix(packaging): PackagePath file paths eliminate Windows silent-empty-wwwroot

### DIFF
--- a/Alis.Reactive/Alis.Reactive.csproj
+++ b/Alis.Reactive/Alis.Reactive.csproj
@@ -21,12 +21,19 @@
         <Content Include="Schemas\**\*.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
-    <!-- Ship JS/CSS as NuGet content files with a configurable output path -->
+    <!-- Ship JS/CSS as NuGet content files with a configurable output path.
+         PackagePath uses explicit file paths (not folder paths with trailing slashes)
+         so the packed entries never contain an empty path segment. A trailing
+         backslash like PackagePath="buildTransitive\" produced ZIP entries such as
+         buildTransitive//AlisReactive.targets which are normalized on macOS/Linux
+         during NuGet extraction but are NOT normalized on Windows — leaving the
+         targets file at a location that does not match NuGet's auto-import
+         convention, so consumers silently get no assets in wwwroot. -->
     <ItemGroup>
-        <None Include="assets\js\alis-reactive.js" Pack="true" PackagePath="buildTransitive\assets\js\" />
-        <None Include="assets\css\design-system.css" Pack="true" PackagePath="buildTransitive\assets\css\" />
-        <None Include="build\AlisReactive.targets" Pack="true" PackagePath="buildTransitive\" />
-        <None Include="build\AlisReactive.targets" Pack="true" PackagePath="build\" />
+        <None Include="assets\js\alis-reactive.js" Pack="true" PackagePath="buildTransitive\assets\js\alis-reactive.js" />
+        <None Include="assets\css\design-system.css" Pack="true" PackagePath="buildTransitive\assets\css\design-system.css" />
+        <None Include="build\AlisReactive.targets" Pack="true" PackagePath="buildTransitive\AlisReactive.targets" />
+        <None Include="build\AlisReactive.targets" Pack="true" PackagePath="build\AlisReactive.targets" />
     </ItemGroup>
 
     <!--


### PR DESCRIPTION
## Root cause

Four \`<None Pack=\"true\">\` entries in \`Alis.Reactive/Alis.Reactive.csproj\` used folder-style \`PackagePath\` values ending in a trailing backslash:

\`\`\`xml
<None Include=\"assets\\js\\alis-reactive.js\" Pack=\"true\" PackagePath=\"buildTransitive\\assets\\js\\\" />
<None Include=\"assets\\css\\design-system.css\" Pack=\"true\" PackagePath=\"buildTransitive\\assets\\css\\\" />
<None Include=\"build\\AlisReactive.targets\" Pack=\"true\" PackagePath=\"buildTransitive\\\" />
<None Include=\"build\\AlisReactive.targets\" Pack=\"true\" PackagePath=\"build\\\" />
\`\`\`

NuGet pack concatenates those with the file name, producing ZIP entries with a **double slash**:

\`\`\`
buildTransitive//AlisReactive.targets
buildTransitive/assets/js//alis-reactive.js
buildTransitive/assets/css//design-system.css
\`\`\`

NuGet pack emits \`NU5129\` because its convention scan cannot find \`buildTransitive/AlisReactive.targets\` (single slash) at the expected location.

## Why Windows consumers see empty wwwroot

- **macOS / Linux:** NuGet client normalizes the double slash during extraction — files land at single-slash paths on disk. The generated \`obj/<project>.csproj.nuget.g.targets\` imports \`buildTransitive/AlisReactive.targets\` (single slash), \`Exists(...)\` returns true, the import fires, \`CopyAlisReactiveAssets\` AfterBuild target runs, assets land in \`wwwroot/scripts\` and \`wwwroot/css\`. **Works by accident.**
- **Windows:** Extraction does **not** normalize the empty path segment. The targets file never materializes at \`buildTransitive/AlisReactive.targets\`. \`Condition=\"Exists(...)\"\` returns false. NuGet silently skips the import. Consumer builds with **0 warnings, 0 errors, empty wwwroot**. User-confirmed on \`1.0.0-preview.16\`.

## Reproduction (macOS simulating Windows)

\`\`\`bash
# Install 1.0.0-preview.16 into a fresh .NET 10 MVC consumer (works)
dotnet new mvc -n Repro -f net10.0 -o /tmp/repro
cd /tmp/repro
dotnet add package AlisReactive --version 1.0.0-preview.16
dotnet build
ls wwwroot/scripts wwwroot/css  # → assets present (macOS normalized the path)

# Simulate Windows: remove the normalized targets file from the NuGet cache
mv ~/.nuget/packages/alisreactive/1.0.0-preview.16/buildTransitive/AlisReactive.targets /tmp/
rm -rf wwwroot obj/Debug bin
dotnet build
ls wwwroot                      # → EMPTY, 0 warnings, 0 errors
\`\`\`

Same symptom as the Windows consumer report.

## Fix

Change \`PackagePath\` from folder form to explicit file paths. With a file path, NuGet pack can no longer insert an empty segment regardless of platform:

\`\`\`xml
<None Include=\"assets\\js\\alis-reactive.js\" Pack=\"true\" PackagePath=\"buildTransitive\\assets\\js\\alis-reactive.js\" />
<None Include=\"assets\\css\\design-system.css\" Pack=\"true\" PackagePath=\"buildTransitive\\assets\\css\\design-system.css\" />
<None Include=\"build\\AlisReactive.targets\" Pack=\"true\" PackagePath=\"buildTransitive\\AlisReactive.targets\" />
<None Include=\"build\\AlisReactive.targets\" Pack=\"true\" PackagePath=\"build\\AlisReactive.targets\" />
\`\`\`

## Verification

Packed locally at \`1.0.0-preview.fixtest\`:

| Before (preview.16) | After (fixtest) |
|---|---|
| \`buildTransitive//AlisReactive.targets\` | \`buildTransitive/AlisReactive.targets\` |
| \`buildTransitive/assets/js//alis-reactive.js\` | \`buildTransitive/assets/js/alis-reactive.js\` |
| \`buildTransitive/assets/css//design-system.css\` | \`buildTransitive/assets/css/design-system.css\` |
| \`NU5129\` warning on pack | no warnings |

## Test plan

- [x] Pack produces clean single-slash ZIP entries
- [x] \`NU5129\` warning no longer emitted
- [ ] Once merged + published as \`1.0.0-preview.N\`, Windows consumer install produces populated \`wwwroot/scripts\` and \`wwwroot/css\` (needs verification on the reporter's Windows machine)
- [ ] macOS/Linux install remains populated (regression check — should be unaffected since normalization was a silent workaround, not a requirement)

## Files changed

- \`Alis.Reactive/Alis.Reactive.csproj\` — 4 \`PackagePath\` values converted from folder form to file form; added XML comment explaining why

🤖 Generated with [Claude Code](https://claude.com/claude-code)