### PR TITLE
fix(pkg): ship net48-consumable assets under Content/alisreactive

### DIFF
--- a/Alis.Reactive/Alis.Reactive.csproj
+++ b/Alis.Reactive/Alis.Reactive.csproj
@@ -28,12 +28,22 @@
          buildTransitive//AlisReactive.targets which are normalized on macOS/Linux
          during NuGet extraction but are NOT normalized on Windows — leaving the
          targets file at a location that does not match NuGet's auto-import
-         convention, so consumers silently get no assets in wwwroot. -->
+         convention, so consumers silently get no assets in wwwroot.
+
+         Assets AND targets are packed under BOTH build\ and buildTransitive\.
+         - build\          : required by net48 projects using packages.config
+                             (classic NuGet only auto-imports build\*.targets and
+                             resolves $(MSBuildThisFileDirectory)assets\* relative
+                             to that folder).
+         - buildTransitive\: required so PackageReference consumers flow the
+                             targets + assets through transitive dependencies. -->
     <ItemGroup>
+        <None Include="assets\js\alis-reactive.js" Pack="true" PackagePath="build\assets\js\alis-reactive.js" />
+        <None Include="assets\css\design-system.css" Pack="true" PackagePath="build\assets\css\design-system.css" />
         <None Include="assets\js\alis-reactive.js" Pack="true" PackagePath="buildTransitive\assets\js\alis-reactive.js" />
         <None Include="assets\css\design-system.css" Pack="true" PackagePath="buildTransitive\assets\css\design-system.css" />
-        <None Include="build\AlisReactive.targets" Pack="true" PackagePath="buildTransitive\AlisReactive.targets" />
         <None Include="build\AlisReactive.targets" Pack="true" PackagePath="build\AlisReactive.targets" />
+        <None Include="build\AlisReactive.targets" Pack="true" PackagePath="buildTransitive\AlisReactive.targets" />
     </ItemGroup>
 
     <!--

--- a/Alis.Reactive/build/AlisReactive.targets
+++ b/Alis.Reactive/build/AlisReactive.targets
@@ -3,32 +3,54 @@
   <!--
     Alis.Reactive static assets (JS + CSS) — versioned filenames.
 
-    Defaults (auto-detected by framework):
-      net10.0+  JS  → wwwroot/scripts/alis-reactive.{version}.js
-                CSS → wwwroot/css/design-system.{version}.css
-      net48     JS  → Scripts/alis-reactive.{version}.js
-                CSS → Content/css/design-system.{version}.css
+    Defaults (auto-detected from $(TargetFrameworkIdentifier)):
+      .NETFramework (classic ASP.NET MVC or SDK-style net48):
+                JS  → Content\alisreactive\alis-reactive.{version}.js
+                CSS → Content\alisreactive\design-system.{version}.css
+      .NETCoreApp (net10.0+):
+                JS  → wwwroot\scripts\alis-reactive.{version}.js
+                CSS → wwwroot\css\design-system.{version}.css
+
+    $(TargetFrameworkIdentifier) is the robust signal — it is set to
+    '.NETFramework' for BOTH classic csproj files (via
+    TargetFrameworkVersion=v4.x) and SDK-style csproj files targeting
+    net4x. A bare $(TargetFramework) check misses classic projects
+    because they do not set that property at all.
+
+    For .NET Framework both JS and CSS live together under
+    Content\alisreactive\ so Web Optimization bundles, View references,
+    and deploy rules only need to track one folder. The folder sits
+    inside Content\ so it is published by default by WebApplication
+    targets (classic projects treat Scripts\ and Content\ as content
+    roots; a custom sibling folder would need extra csproj wiring).
 
     Override in your csproj:
       <PropertyGroup>
-        <AlisReactiveJsPath>my/custom/js</AlisReactiveJsPath>
-        <AlisReactiveCssPath>my/custom/css</AlisReactiveCssPath>
+        <AlisReactiveJsPath>my\custom\js</AlisReactiveJsPath>
+        <AlisReactiveCssPath>my\custom\css</AlisReactiveCssPath>
       </PropertyGroup>
   -->
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
-    <AlisReactiveJsPath Condition="'$(AlisReactiveJsPath)' == ''">Scripts</AlisReactiveJsPath>
-    <AlisReactiveCssPath Condition="'$(AlisReactiveCssPath)' == ''">Content\css</AlisReactiveCssPath>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <AlisReactiveJsPath Condition="'$(AlisReactiveJsPath)' == ''">Content\alisreactive</AlisReactiveJsPath>
+    <AlisReactiveCssPath Condition="'$(AlisReactiveCssPath)' == ''">Content\alisreactive</AlisReactiveCssPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net48'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <AlisReactiveJsPath Condition="'$(AlisReactiveJsPath)' == ''">wwwroot\scripts</AlisReactiveJsPath>
     <AlisReactiveCssPath Condition="'$(AlisReactiveCssPath)' == ''">wwwroot\css</AlisReactiveCssPath>
   </PropertyGroup>
 
+  <!--
+    $(MSBuildThisFileDirectory) is the build\ folder inside the extracted
+    NuGet package. Its parent is '{PackageId}.{Version}', e.g.
+    'AlisReactive.1.0.0-preview.17'. Strip the 'AlisReactive.' prefix
+    (13 chars) to keep only the version for use in output filenames.
+  -->
   <PropertyGroup>
     <AlisReactivePkgDir>$(MSBuildThisFileDirectory)</AlisReactivePkgDir>
-    <AlisReactiveVersion Condition="'$(AlisReactiveVersion)' == ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(AlisReactivePkgDir.TrimEnd('\/'))))))</AlisReactiveVersion>
+    <AlisReactivePkgFolderName>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(AlisReactivePkgDir.TrimEnd('\/'))))))</AlisReactivePkgFolderName>
+    <AlisReactiveVersion Condition="'$(AlisReactiveVersion)' == ''">$(AlisReactivePkgFolderName.Substring(13))</AlisReactiveVersion>
   </PropertyGroup>
 
   <Target Name="CopyAlisReactiveAssets" AfterTargets="Build">


### PR DESCRIPTION
Three defects prevented the published NuGet from being consumed from a classic .NET Framework 4.8 web project:

1. MSB3030: Alis.Reactive.targets looks up $(MSBuildThisFileDirectory)assets/<kind>/<file>, which for packages.config consumers (net48) resolves under the package's build\ folder. Assets were only packed at buildTransitive\assets\, so the copy target failed at build time. Pack the JS/CSS under both build\ and buildTransitive\ so every consumer class sees them.

2. Classic .NET Framework projects (non-SDK csproj) set TargetFrameworkVersion=v4.x and do NOT set TargetFramework, so the previous 'TargetFramework == net48' branch never matched and the defaults fell through to wwwroot\. Switch the gate to TargetFrameworkIdentifier == '.NETFramework', which MSBuild sets for BOTH classic csproj and SDK-style net4x. Put both JS and CSS under Content\alisreactive\ so bundles, views, and deploy rules only need to track one folder.

3. AlisReactiveVersion was derived from the package folder name '{id}.{version}' and kept the package-id prefix, producing filenames like alis-reactive.AlisReactive.1.0.0-preview.17.js. Strip the 'AlisReactive.' prefix (13 chars) so the version in the filename matches the package version.

Verified by packing the fix and building a net48 classic MVC project via nuget.exe install + Import — build succeeds and both Content\alisreactive\alis-reactive.<ver>.js and
Content\alisreactive\design-system.<ver>.css are produced with no MSB3030.