### PR TITLE
Onboard Fusion components and automation skill

### DIFF
--- a/.claude/skills/onboard-fusion-component/SKILL.md
+++ b/.claude/skills/onboard-fusion-component/SKILL.md
@@ -1,337 +1,173 @@
 ---
 name: onboard-fusion-component
-description: Guides onboarding of Syncfusion EJ2 components — adding new vertical slices, events, methods, or props to existing components, and experimenting with SF APIs to verify behavior before integration.
+description: Onboards Syncfusion EJ2 components into Alis Reactive by proving the real JS object API in raw HTML, tracing properties/methods/events, then implementing a typed Fusion vertical slice. Use when adding a new Fusion component, adding props/methods/events to an existing Fusion component, or validating whether a Syncfusion API should become typed DSL.
 disable-model-invocation: true
 ---
 
 # Onboard Fusion Component
 
-## The Process
-
-```
-1. Read SF docs → understand the API
-2. Experiment in browser → verify it actually works
-3. Check existing files → never duplicate, never overwrite
-4. Add only what's new → follow exact patterns from reference files
-5. Test → Playwright must pass
-```
-
-## Step 1: Read SF EJ2 Docs
-
-Always check the SF API docs first:
-- **API reference:** `https://ej2.syncfusion.com/javascript/documentation/api/{component}/`
-- **Events:** `https://ej2.syncfusion.com/javascript/documentation/api/{component}/#events`
-- **Methods:** `https://ej2.syncfusion.com/javascript/documentation/api/{component}/#methods`
-- **How-to guides:** `https://ej2.syncfusion.com/javascript/documentation/{component}/how-to/`
-- **Demos:** `https://ej2.syncfusion.com/demos/{component}/`
-
-Identify: property names (camelCase), method signatures, event names, event args properties.
-
-## Step 2: Experiment in Browser
-
-**NEVER onboard an API without verifying it works.** SF docs can be misleading — methods may exist but have no visible effect.
-
-Run a temporary experiment on the sandbox page using JS in the browser console:
-
-```javascript
-// Find the ej2 instance
-const el = document.getElementById('{componentId}');
-const ej2 = el.ej2_instances[0];
-
-// Test property set
-ej2.enabled = false;  // Does it disable?
-
-// Test method call
-ej2.showPopup();      // Does popup appear?
-ej2.showSpinner();    // Does spinner show? (may not on all components)
-
-// Test if method exists
-typeof ej2.someMethod; // "function" or "undefined"
-
-// Test event args methods (inside event handler)
-// Create a temp AutoComplete and wire the event to test:
-const ac = new ej.dropdowns.AutoComplete({
-    placeholder: 'test',
-    fields: { value: 'value', text: 'text' },
-    filtering: function(e) {
-        e.preventDefaultAction = true;
-        setTimeout(() => {
-            e.updateData([{value:'a', text:'A'}]); // Does popup show?
-        }, 200);
-    }
-});
-ac.appendTo('#temp-input');
-```
-
-**Document results** as comments in the vertical slice extensions file:
-```csharp
-// NOTE: showSpinner/hideSpinner have no visible effect on SF AutoComplete.
-// refresh() causes focus loss mid-typing — not usable during filtering.
-// Both verified manually. Omitted intentionally.
-```
-
-**Remove the experiment** before onboarding. No temp code in the codebase.
-
-## Step 3: Check Existing Files
-
-**Read before writing. Never duplicate.**
-
-```
-Alis.Reactive.Fusion/Components/FusionXxx/
-├── FusionXxx.cs                    ← EXISTS? Don't touch
-├── FusionXxxExtensions.cs          ← EXISTS? ADD methods, don't recreate
-├── FusionXxxHtmlExtensions.cs      ← EXISTS? Don't touch
-├── FusionXxxEvents.cs              ← EXISTS? ADD event descriptor, don't recreate
-├── FusionXxxReactiveExtensions.cs  ← EXISTS? Don't touch (generic TArgs handles any event)
-└── Events/
-    └── FusionXxxOnChanged.cs       ← EXISTS? Don't touch
-    └── FusionXxxOnFiltering.cs     ← NEW? Create following pattern
-```
-
-**If the Events singleton exists**, just add a property. **If the extensions file exists**, just add methods. **If the reactive extensions exist**, they already handle any event type via generic `TArgs` — don't touch.
-
-## Step 4: Add Only What's New
-
-### Capability Check — What the Framework Supports
-
-| JS API Pattern | Supported? | Mechanism |
-|---|---|---|
-| `ej2.prop = value` | YES | `self.Emit(new SetPropMutation("prop"), value: val)` |
-| `ej2.method()` | YES | `self.Emit(new CallMutation("method"))` |
-| `ej2.method("arg")` | YES | `self.Emit(new CallMutation("method", args: new[] { new LiteralArg("arg") }))` |
-| `ej2.method(data)` from response | YES | `CallMutation` + `SourceArg(new EventSource(path))` |
-| `ej2.prop` (read for conditions) | YES | `new TypedComponentSource<T>(id, vendor, readExpr)` |
-| `e.prop = true` on event args | YES | `new MutateEventCommand(new SetPropMutation("prop"), value: true)` |
-| `e.method(data)` on event args | YES | `new MutateEventCommand(new CallMutation("method", args: ...))` |
-| `evt.text` send to server | YES | `g.FromEvent(args, x => x.Text, "param")` |
-| `ej2.method()` → use return value | NO (v2) | Return value capture not supported |
-| `ej2.method()[0].prop` chained | NO (v2) | Variable concept not in plan |
-
-**If request maps to NO → explain why and stop. Do not invent workarounds.**
-
-### Adding a Method/Prop to Existing Component
-
-One-line addition to `FusionXxxExtensions.cs`. Reference: `FusionAutoCompleteExtensions.cs`
-
-```csharp
-// Void method → CallMutation
-public static ComponentRef<FusionXxx, TModel> ShowPopup<TModel>(
-    this ComponentRef<FusionXxx, TModel> self) where TModel : class
-    => self.Emit(new CallMutation("showPopup"));
-
-// Property set → SetPropMutation
-public static ComponentRef<FusionXxx, TModel> Disable<TModel>(
-    this ComponentRef<FusionXxx, TModel> self) where TModel : class
-    => self.Emit(new SetPropMutation("enabled"), value: false);
-
-// Property set from response → SetPropMutation + EventSource (ResponseBody overload)
-public static ComponentRef<FusionXxx, TModel> SetDataSource<TModel, TResponse>(
-    this ComponentRef<FusionXxx, TModel> self,
-    ResponseBody<TResponse> source, Expression<Func<TResponse, object?>> path)
-    where TModel : class where TResponse : class
-{
-    var sourcePath = ExpressionPathHelper.ToResponsePath(path);
-    return self.Emit(new SetPropMutation("dataSource"), source: new EventSource(sourcePath));
-}
-
-// Property set from generic event payload → SetPropMutation + EventSource (TSource overload)
-public static ComponentRef<FusionXxx, TModel> SetDataSource<TModel, TSource>(
-    this ComponentRef<FusionXxx, TModel> self,
-    TSource source, Expression<Func<TSource, object?>> path)
-    where TModel : class
-{
-    var sourcePath = ExpressionPathHelper.ToEventPath(path);
-    return self.Emit(new SetPropMutation("dataSource"), source: new EventSource(sourcePath));
-}
-
-// Read value → TypedComponentSource
-public static TypedComponentSource<string> Value<TModel>(
-    this ComponentRef<FusionXxx, TModel> self) where TModel : class
-    => new TypedComponentSource<string>(self.TargetId, Component.Vendor, Component.ReadExpr);
-```
-
-### Adding an Event (Simple — No Methods on Args)
-
-Reference: `Events/FusionAutoCompleteOnChanged.cs` + `FusionAutoCompleteEvents.cs`
-
-**File 1:** Create `Events/FusionXxxOnYyy.cs`:
-```csharp
-public class FusionXxxYyyArgs
-{
-    public string? Value { get; set; }
-    public bool IsInteracted { get; set; }
-    public FusionXxxYyyArgs() { }
-}
-```
-
-**File 2:** Add to `FusionXxxEvents.cs`:
-```csharp
-public TypedEventDescriptor<FusionXxxYyyArgs> Yyy =>
-    new TypedEventDescriptor<FusionXxxYyyArgs>("yyy", new FusionXxxYyyArgs());
-```
-
-The string `"yyy"` is the SF JS event name from docs. The reactive extensions already handle any `TArgs` — no changes needed there.
-
-### Adding an Event (With Methods on Args)
-
-Reference: `Events/FusionAutoCompleteOnFiltering.cs`
-
-Args class AND typed extensions go in ONE file. Extensions go on the args class itself — NOT on a separate builder:
-
-```csharp
-public class FusionXxxFilteringArgs
-{
-    public string Text { get; set; } = "";
-    public FusionXxxFilteringArgs() { }
-}
-
-public static class FusionXxxFilteringArgsExtensions
-{
-    // set-prop on event args
-    public static void PreventDefault(
-        this FusionXxxFilteringArgs args,
-        ICommandEmitter pipeline)
-    {
-        pipeline.AddCommand(new MutateEventCommand(
-            new SetPropMutation("preventDefaultAction"), value: true));
-    }
-
-    // call on event args with response data
-    public static void UpdateData<TResponse>(
-        this FusionXxxFilteringArgs args,
-        ICommandEmitter pipeline,
-        ResponseBody<TResponse> source,
-        Expression<Func<TResponse, object?>> path)
-        where TResponse : class
-    {
-        var sourcePath = ExpressionPathHelper.ToResponsePath(path);
-        pipeline.AddCommand(new MutateEventCommand(
-            new CallMutation("updateData", args: new MethodArg[]
-            {
-                new SourceArg(new EventSource(sourcePath))
-            })));
-    }
-}
-```
-
-**Why `pipeline` parameter?** `args` is a phantom shared across the entire reactive lambda. Unlike `ComponentRef` (created per-context via `p.Component`/`s.Component`), `args` has no pipeline binding. The builder must be passed explicitly.
-
-### View Usage — FromEvent + UpdateData Pattern
-
-```csharp
-.Reactive(plan, evt => evt.Filtering, (args, p) =>
-{
-    args.PreventDefault(p);
-    p.Get("/url")
-     .Gather(g => g.FromEvent(args, x => x.Text, "QueryParam"))
-     .Response(r => r.OnSuccess<TResponse>((json, s) =>
-     {
-         args.UpdateData(s, json, j => j.Items);
-         s.Element("status").SetText("loaded");
-     }));
-})
-```
-
-**`FromEvent` vs `Include`:**
-- `FromEvent(args, x => x.Text, "param")` — value from event args (typed text during filtering)
-- `Include<Component, Model>(m => m.Prop)` — value from component's current state (cascade)
-
-### New Component (Full Vertical Slice)
-
-Read ALL files in `FusionAutoComplete/` as reference. The pattern is 5 base files + 1 event file per event:
-
-1. `FusionXxx.cs` — extends `FusionComponent` (abstract base that provides `Vendor => "fusion"`), implements `IInputComponent`, declares `ReadExpr`
-2. `FusionXxxExtensions.cs` — mutations (SetValue, Enable, ShowPopup, Value, etc.)
-3. `FusionXxxHtmlExtensions.cs` — `Html.InputField().Xxx()` factory + `Fields<TItem>()` + `ComponentRegistration`
-4. `FusionXxxEvents.cs` — singleton, one `TypedEventDescriptor` per event
-5. `FusionXxxReactiveExtensions.cs` — `.Reactive()` on builder, generic `TArgs`
-
-Plus under `Events/`: one file per event (e.g., `FusionXxxOnChanged.cs`, `FusionXxxOnFiltering.cs`). The number of event files varies by component.
-
-Note: Gather extensions (`Include<FusionXxx, TModel>`) live in the core project (`GatherExtensions.cs`), not in the component directory.
-
-Copy each file, rename class/type names. Do not invent structure.
-
-### ComponentRegistration (Critical — Inside HtmlExtensions)
-
-The `FusionXxxHtmlExtensions.cs` factory method MUST call `AddToComponentsMap` to register the component with the plan. Without this, the runtime cannot find or gather from the component. Template from `FusionAutoCompleteHtmlExtensions.cs`:
-
-```csharp
-public static void FusionXxx<TModel, TProp>(
-    this InputBoundField<TModel, TProp> setup,
-    Action<XxxBuilder> build)
-    where TModel : class
-{
-    setup.Plan.AddToComponentsMap(setup.BindingPath, new ComponentRegistration(
-        setup.ElementId, Component.Vendor, setup.BindingPath, Component.ReadExpr, "xxx",
-        CoercionTypes.InferFromType(typeof(TProp))));
-
-    var builder = setup.Helper.EJS().XxxFor(setup.Expression)
-        .HtmlAttributes(new Dictionary<string, object> { ["id"] = setup.ElementId, ["name"] = setup.BindingPath });
-    build(builder);
-    setup.Render(builder.Render());
-}
-```
-
-Parameters: `elementId`, `vendor` (from `Component.Vendor`), `bindingPath`, `readExpr` (from `Component.ReadExpr`), `componentType` string (SF component name, lowercase), `CoercionTypes.InferFromType(typeof(TProp))`.
-
-### Event Naming Convention
-
-Three distinct names per event follow different conventions:
-- **Property name** on the events class: past tense (e.g. `Changed`, `Filtering`)
-- **SF event string** in `TypedEventDescriptor`: present tense (e.g. `"change"`, `"filtering"`)
-- **Args class name**: uses the SF event string style, not the property name (e.g. `FusionAutoCompleteChangeArgs`, NOT `FusionAutoCompleteChangedArgs`)
-
-## What Does NOT Change
-
-When onboarding any component, event, method, or prop — **NONE of these change:**
-- TS runtime (trigger.ts, commands.ts, element.ts, gather.ts)
-- JSON schema (reactive-plan.schema.json)
-- TS types (types/*.ts)
-- Core descriptors (Alis.Reactive project)
-
-**If you find yourself modifying any of these, STOP — you're doing it wrong.**
-
-## Mistakes to Avoid
-
-| Mistake | Why It's Wrong | Correct |
-|---|---|---|
-| Using `Static("p", args.Text)` for event args | Resolves at C# compile time → always `""` | `FromEvent(args, x => x.Text, "p")` |
-| Using `SetDataSource` for filtering events | SF's filtering lifecycle closes before async HTTP completes | `args.UpdateData(s, json, path)` |
-| Calling `DataBind` after `updateData` | `updateData` handles everything internally | Only use `DataBind` after `SetDataSource` in cascade/Changed patterns |
-| Forgetting `PreventDefault` on filtering | SF flashes "No records found" during async HTTP | Call `args.PreventDefault(p)` first |
-| Putting args extensions on a builder class | Creates indirection, loses compile-time type safety | Extensions go directly on the args class |
-| Creating new `EventArgsRef` type | Dead pattern — was tried and removed | Args type IS the API surface |
-| Modifying TS runtime for new component | Breaks architecture — plan carries all behavior | Zero runtime changes, always |
-| Onboarding without browser experiment | SF docs can be misleading — APIs may not work as described | Always verify with JS in browser first |
-| Recreating existing files | Duplicates code, causes conflicts | Check existing files first, add to them |
-| Using `ej2.showSpinner()`/`hideSpinner()` on dropdown components | SF spinner is a standalone utility from ej2-popups, not built into dropdown inputs | Use DOM elements for loading indicators |
-| Using `ej2.refresh()` during typing | Causes focus loss | Omit — document why in comments |
-| Forgetting `AllowFiltering(true)` on MultiSelect/DropDownList | SF AutoComplete has filtering built-in, but MultiSelect/DDL do not — event never fires | Add `.AllowFiltering(true)` in the view builder chain |
-| Typing into `#{ComponentId}` for MultiSelect filtering tests | SF MultiSelect filter input is a sibling `input.e-dropdownbase`, not the component input | Use `Locator("xpath=preceding-sibling::input[contains(@class,'e-dropdownbase')]")` |
-| Missing sandbox model/controller/view for new event | Playwright tests need a working demo page with HTTP endpoints and status elements | Create the full sandbox vertical slice: model property + item/response classes, controller endpoint, view section |
-
-## Step 5: Tests
-
-Every onboarded component/event needs tests at the layers it touches.
-
-### Playwright Tests (Always Required)
-
-See `references/playwright-patterns.md` for DOM structure details and test templates.
-
-### C# Unit Tests (If Adding New Descriptor Patterns)
-
-Only needed when adding a pattern that doesn't exist yet. If you're just adding methods/events using existing mechanisms (SetPropMutation, CallMutation, MutateEventCommand, EventGather), the existing tests already cover the serialization.
-
-### Sandbox Demo (Always Required — Full Vertical Slice)
-
-See `references/sandbox-templates.md` for complete model, controller, and view templates.
-
-### Run All Tests Before Done
-
-```bash
-npm test                                                    # TS unit tests
-dotnet test tests/Alis.Reactive.UnitTests                   # Core C# tests
-dotnet test tests/Alis.Reactive.Fusion.UnitTests             # Fusion tests
-dotnet test tests/Alis.Reactive.PlaywrightTests              # Browser tests
-```
+## Operating Rule
+
+Do not onboard from memory, docs alone, or inferred API names. The source of truth is Syncfusion's shipped JS source plus a running raw HTML probe that instantiates the object, calls the exact API, captures event payloads, and records method return behavior.
+
+The Syncfusion MVC builder remains the configuration surface for initial render. Do not duplicate builder-covered static properties in the reactive DSL unless they must be read or mutated after render. The Fusion slice adds typed runtime behavior: post-render property reads/writes, method calls, method return sources, and event-to-plan wiring.
+
+The public DSL remains typed. Internal plan member names may be strings; developer-facing APIs must not expose arbitrary member strings except plugin escape hatches.
+
+Loose typing in Syncfusion contracts is not permission to add loose typing in Alis. Public shapes such as `object`, `Record<string, any>`, or broad event args are candidate evidence only. The onboarding decision must narrow them through JS source and an HTML execution trace before exposing a typed C# API. If a member cannot be narrowed and proven, keep it out of the public Fusion slice.
+
+## Workflow
+
+1. **Pick the exact Syncfusion object**
+   - Identify package, global namespace, class name, styles, and required scripts.
+   - Example: `@syncfusion/ej2-interactive-chat` -> `ej.interactivechat.AIAssistView`.
+   - If Syncfusion ships an official ASP.NET Core agent skill for the component, use it as a documentation accelerator only. It can suggest setup and builder usage, but it does not replace JS source, builder coverage, raw probe, or Playwright proof.
+   - If any source path is unknown, read [Source discovery](references/source-discovery.md) and run the discovery helper before continuing:
+     ```bash
+     node .claude/skills/onboard-fusion-component/scripts/discover-syncfusion-component.mjs --class ChipList
+     ```
+
+2. **Generate the source-grounded surface matrix**
+   - Prefer the helper before designing the slice:
+     ```bash
+     node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-surface.mjs \
+       --class AIAssistView \
+       --dts node_modules/@syncfusion/ej2-interactive-chat/src/ai-assistview/ai-assistview.d.ts \
+       --xml ~/.nuget/packages/syncfusion.ej2.aspnet.core/32.2.8/lib/netstandard2.0/Syncfusion.EJ2.xml
+     ```
+   - Treat the output as a candidate matrix. The final decision still depends on runtime need and browser proof.
+
+3. **Use Blazor metadata as a typed candidate map**
+   - When Syncfusion ships a matching Blazor package, inspect its XML and IL with ILSpy before finalizing C# names:
+     ```bash
+     node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-blazor-metadata.mjs \
+       --package Syncfusion.Blazor.Kanban \
+       --version 32.2.8 \
+       --component Kanban \
+       --decompiled /tmp/alis-syncfusion-blazor-kanban/decompiled/Syncfusion.Blazor.Kanban.SfKanban`1.decompiled.cs
+     ```
+   - Blazor often reveals the clean C# vocabulary for methods and event payloads. It is not the final runtime contract for Alis.
+   - Classify every Blazor candidate as direct EJ2 overlap, bridge-computed browser behavior, or Blazor-owned state behavior. Direct overlap can become a normal Fusion API after raw HTML proof. Bridge-computed behavior can become a Fusion API only through an explicit Alis bridge that reproduces the same browser facts and is proven in raw HTML/Playwright. Blazor-owned state behavior stays out of Fusion unless Alis intentionally owns the same state concept.
+   - Read [Blazor metadata](references/blazor-metadata.md) before using ILSpy output to shape a component slice.
+
+4. **Create a raw HTML probe**
+   - Prefer the helper:
+     ```bash
+     node .claude/skills/onboard-fusion-component/scripts/create-fusion-probe.mjs \
+       --component ai-assistview \
+       --namespace interactivechat \
+       --class AIAssistView \
+       --id ai-assist
+     ```
+   - Open the generated `/sf-ai-assistview-probe.html` in the sandbox.
+   - See [HTML probe and API trace](references/html-probe-api-trace.md).
+   - Record where the Syncfusion instance is actually stored. Most components keep
+     `ej2_instances` on the rendered host. Target-attached components such as
+     Mention can use a disposable MVC host while the stable runtime join key must
+     stay elsewhere. If the MVC host can disappear, add a component-slice bridge
+     that preserves the exact Syncfusion root under the developer-facing component id
+     before reactive boot.
+
+5. **Trace the API before C#**
+   - Build a matrix with one row per member:
+     `JS expression -> member kind -> builder coverage -> args -> return -> event payload -> visual/runtime proof -> typed C# API`.
+   - A row is not accepted until the HTML page proves the behavior.
+   - Syncfusion public d.ts contracts often use loose shapes such as
+     `Record<string, any>` or broad event arg objects. Do not copy that looseness
+     into Alis. Use the HTML probe to execute the member, print the actual
+     payload/return shape, and record the trace that justifies the typed C# shape.
+   - Accept public JS API first. Inspector output may include hidden/internal members; skip those unless there is no public API for the real behavior and the exception is explicitly documented in the matrix.
+   - Prove property reads and writes separately. A readable Syncfusion property is not automatically a valid reactive write API for every builder configuration.
+   - If a property write requires a public flush method such as `dataBind()`, capture that in the matrix and encapsulate it in the typed Fusion API. Do not expose a write method when the raw browser proof is not stable.
+   - For each `EmitType<TArgs>` event selected, read [Event payload contracts](references/event-payload-contracts.md), inspect `TArgs`, and prove payload properties, writable properties, and methods in raw HTML:
+     ```bash
+     node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-event-payload.mjs --type FilteringEventArgs
+     ```
+   - If a payload property is an array, keep it typed as `List<T>`/typed array in the C# event contract. Prove it either through a typed indexed read (`args => args.Data[0].Summary`) or a whole-array gather into a real HTTP workflow. Do not add untyped element accessors to component slices. If the app needs dynamic array projection/filtering/reduction beyond the typed member path, use a plugin escape hatch.
+
+6. **Apply the builder coverage gate**
+   - Keep initial render options on `Syncfusion.EJ2.*Builder`.
+   - Onboard only runtime gaps: methods, method-return reads, event payload access, event arg mutation/calls, and properties that reactive plans need to read/write after render.
+   - If a member is only static configuration and the builder already exposes it, do not add a Fusion reactive extension for it.
+
+7. **Map traced API to the current model**
+   - JS property read: `ComponentProperty<T>.Named/Mapped(...)` + `self.Read(property)`.
+   - JS property write: `ComponentProperty<T>` + `self.EmitSet(property, ValueExpression...)`.
+   - JS void method: `ComponentMethod.Named/Mapped(...).WithArgs<...>()` + `self.EmitCall(method, args)`.
+   - JS method returning value: `ComponentMethod...` + `self.Read<TReturn>(method, args)`.
+   - JS event/callback: `TypedEvent<TArgs>` + `ComponentEventOnboarding.Wire(...)`.
+   - Event arg mutation/call: emit `ReactionGraph.Set/Call` on `PayloadSource.Event()`.
+   - JS overloaded methods: use distinct typed C# methods and distinct plan member names mapped to the same JS path, so contract merge remains deterministic.
+
+8. **Implement the vertical slice**
+   - Keep files under `Alis.Reactive.Fusion/Components/FusionXxx/`.
+   - Preserve the component isolation pattern:
+     `FusionXxx.cs`, `FusionXxxBuilder.cs`, `FusionXxxHtmlExtensions.cs`, `FusionXxxExtensions.cs`, `FusionXxxEvents.cs`, `FusionXxxReactiveExtensions.cs`, `Events/*`.
+   - Input components implement the input registration pattern. App/display components do not register form bindings.
+   - If Syncfusion ships no MVC builder, a Fusion slice may own a typed render helper.
+     Keep that helper typed and bounded to real options, endpoints, and event payloads;
+     do not expose raw JavaScript strings/functions as a public configuration surface.
+
+9. **Prove through sandbox and Playwright**
+   - Add a real sandbox view using the typed API.
+   - For stateful components, make the sandbox HTTP-backed and SQLite-backed by default. Use normal verbs (`POST`, `PUT`, `DELETE`) and prove reload after create/update/delete/move so the test covers a real app workflow. Use in-memory storage only for throwaway probes, not for final onboarding proof.
+   - Write behavior tests against visible behavior and trace output, not internal plan JSON shortcuts.
+   - Prove every onboarded member. If a typed method/property/event is added, it gets a sandbox behavior and a Playwright assertion.
+   - When a member is a value source for gather, conditions, or HTTP, prove at least one consumer path. A displayed raw value is useful, but a source is not fully onboarded until a realistic pipeline consumes it.
+   - After changing sandbox views/controllers/component slices, run Playwright once with
+     build enabled so the SandboxApp assembly is recopied to the test output. Use
+     `--no-build` only for repeat runs after that rebuilt output is known current.
+   - Before closing the slice, run through [Automation gates](references/automation-gates.md).
+
+## Capability Matrix
+
+| JS Object API | Supported | Current Pattern |
+|---|---:|---|
+| `ej2.prop` read | Yes, when reactive state source is needed | `self.Read(ComponentProperty<T>)` |
+| `ej2.prop = value` | Yes, when post-render mutation is needed | `self.EmitSet(ComponentProperty<T>, ValueExpression)` |
+| `ej2.method()` | Yes | `self.EmitCall(ComponentMethod)` |
+| `ej2.method(arg1, arg2, arg3)` | Yes | `ComponentMethod.WithArgs<T1,T2,T3>()` + `EmitCall` |
+| `ej2.method(...) -> value` | Yes | `self.Read<TReturn>(ComponentMethod, args)` |
+| `eventArgs.prop` read | Yes | typed event args + `FromEvent` / conditions |
+| `eventArgs.array[index].prop` read | Yes | typed event args with `List<T>` and expression index path |
+| `eventArgs.prop = value` | Yes | `ReactionGraph.Set(PayloadSource.Event(), ...)` |
+| `eventArgs.method(args)` | Yes | `ReactionGraph.Call(PayloadSource.Event(), ...)` |
+| builder-only static option | No | keep on Syncfusion MVC builder |
+| arbitrary untyped member access in public DSL | No | onboard typed API or use plugin intentionally |
+
+## Do / Do Not
+
+| Do | Do Not |
+|---|---|
+| Start with raw HTML and real browser traces | Start by copying docs into C# |
+| Read shipped JS source and d.ts files | Infer from builder names alone |
+| Use Blazor XML/ILSpy to find clean C# vocabulary | Treat Blazor bridge-only fields as direct EJ2 payloads |
+| Use official Syncfusion skills as extra context | Treat generated examples as source of truth |
+| Run the surface inspector before hand-designing APIs | Build a prose-only inventory |
+| Exclude builder-covered static configuration | Rewrap the MVC builder as reactive methods |
+| Keep a trace matrix beside the work while designing | Rely on old unit tests or plan JSON assertions |
+| Use exact Syncfusion runtime names for object paths | Invent friendlier JS member names without mapping |
+| Expose typed C# methods/properties/events | Add `string methodName` APIs to component slices |
+| Add only proven members | Onboard a broad component surface blindly |
+| Prefer public JS members from source/prototype traces | Promote hidden/internal Syncfusion members found by the inspector |
+| Trace event payload methods inside the live event lifecycle | Assume payload methods work because d.ts lists them |
+| Keep runtime vendor-neutral | Add Syncfusion checks to execution/gather/conditions |
+| Preserve sync behavior for normal component actions | Turn sync component calls into async work |
+
+## Reference Files
+
+- `Alis.Reactive.Fusion/Components/FusionSchedule/FusionScheduleExtensions.cs` - method return source and multi-arg method examples.
+- `Alis.Reactive.Fusion/Components/FusionAccordion/FusionAccordionExtensions.cs` - two-arg component method call.
+- `Alis.Reactive.Fusion/Components/FusionTooltip/` - non-input display component slice.
+- `Alis.Reactive.Fusion/Components/FusionAutoComplete/` - input component with filtering event behavior.
+- `Alis.Reactive/ComponentRef.cs` - `EmitSet`, `EmitCall`, and `Read<T>` domain entry points.
+- `Alis.Reactive.Assets/runtime/domain/runtime-object.ts` - vendor-neutral property/method execution.
+- `scripts/inspect-syncfusion-surface.mjs` - extracts JS surface plus MVC builder coverage.
+- `scripts/inspect-syncfusion-blazor-metadata.mjs` - extracts Blazor typed metadata and ILSpy bridge clues from a local NuGet package.
+- `scripts/inspect-syncfusion-event-payload.mjs` - extracts event payload properties/methods from Syncfusion d.ts files.
+- `scripts/discover-syncfusion-component.mjs` - finds class package, d.ts, JS source, MVC builder, and next commands.
+- `scripts/create-fusion-probe.mjs` - creates a temporary raw HTML probe.
+- `references/source-discovery.md` - deterministic source-finding workflow.
+- `references/blazor-metadata.md` - how to use Blazor packages as typed candidate maps without copying bridge-only behavior.
+- `references/event-payload-contracts.md` - event payload property/method tracing and C# mapping.
+- `references/automation-gates.md` - done criteria for a fully onboarded member/component.

--- a/.claude/skills/onboard-fusion-component/references/automation-gates.md
+++ b/.claude/skills/onboard-fusion-component/references/automation-gates.md
@@ -1,0 +1,125 @@
+# Automation Gates
+
+Use this as the final checklist before saying a Syncfusion component or member is onboarded.
+
+## Gate 1: Source Facts
+
+| Required | Evidence |
+|---|---|
+| d.ts class found | `discover-syncfusion-component.mjs` output |
+| JS source found/read | exact `node_modules/@syncfusion/.../*.js` path |
+| MVC builder coverage known | Syncfusion XML builder member list |
+| raw global constructor known | `new ej.{namespace}.{ClassName}` works |
+| instance host known | `ej2_instances[0]` location recorded |
+| browser data casing known | rendered JSON shape matches builder field names |
+
+## Gate 2: Surface Matrix
+
+Run:
+
+```bash
+node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-surface.mjs \
+  --class {ClassName} \
+  --dts {path-to-class.d.ts} \
+  --xml ~/.nuget/packages/syncfusion.ej2.aspnet.core/32.2.8/lib/netstandard2.0/Syncfusion.EJ2.xml
+```
+
+Then classify each row:
+
+| Decision | Meaning |
+|---|---|
+| builder-owned | keep on MVC builder |
+| runtime property source | typed `Read` source, prove consumer |
+| runtime property write | typed setter, prove DOM/runtime effect |
+| runtime method | typed method, prove effect |
+| method return source | typed source, prove consumer |
+| event payload read | typed event arg property, prove in sandbox |
+| event payload mutation/call | typed event arg extension, prove effect |
+| skip | hidden/internal/lifecycle-only or no proven use |
+
+## Gate 3: Event Payload Matrix
+
+For every event selected from `EmitType<TArgs>`:
+
+```bash
+node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-event-payload.mjs \
+  --type {TArgs}
+```
+
+Then prove payload properties/methods in raw HTML. Event payload contracts are not complete until method calls and writable properties have visible proof.
+
+For payloads whose shape varies by gesture, capture every gesture the typed event claims to support. Grid `dataStateChange` is the reference case: sorting, paging, filtering, searching, and grouping can produce different nested payload shapes. A single payload sample is not enough.
+
+## Gate 4: Typed Slice
+
+| File | Required When |
+|---|---|
+| `FusionXxx.cs` | every component |
+| `FusionXxxHtmlExtensions.cs` | MVC builder wrapper or typed render helper |
+| `FusionXxxBuilder.cs` | non-standard builder return shape |
+| `FusionXxxExtensions.cs` | post-render component members |
+| `FusionXxxEvents.cs` | event selectors |
+| `Events/FusionXxxOn*.cs` | typed payload and event-arg extensions |
+| sandbox controller/model/view | every onboarded behavior |
+| Playwright tests | every onboarded behavior |
+
+No core runtime/DSL changes are allowed during component onboarding unless the current plan model cannot represent a source-proven JS object behavior.
+
+Typed Syncfusion templates are part of the component proof when the component's
+normal app usage depends on templated content. Use `FusionTemplate.Create<T>()`
+and prove the rendered template in Playwright instead of raw template strings.
+
+## Gate 5: Runtime Consumer Proof
+
+| Onboarded Member | Consumer Proof |
+|---|---|
+| property source | `SetText`, condition, gather, or HTTP payload |
+| method return source | `SetText`, condition, gather, or HTTP payload |
+| void method | visible DOM/component state change |
+| property write | visible DOM/component state change |
+| event payload property | visible text or HTTP payload from `FromEvent` |
+| event payload method | visible popup/data/component behavior |
+
+## Gate 6: Stateful App Proof
+
+If the component normally edits or moves domain data, prove it against an
+in-memory HTTP-backed sandbox instead of only local button mutations.
+
+| Behavior | Required Proof |
+|---|---|
+| create | `POST` endpoint mutates server state, component updates, reload preserves it |
+| update | `PUT` endpoint mutates server state, component updates, reload preserves it |
+| delete | `DELETE` endpoint mutates server state, component updates, reload preserves it |
+| move/reorder | drag/drop or reorder event gathers typed payload, HTTP persists, reload preserves it |
+| event-driven persistence | event payload goes through `FromEvent` into HTTP, not manual JS |
+
+This gate is mandatory for boards, grids, schedulers, lists, tree views, and
+other components where the normal user workflow changes data.
+
+## Gate 7: Build and Test
+
+Run build-enabled Playwright once after C#/sandbox changes:
+
+```bash
+dotnet test tests/Alis.Reactive.PlaywrightTests/Alis.Reactive.PlaywrightTests.csproj \
+  --filter "FullyQualifiedName~WhenUsingFusion{ComponentName}" \
+  --logger "console;verbosity=normal"
+```
+
+Then verify the running sandbox URL manually or with browser automation:
+
+```text
+http://localhost:5220/Sandbox/Components/{ComponentName}
+```
+
+## Done Means Done
+
+A member is not onboarded when only one of these is true:
+
+| Not Enough | Missing |
+|---|---|
+| d.ts says it exists | browser proof |
+| raw HTML works | typed Fusion API |
+| typed API compiles | sandbox behavior |
+| sandbox displays raw value | realistic consumer proof |
+| one Playwright assertion passes | all onboarded members proved |

--- a/.claude/skills/onboard-fusion-component/references/blazor-metadata.md
+++ b/.claude/skills/onboard-fusion-component/references/blazor-metadata.md
@@ -1,0 +1,87 @@
+# Blazor Metadata
+
+Use Syncfusion Blazor packages as a typed candidate map, not as the Alis runtime contract.
+
+## Why It Helps
+
+Blazor has already mapped many Syncfusion concepts into C# names:
+
+| Blazor Signal | Use In Alis |
+|---|---|
+| public `SfXxx<T>` methods | C# naming and overload candidates |
+| `EventArgs<T>` properties | candidate event payload vocabulary |
+| XML docs | quick navigation to related concepts |
+| decompiled `ClientPropertyChangeHandler` | property-change names sent to JS |
+| decompiled `sfBlazor.*` calls | bridge boundary and Blazor-owned behavior |
+
+## Acceptance Rule
+
+Classify each Blazor candidate before exposing a Fusion API:
+
+| Classification | Required Proof | Fusion Decision |
+|---|---|
+| Direct EJ2 overlap | EJ2 source/d.ts exposes the same member and raw HTML trace proves the exact value, args, return, or mutation | normal typed Fusion API |
+| Bridge-computed browser behavior | Blazor JS bridge derives the value from DOM/EJ2/browser facts, and an Alis bridge can reproduce the same facts in raw HTML/Playwright | explicit typed Fusion API backed by an Alis bridge |
+| Blazor-owned state behavior | Blazor C# state or lifecycle creates the value and direct browser facts are insufficient | keep out unless Alis intentionally owns the same state concept |
+
+Do not treat `sfBlazor.*` as a rejection by itself. Treat it as a boundary that must be classified. The question is whether the behavior is direct EJ2, bridge-computed from browser facts, or Blazor-owned state.
+
+## Kanban Example
+
+| Candidate | Blazor Evidence | EJ2/Trace Result | Fusion Decision |
+|---|---|---|---|
+| `dataBinding.Result` | `DataBindingEventArgs<T>.Result` | direct EJ2 `ReturnType.result`; trace posts two typed cards | onboard typed `Result` |
+| `dataBinding.Count` | `DataBindingEventArgs<T>.Count` | direct EJ2 local data bind reports `count:0` while `result.length:2` | onboard `Count`, test actual EJ2 value |
+| `queryCellInfo.Data/RequestType` | `QueryCellInfoEventArgs<T>` | direct EJ2 creates `{ data, requestType }` for header/swimlane/content rows | onboard typed header args |
+| `dragStart/drag/dragStop.Data` | Blazor maps card ids to typed data | direct EJ2 trace exposes `data[]` | onboard direct typed `List<TCard>` payload |
+| `dragStop.DropIndex` / Blazor `DragIndex` | Blazor bridge computes DOM drop index as `index`; EJ2 computes `dropIndex` | direct EJ2 trace exposes `dropIndex` on `dragStop` | onboard direct `DropIndex`; consider `DragIndex` only as a C# alias if needed |
+| `dragStart.Left/Top` | Blazor bridge reads pointer coordinates and passes them to C# | direct EJ2 trace exposes `event`, not `left/top` fields | bridge-computed; onboard only if an Alis bridge intentionally exposes pointer coordinates |
+| `dragStop.IsExternal` | Blazor bridge derives external drop state from DOM/drag target | direct EJ2 public payload does not expose `isExternal` | bridge-computed; onboard only with an explicit Alis external-drop bridge |
+| `dragStop.PreviousCardData` | Blazor bridge finds previous card id, then C# maps id to data | direct EJ2 public payload does not expose previous card data | bridge-computed plus Blazor state; prefer `dropIndex` unless Alis owns a bridge |
+| `AddCardAsync/UpdateCardAsync/DeleteCardAsync` | Blazor mutates C# data then coordinates CRUD | direct EJ2 has `addCard/updateCard/deleteCard` methods | onboard direct EJ2 methods, not Blazor state machinery |
+
+Raw HTML Kanban drag trace from the running sandbox confirmed direct EJ2 payload keys:
+
+| Event | Direct EJ2 payload keys |
+|---|---|
+| `dragStart` | `cancel`, `data`, `element`, `event` |
+| `drag` | `data`, `element`, `event` |
+| `dragStop` | `cancel`, `data`, `dropIndex`, `element`, `event` |
+
+## Commands
+
+Install or restore the package first, then inspect XML and IL:
+
+```bash
+dotnet new classlib -o /tmp/sf-blazor-probe
+dotnet add /tmp/sf-blazor-probe package Syncfusion.Blazor.Kanban --version 32.2.8
+ilspycmd -t Syncfusion.Blazor.Kanban.SfKanban`1 \
+  -o /tmp/sf-blazor-kanban-decompiled \
+  ~/.nuget/packages/syncfusion.blazor.kanban/32.2.8/lib/netstandard2.0/Syncfusion.Blazor.Kanban.dll
+node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-blazor-metadata.mjs \
+  --package Syncfusion.Blazor.Kanban \
+  --version 32.2.8 \
+  --component Kanban \
+  --decompiled /tmp/sf-blazor-kanban-decompiled/Syncfusion.Blazor.Kanban.SfKanban`1.decompiled.cs
+```
+
+If the package is downloaded to a temporary location instead of the global NuGet
+cache, pass its package root directly:
+
+```bash
+node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-blazor-metadata.mjs \
+  --package Syncfusion.Blazor.Kanban \
+  --version 32.2.8 \
+  --component Kanban \
+  --package-root /tmp/alis-syncfusion-blazor-kanban/pkg \
+  --decompiled /tmp/alis-syncfusion-blazor-kanban/decompiled/Syncfusion.Blazor.Kanban.SfKanban`1.decompiled.cs
+```
+
+## Red Flags
+
+| Signal | Meaning |
+|---|---|
+| `sfBlazor.Component.*` only | likely Blazor bridge behavior, not direct EJ2 |
+| method mutates Blazor C# collections before JS | use naming only; prove direct EJ2 method separately |
+| payload field appears only in Blazor event args | do not expose until HTML trace proves it |
+| XML type is broad or missing nested shape | use EJ2 source and trace to narrow |

--- a/.claude/skills/onboard-fusion-component/references/event-payload-contracts.md
+++ b/.claude/skills/onboard-fusion-component/references/event-payload-contracts.md
@@ -1,0 +1,182 @@
+# Event Payload Contracts
+
+Use this before adding any `FusionXxxEvents` or `Events/FusionXxxOn*.cs` type.
+
+Event payloads are separate JS objects. They can have readable properties, writable properties, and callable methods. Treat them like component objects, but with `PayloadSource.Event()` as the runtime root.
+
+## Required Matrix
+
+| Event | Trigger Gesture | Payload Type From d.ts | Raw Keys | Methods | Mutations/Calls Proved | Typed C# Shape |
+|---|---|---|---|---|---|---|
+| `filtering` | type in popup input | `FilteringEventArgs` | `text`, `preventDefaultAction`, `updateData` | `updateData` | set `preventDefaultAction`; call `updateData(data)` | args props + extensions |
+| `popupOpen` | click schedule cell/event | `PopupOpenEventArgs` | `type`, `data`, `cancel` | none | set `cancel` prevents popup | args props + `PreventDefault` |
+| `dataStateChange` | grid sort/page/filter | `DataStateChangeEventArgs` | `skip`, `take`, `sorted`, `action` | maybe none | read full state and post to server | nested state types |
+
+Do not use this table as source truth. Fill it from the component being onboarded.
+
+## Inspect d.ts Payload Type
+
+Start with the event row from the component surface, for example:
+
+```ts
+filtering: EmitType<FilteringEventArgs>;
+```
+
+Then inspect the payload type:
+
+```bash
+node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-event-payload.mjs \
+  --type FilteringEventArgs
+```
+
+If the type is imported from another Syncfusion package, run without `--dts` so the script searches all Syncfusion d.ts files.
+
+## Raw Browser Proof
+
+Wire the event in the raw probe constructor, not after render, unless Syncfusion source proves late assignment works.
+
+```javascript
+const ej2 = new ej.dropdowns.AutoComplete({
+  filtering: args => {
+    window.__lastArgs = args;
+    probe.event("filtering payload", args);
+  }
+});
+```
+
+For payload methods, call the method inside the real event lifecycle and verify the visible effect:
+
+```javascript
+filtering: args => {
+  args.preventDefaultAction = true;
+  probe.eventCall("filtering.updateData", args, "updateData", () =>
+    args.updateData([{ text: "Aspirin", value: "rx-aspirin" }])
+  );
+}
+```
+
+For writable properties, mutate the payload inside the event and verify the outcome:
+
+```javascript
+popupOpen: args => {
+  args.cancel = true;
+  probe.event("popupOpen cancelled", args);
+}
+```
+
+## C# Mapping
+
+| Proven JS Payload Behavior | C# Pattern |
+|---|---|
+| `args.text` read | property on event args type |
+| `args.action.requestType` read | nested event args type |
+| `args.cancel = true` | extension method emitting `ReactionGraph.Set(PayloadSource.Event(), "cancel", ...)` |
+| `args.preventDefaultAction = true` | extension method emitting `ReactionGraph.Set(PayloadSource.Event(), "preventDefaultAction", ...)` |
+| `args.updateData(data)` | extension method emitting `ReactionGraph.Call(PayloadSource.Event(), "updateData", ...)` |
+
+Use event-arg extension methods for payload mutations/calls. Do not put arbitrary public strings in the DSL.
+
+## Proof Gates
+
+Each event payload member needs a consumer proof:
+
+| Member Kind | Minimum Proof |
+|---|---|
+| readable scalar | displayed in sandbox or sent via gather |
+| readable object | nested property displayed or posted to server |
+| readable typed array | typed indexed member displayed, or whole typed array posted to server |
+| writable property | visible behavior changes because of the mutation |
+| callable method | visible behavior changes because the method ran |
+
+Array payloads are not a reason to expose loose public APIs. Model the array as
+`List<T>` in the event args and prove the actual member path (`Data[0].Summary`,
+`Result[0].Name`, etc.) or prove the whole array as a gather source. Dynamic
+array transforms belong in plugin code because plugin is the intentional escape
+hatch for behavior that is difficult to express as deterministic typed member
+paths.
+
+Examples:
+
+| Component | Event | Payload Behavior | Proof |
+|---|---|---|---|
+| AutoComplete/MultiSelect | `filtering` | `preventDefaultAction`, `updateData(data)` | server-filtered popup shows returned rows |
+| Schedule | `popupOpen` | `cancel` | Syncfusion editor/quick-info does not open; custom drawer/dialog opens |
+| Grid | `dataStateChange` | `skip`, `take`, `sorted`, `action.*` | server receives full state and grid refreshes |
+
+If a payload method exists in d.ts but cannot be made to produce a visible/runtime effect in raw HTML, do not onboard it.
+
+## Concrete Proof Recipes
+
+### Dropdown Filtering Payload With `updateData`
+
+This proves a payload method, not a component method.
+
+```javascript
+const rows = [
+  { text: "Aspirin", value: "rx-aspirin" },
+  { text: "Metformin", value: "rx-metformin" }
+];
+
+const ej2 = new ej.dropdowns.AutoComplete({
+  fields: { text: "text", value: "value" },
+  filtering: args => {
+    probe.event("filtering payload", args);
+    args.preventDefaultAction = true;
+    probe.eventCall("filtering.updateData", args, "updateData", () =>
+      args.updateData(rows)
+    );
+  }
+});
+```
+
+Required visible proof: typing opens the popup and shows `Aspirin`/`Metformin`.
+
+### Schedule Popup Payload With `cancel`
+
+This proves a writable payload property.
+
+```javascript
+const ej2 = new ej.schedule.Schedule({
+  selectedDate: new Date(2026, 4, 29),
+  eventSettings: { dataSource: [{ Id: 1, Subject: "Shift", StartTime: new Date(2026, 4, 29, 9), EndTime: new Date(2026, 4, 29, 10) }] },
+  popupOpen: args => {
+    probe.event("popupOpen payload", args);
+    if (args.type === "Editor") {
+      args.cancel = true;
+      probe.event("popupOpen cancelled", args);
+    }
+  }
+});
+```
+
+Required visible proof: the built-in editor does not open when the edit gesture is performed. If the Fusion slice opens a custom drawer/dialog, Playwright must assert that replacement UI.
+
+### Grid Data State Payload
+
+This proves nested event payload shape under real gestures.
+
+```javascript
+const ej2 = new ej.grids.Grid({
+  allowSorting: true,
+  allowPaging: true,
+  pageSettings: { pageSize: 10 },
+  dataSource: { result: rows, count: rows.length },
+  dataStateChange: args => {
+    probe.event("dataStateChange payload", args);
+  },
+  columns: [
+    { field: "name", headerText: "Name" },
+    { field: "age", headerText: "Age" }
+  ]
+});
+```
+
+Required gestures and proof:
+
+| Gesture | Expected Payload |
+|---|---|
+| click sortable header | `action.requestType`, `action.columnName`, `action.direction`, `sorted[]` |
+| click next page | `skip`, `take`, `action.currentPage`, `action.requestType` |
+| apply filter/search when enabled | `where[]` or `search[]` plus full state |
+
+Do not model only the first payload sample. Capture each gesture that the typed API claims to support because Syncfusion payload shape changes by action.

--- a/.claude/skills/onboard-fusion-component/references/html-probe-api-trace.md
+++ b/.claude/skills/onboard-fusion-component/references/html-probe-api-trace.md
@@ -1,0 +1,227 @@
+# HTML Probe And API Trace
+
+## Purpose
+
+The raw HTML probe answers what to onboard. It must prove the Syncfusion JS object shape before any C# vertical slice is written.
+
+For Fusion components, the question is not "what exists on the component?" The question is "what runtime behavior is missing after the Syncfusion MVC builder has already configured initial render?"
+
+The expected output is an API trace matrix in the HTML page, not a prose summary hidden in chat.
+
+## Probe Checklist
+
+1. Load the same vendor assets used by the sandbox:
+   - `/vendor/syncfusion/material.css`
+   - `/vendor/syncfusion/dist/ej2.min.js`
+2. Instantiate the exact object:
+   - `new ej.{namespace}.{ClassName}(options).appendTo("#{id}")`
+3. Expose the instance:
+   - `window.__sfProbe.ej2`
+4. Read the shipped JS source and d.ts for the exact class.
+5. Compare against the Syncfusion MVC builder surface.
+6. Trace:
+   - property reads
+   - property writes
+   - method existence
+   - method calls with exact arguments
+   - method return values
+   - event payload shape
+   - event payload writable properties
+   - event payload methods and their visible/runtime effect
+   - visible DOM effect
+7. Record one row per candidate member.
+8. Render the trace matrix in the HTML page.
+9. Onboard only proven rows that are runtime gaps, not builder-only static options.
+
+## Trace Matrix
+
+| JS Expression | Kind | Builder Coverage | Args | Return | Event Payload | Proof | C# API |
+|---|---|---|---|---|---|---|---|
+| `ej2.prompt` | property read/write | builder sets initial `Prompt(...)`; runtime read/write still useful | none | `string` | n/a | value appears in footer | `Prompt()` / `SetPrompt(...)` |
+| `ej2.executePrompt("hello")` | method call | not builder-covered | `string` | `void` | `promptRequest.prompt` | event fires, prompt rendered | `ExecutePrompt("hello")` |
+| `ej2.addPromptResponse("ok", true)` | method call | not builder-covered | `string`, `bool` | `void` | n/a | response rendered | `AddPromptResponse(...)` |
+| `ej2.getEvents()` | method read | not builder-covered | none | array | n/a | returned array count logged | `GetEvents()` |
+| `ej2.selectedChips` | property read/write | builder sets initial `SelectedChips(...)`; runtime read/write still useful | `string[]` for chip values, `number[]` for index chips | selected ids/indexes | n/a | property reflects selected chips; index writes require `dataBind()` to update DOM; value writes are not stable on delete-enabled chips | `SelectedChipValues()` / `SelectedChipIndexes()` / `SetSelectedChipIndexes(...)` |
+| `ej2.select([0, 2])` | method call | not builder-covered | `number[]` | `void` | n/a | both indexed chips become active | `SelectByIndexes(...)` |
+| `ej2.remove([0, 2])` | method call | not builder-covered | `number[]` | `void` | deleted event per chip | indexed chips are removed | `RemoveByIndexes(...)` |
+
+Rows above are examples. Replace them with actual observed rows from the running component.
+
+## HTML Candidate Matrix
+
+Before C# work starts, the probe page must show a candidate table:
+
+| Column | Meaning |
+|---|---|
+| Candidate | JS property, method, event, payload member, or bridge-computed behavior |
+| Kind | prop-read, prop-write, method, method-source, event, payload-read, payload-call, bridge |
+| Builder | covered, not covered, or static-only |
+| Args | exact argument list and order |
+| Return/Payload | scalar/object/array shape proven by trace |
+| Proof | visible DOM effect, trace row, method return, or event mutation effect |
+| Proposed C# | typed Fusion member or event args shape |
+| Outcome | implement, bridge-needed, exclude, or needs-proof |
+
+Outcome rules:
+
+| Outcome | Meaning |
+|---|---|
+| `implement` | direct EJ2 behavior; implement typed Fusion API |
+| `bridge-needed` | not direct EJ2 payload, but browser facts prove an Alis bridge can own it |
+| `exclude` | builder-covered, internal-only, unstable, or unneeded |
+| `needs-proof` | promising but not yet proven enough |
+
+The implementation may include only `implement` rows and intentionally selected `bridge-needed` rows. Excluded and unproven rows stay in the matrix with the reason.
+
+## Browser Console Commands
+
+```javascript
+const probe = window.__sfProbe;
+const ej2 = probe.ej2;
+
+probe.member("prompt", () => ej2.prompt);
+probe.member("executePrompt type", () => typeof ej2.executePrompt);
+probe.call("executePrompt", () => ej2.executePrompt("hello from probe"));
+probe.call("addPromptResponse", () => ej2.addPromptResponse("probe response", true));
+probe.member("keys", () => Object.keys(ej2).sort());
+```
+
+## Event Payload Commands
+
+The generated probe exposes helpers for event args. Use these inside event handlers while the event is firing:
+
+```javascript
+const ej2 = new ej.dropdowns.AutoComplete({
+  filtering: args => {
+    probe.event("filtering", args);
+    args.preventDefaultAction = true;
+    probe.eventCall("filtering.updateData", args, "updateData", () =>
+      args.updateData([{ text: "Aspirin", value: "rx-aspirin" }])
+    );
+  }
+});
+```
+
+For schedule popup replacement:
+
+```javascript
+const ej2 = new ej.schedule.Schedule({
+  popupOpen: args => {
+    probe.event("popupOpen", args);
+    if (args.type === "Editor") {
+      args.cancel = true;
+      probe.event("popupOpen.cancelled", args);
+    }
+  }
+});
+```
+
+For grid state:
+
+```javascript
+const ej2 = new ej.grids.Grid({
+  dataStateChange: args => {
+    probe.event("dataStateChange", args);
+  }
+});
+```
+
+The payload trace must include `ownKeys`, callable function names, sampled property values, and the result of any method call being onboarded.
+
+## Event Payload Capture
+
+Wire events in the object constructor, not after-the-fact, unless the component docs prove late assignment is supported.
+
+```javascript
+const trace = [];
+
+const component = new ej.interactivechat.AIAssistView({
+  promptRequest: function (args) {
+    trace.push({
+      event: "promptRequest",
+      keys: Object.keys(args).sort(),
+      payload: JSON.parse(JSON.stringify(args, safeJson))
+    });
+    renderTrace();
+  }
+});
+```
+
+Use a safe serializer because Syncfusion event payloads often contain DOM references.
+
+```javascript
+function safeJson(key, value) {
+  if (value instanceof Element) return `[Element#${value.id || value.tagName}]`;
+  if (typeof value === "function") return "[Function]";
+  return value;
+}
+```
+
+Sanitize values before storing them in `trace`. Many Syncfusion instances contain circular object graphs; `JSON.stringify(trace, replacer)` is too late if the raw circular object is already inside `trace`.
+
+## Decision Gate
+
+Do not implement a member unless all fields are known:
+
+| Required Fact | Why |
+|---|---|
+| JS path | Needed for `ComponentProperty` / `ComponentMethod` |
+| Builder coverage | Prevents wrapping static configuration already handled by Syncfusion MVC |
+| Access kind | read, write, call, event |
+| Args shape and order | Needed for `WithArgs<T...>()` and runtime call order |
+| Return shape | Needed for `Read<TReturn>(method, args)` |
+| Event payload shape | Needed for typed event args and nested classes |
+| Event payload methods | Needed for event-arg extension methods |
+| Sync/async behavior | Runtime lane must stay correct |
+| Visible or trace proof | Prevents onboarding dead APIs |
+
+## Mapping Rules
+
+| Observed JS | C# Model |
+|---|---|
+| `ej2.x` | `ComponentProperty<T>.Named("x")` |
+| `ej2.a.b` | `ComponentProperty<T>.Mapped("name", "a.b")` |
+| `ej2.doThing()` | `ComponentMethod.Named("doThing")` |
+| `ej2.doThing(a, b)` | `ComponentMethod.Named("doThing").WithArgs<TA, TB>()` |
+| `ej2.doThing(a, b)` returns value | `self.Read<TReturn>(DoThingMethod, args)` |
+| overloaded `ej2.doThing(...)` | `ComponentMethod.Mapped("doThingForX", "doThing")` and another mapped method for the other shape |
+| `args.cancel = true` | `ReactionGraph.Set(PayloadSource.Event(), "cancel", ValueExpression.Literal(true))` |
+| `args.updateData(data)` | `ReactionGraph.Call(PayloadSource.Event(), "updateData", args)` |
+
+## Builder Coverage Gate
+
+Before writing C#, classify each traced member:
+
+| Class | Onboard? | Reason |
+|---|---:|---|
+| Initial render option already exposed by `Syncfusion.EJ2.*Builder` | No | the builder is already typed and owns SSR/static setup |
+| Property that reactive gather/condition/http needs to read after render | Yes | runtime state source |
+| Property that a reactive pipeline needs to mutate after render | Yes | runtime behavior |
+| Public JS method | Yes | builder cannot express post-render method execution |
+| Public JS method returning value | Yes | typed source for gather/conditions/http |
+| Event payload or cancellable event args | Yes | reactive plan needs typed event data/mutation |
+
+## Browser Data Shape Gate
+
+Syncfusion field names are evaluated in the browser against the serialized JSON
+shape, not the C# property shape. If the app uses camelCase JSON, builder string
+fields must use camelCase:
+
+| C# Property | Browser Data Field | Syncfusion Builder Field |
+|---|---|---|
+| `Status` | `status` | `KeyField("status")` |
+| `Id` | `id` | `HeaderField = "id"` |
+| `Summary` | `summary` | `ContentField = "summary"` |
+| `FacilityId` | `facilityId` | `SwimlaneSettings.KeyField = "facilityId"` |
+
+Typed `FusionTemplate.Create<T>()` expressions already emit camelCase bindings.
+Do not replace typed templates with raw string templates to fix casing. Fix the
+Syncfusion builder field names to the real browser data shape.
+
+Literal objects passed as runtime method arguments also serialize through the
+plan serializer. Confirm their browser shape in the rendered plan before using
+them for methods like `addColumn(...)` or `openDialog(...)`.
+
+## Temporary Probe Policy
+
+Probe HTML may be committed only if it is useful as a permanent vendor API fixture. Otherwise delete it after the typed vertical slice and Playwright coverage exist.

--- a/.claude/skills/onboard-fusion-component/references/source-discovery.md
+++ b/.claude/skills/onboard-fusion-component/references/source-discovery.md
@@ -1,0 +1,45 @@
+# Source Discovery
+
+Use this when the component package, d.ts path, MVC builder, or JavaScript namespace is not already known.
+
+## Command
+
+```bash
+node .claude/skills/onboard-fusion-component/scripts/discover-syncfusion-component.mjs \
+  --class ChipList
+```
+
+The output gives:
+
+| Fact | Used For |
+|---|---|
+| package | confirms which Syncfusion module owns the component |
+| d.ts path | public JS object contract |
+| JS source path | implementation details and lifecycle quirks |
+| MVC builder | builder coverage gate |
+| JS global guess | raw HTML constructor |
+
+## Source Priority
+
+| Priority | Source | Use |
+|---:|---|---|
+| 1 | Raw browser probe | proves the API works with real assets and real DOM |
+| 2 | Syncfusion shipped JS source | explains lifecycle, hidden requirements, `dataBind()`, event timing |
+| 3 | Syncfusion d.ts | identifies public members, event payload types, args, returns |
+| 4 | Syncfusion MVC XML/builder | decides what remains builder-owned |
+| 5 | Syncfusion docs/skills | accelerates setup only; never replaces proof |
+
+## Hard Rule
+
+Do not start C# until these facts are written down:
+
+| Fact | Example |
+|---|---|
+| exact class | `ChipList` |
+| exact global | `ej.buttons.ChipList` |
+| exact host | `#care-tags` owns `ej2_instances[0]` |
+| exact builder | `Syncfusion.EJ2.Buttons.ChipListBuilder` |
+| exact d.ts and JS source | `node_modules/@syncfusion/ej2-buttons/src/chips/chip-list.d.ts/js` |
+| exact event payload types | `FilteringEventArgs`, `DataStateChangeEventArgs`, etc. |
+
+If one is unknown, stop and discover it first.

--- a/.claude/skills/onboard-fusion-component/scripts/create-fusion-probe.mjs
+++ b/.claude/skills/onboard-fusion-component/scripts/create-fusion-probe.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+
+const component = requireArg(args, "component");
+const namespace = requireArg(args, "namespace");
+const className = requireArg(args, "class");
+const id = args.id ?? component;
+
+const file = resolve(`Alis.Reactive.SandboxApp/wwwroot/sf-${component}-probe.html`);
+
+if (existsSync(file)) {
+  console.error(`Probe already exists: ${file}`);
+  process.exit(1);
+}
+
+mkdirSync(dirname(file), { recursive: true });
+writeFileSync(file, template({ component, namespace, className, id }), "utf8");
+console.log(file);
+
+function parseArgs(items) {
+  const result = {};
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item.startsWith("--")) continue;
+    const key = item.slice(2);
+    const value = items[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      result[key] = true;
+      continue;
+    }
+    result[key] = value;
+    i++;
+  }
+  return result;
+}
+
+function requireArg(args, name) {
+  const value = args[name];
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  console.error(`Missing --${name}`);
+  process.exit(1);
+}
+
+function template({ component, namespace, className, id }) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF ${className} API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF ${className} API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <div id="${id}"></div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("${id}");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        const ej2 = new ej.${namespace}.${className}({
+            // Add real component options and event handlers here while tracing.
+            // Example:
+            // filtering: args => probe.event("filtering", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "${component}",
+            namespace: "ej.${namespace}",
+            className: "${className}",
+            id: "${id}"
+        });
+        proposal({
+            candidate: "replace this row",
+            kind: "method | prop-read | prop-write | event | payload-read | bridge",
+            builder: "covered | not covered | static-only",
+            args: "exact args and order",
+            returnOrPayload: "shape proven by trace",
+            proof: "visible behavior or trace label",
+            csharp: "typed Fusion API",
+            outcome: "implement | bridge-needed | exclude | needs-proof"
+        });
+    </script>
+</body>
+</html>
+`;
+}

--- a/.claude/skills/onboard-fusion-component/scripts/discover-syncfusion-component.mjs
+++ b/.claude/skills/onboard-fusion-component/scripts/discover-syncfusion-component.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const classQuery = requireArg(args, "class");
+const root = args.root ?? "node_modules/@syncfusion";
+const xmlPath = args.xml ?? `${process.env.HOME}/.nuget/packages/syncfusion.ej2.aspnet.core/32.2.8/lib/netstandard2.0/Syncfusion.EJ2.xml`;
+
+if (!existsSync(root)) {
+  console.error(`Syncfusion node_modules root not found: ${root}`);
+  process.exit(1);
+}
+
+const xml = existsSync(xmlPath) ? readFileSync(xmlPath, "utf8") : "";
+const matches = [];
+
+for (const dtsPath of walk(root).filter(file => file.endsWith(".d.ts"))) {
+  const text = readFileSync(dtsPath, "utf8");
+  const classes = extractClasses(text);
+  for (const className of classes) {
+    if (!className.toLowerCase().includes(classQuery.toLowerCase())) continue;
+    matches.push(describeMatch(className, dtsPath, root, xml, xmlPath));
+  }
+}
+
+if (matches.length === 0) {
+  console.error(`No Syncfusion d.ts class found for query: ${classQuery}`);
+  process.exit(1);
+}
+
+print(matches);
+
+function parseArgs(items) {
+  const result = {};
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item.startsWith("--")) continue;
+    const key = item.slice(2);
+    const value = items[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      result[key] = true;
+      continue;
+    }
+    result[key] = value;
+    i++;
+  }
+  return result;
+}
+
+function requireArg(values, name) {
+  const value = values[name];
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  console.error(`Missing --${name}`);
+  process.exit(1);
+}
+
+function walk(folder) {
+  const output = [];
+  for (const entry of readdirSync(folder)) {
+    const path = join(folder, entry);
+    const stats = statSync(path);
+    if (stats.isDirectory()) {
+      output.push(...walk(path));
+      continue;
+    }
+    output.push(path);
+  }
+  return output;
+}
+
+function extractClasses(text) {
+  const names = [];
+  const expression = /(?:export\s+declare\s+|export\s+)?class\s+([A-Za-z_][A-Za-z0-9_]*)\b/g;
+  let match;
+  while ((match = expression.exec(text)) !== null) {
+    names.push(match[1]);
+  }
+  return names;
+}
+
+function describeMatch(className, dtsPath, root, xml, xmlPath) {
+  const relativePath = relative(root, dtsPath);
+  const packageName = relativePath.split(/[\\/]/)[0];
+  const jsPath = dtsPath.replace(/\.d\.ts$/, ".js");
+  const builder = findBuilder(className, xml);
+  const builderNamespace = builder?.namespace ?? "";
+  const jsNamespace = builderNamespace ? builderNamespace.toLowerCase() : packageToNamespace(packageName);
+  return {
+    className,
+    packageName: `@syncfusion/${packageName}`,
+    dtsPath,
+    jsPath: existsSync(jsPath) ? jsPath : "",
+    builderType: builder?.type ?? "",
+    builderName: `${className}Builder`,
+    jsNamespace,
+    component: kebab(className),
+    xmlPath
+  };
+}
+
+function findBuilder(className, xml) {
+  if (!xml) return null;
+  const expression = new RegExp(`T:Syncfusion\\.EJ2\\.([A-Za-z0-9_.]+)\\.${escapeRegExp(className)}Builder`, "g");
+  const match = expression.exec(xml);
+  if (!match) return null;
+  return {
+    namespace: match[1],
+    type: `Syncfusion.EJ2.${match[1]}.${className}Builder`
+  };
+}
+
+function packageToNamespace(packageName) {
+  return packageName.replace(/^ej2-/, "").replace(/-/g, "");
+}
+
+function kebab(value) {
+  return value
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase();
+}
+
+function print(matches) {
+  console.log(`# Syncfusion Component Discovery`);
+  console.log("");
+  console.log("| Class | Package | d.ts | JS source | MVC builder | JS global guess |");
+  console.log("|---|---|---|---|---|---|");
+  for (const item of matches) {
+    console.log(`| ${item.className} | ${item.packageName} | \`${item.dtsPath}\` | ${item.jsPath ? `\`${item.jsPath}\`` : "-"} | ${item.builderType || "-"} | \`ej.${item.jsNamespace}.${item.className}\` |`);
+  }
+  console.log("");
+  console.log("## Next Commands");
+  for (const item of matches) {
+    console.log("");
+    console.log(`### ${item.className}`);
+    console.log("```bash");
+    console.log(`node .claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-surface.mjs \\`);
+    console.log(`  --class ${item.className} \\`);
+    console.log(`  --dts ${item.dtsPath} \\`);
+    console.log(`  --xml ${item.xmlPath}`);
+    console.log("");
+    console.log(`node .claude/skills/onboard-fusion-component/scripts/create-fusion-probe.mjs \\`);
+    console.log(`  --component ${item.component} \\`);
+    console.log(`  --namespace ${item.jsNamespace} \\`);
+    console.log(`  --class ${item.className} \\`);
+    console.log(`  --id ${item.component}`);
+    console.log("```");
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/.claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-blazor-metadata.mjs
+++ b/.claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-blazor-metadata.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const packageName = requireArg(args, "package");
+const version = requireArg(args, "version");
+const component = requireArg(args, "component");
+const decompiledPath = args.decompiled;
+const explicitPackageRoot = args["package-root"];
+
+const packageRoot = explicitPackageRoot ||
+  join(homedir(), ".nuget", "packages", packageName.toLowerCase(), version);
+if (!existsSync(packageRoot)) {
+  console.error(`Package not found in NuGet cache: ${packageRoot}`);
+  console.error(`Install it with: dotnet add package ${packageName} --version ${version}`);
+  console.error("Or pass --package-root /path/to/extracted/package");
+  process.exit(1);
+}
+
+const xmlPath = findFirst(packageRoot, file => file.endsWith(".xml") && file.includes(packageName));
+const dllPath = findFirst(packageRoot, file => file.endsWith(".dll") && file.includes(packageName));
+if (!xmlPath) {
+  console.error(`Could not find XML docs under ${packageRoot}`);
+  process.exit(1);
+}
+
+const xml = readFileSync(xmlPath, "utf8");
+const sfType = `Sf${component}`;
+const methodRows = extractSfMethods(xml, packageName, sfType);
+const eventArgRows = extractEventArgs(xml, packageName);
+const bridgeRows = decompiledPath && existsSync(decompiledPath)
+  ? extractBridgeCalls(readFileSync(decompiledPath, "utf8"))
+  : [];
+
+printMarkdown({
+  packageName,
+  version,
+  component,
+  packageRoot,
+  xmlPath,
+  dllPath,
+  sfType,
+  methodRows,
+  eventArgRows,
+  bridgeRows,
+  decompiledPath
+});
+
+function parseArgs(items) {
+  const result = {};
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item.startsWith("--")) continue;
+    const key = item.slice(2);
+    const value = items[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      result[key] = true;
+      continue;
+    }
+    result[key] = value;
+    i++;
+  }
+  return result;
+}
+
+function requireArg(values, name) {
+  const value = values[name];
+  if (typeof value === "string" && value.trim()) return value.trim();
+  console.error(`Missing --${name}`);
+  process.exit(1);
+}
+
+function findFirst(root, predicate) {
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const name of readdirSync(current)) {
+      const full = join(current, name);
+      const stats = statSync(full);
+      if (stats.isDirectory()) {
+        stack.push(full);
+      } else if (predicate(full)) {
+        return full;
+      }
+    }
+  }
+  return "";
+}
+
+function extractSfMethods(xmlText, pkg, sfType) {
+  const rows = [];
+  const expression = new RegExp(`name="M:${escapeRegExp(pkg)}\\.[^"]*${escapeRegExp(sfType)}(?:\`\\d+)?\\.([^"(]+)(?:\\(([^"]*)\\))?"`, "g");
+  let match;
+  while ((match = expression.exec(xmlText)) !== null) {
+    rows.push({
+      name: match[1],
+      signature: match[2] || ""
+    });
+  }
+  return uniqueRows(rows, row => `${row.name}(${row.signature})`).sort(byName);
+}
+
+function extractEventArgs(xmlText, pkg) {
+  const groups = new Map();
+  const expression = new RegExp(`name="P:${escapeRegExp(pkg)}\\.([^"]*EventArgs(?:\`\\d+)?)\\.([^"]+)"`, "g");
+  let match;
+  while ((match = expression.exec(xmlText)) !== null) {
+    const type = match[1].replace(/`1$/, "<T>");
+    const property = match[2];
+    const values = groups.get(type) || [];
+    values.push(property);
+    groups.set(type, values);
+  }
+
+  return Array.from(groups.entries())
+    .map(([type, properties]) => ({
+      type,
+      properties: Array.from(new Set(properties)).sort()
+    }))
+    .sort((left, right) => left.type.localeCompare(right.type));
+}
+
+function extractBridgeCalls(source) {
+  const calls = new Set();
+  const expression = /sfBlazor\.[A-Za-z0-9_.]+/g;
+  let match;
+  while ((match = expression.exec(source)) !== null) {
+    calls.add(match[0]);
+  }
+  return Array.from(calls).sort();
+}
+
+function uniqueRows(rows, keySelector) {
+  const seen = new Set();
+  return rows.filter(row => {
+    const key = keySelector(row);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function byName(left, right) {
+  return left.name.localeCompare(right.name);
+}
+
+function printMarkdown(report) {
+  console.log(`# Syncfusion Blazor ${report.component} Metadata`);
+  console.log("");
+  console.log(`Package: \`${report.packageName}\` ${report.version}`);
+  console.log(`Package root: \`${report.packageRoot}\``);
+  console.log(`XML: \`${report.xmlPath}\``);
+  console.log(`DLL: \`${report.dllPath || "not found"}\``);
+  if (report.decompiledPath) console.log(`Decompiled source: \`${report.decompiledPath}\``);
+  console.log("");
+  console.log("## Public Sf Methods");
+  console.log("");
+  console.log("| Method | Parameters | Alis Decision |");
+  console.log("|---|---|---|");
+  for (const row of report.methodRows) {
+    console.log(`| \`${row.name}\` | \`${row.signature || "-"}\` | candidate only; verify direct EJ2 source + HTML trace |`);
+  }
+  console.log("");
+  console.log("## Event Args");
+  console.log("");
+  console.log("| Type | Properties | Alis Decision |");
+  console.log("|---|---|---|");
+  for (const row of report.eventArgRows) {
+    console.log(`| \`${row.type}\` | \`${row.properties.join(", ")}\` | candidate only; expose direct EJ2 overlap |`);
+  }
+  console.log("");
+  console.log("## Blazor JS Bridge Calls");
+  console.log("");
+  if (report.bridgeRows.length === 0) {
+    console.log("No decompiled bridge calls supplied or found.");
+  } else {
+    for (const call of report.bridgeRows) {
+      console.log(`- \`${call}\` - bridge clue, not direct Fusion API by itself`);
+    }
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/.claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-event-payload.mjs
+++ b/.claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-event-payload.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const typeName = requireArg(args, "type");
+const root = args.root ?? "node_modules/@syncfusion";
+const explicitFile = args.dts;
+
+const files = explicitFile ? [explicitFile] : walk(root).filter(file => file.endsWith(".d.ts"));
+const matches = [];
+
+for (const file of files) {
+  if (!existsSync(file)) continue;
+  const text = readFileSync(file, "utf8");
+  const body = extractNamedBody(text, typeName);
+  if (!body) continue;
+  matches.push({ file, body });
+}
+
+if (matches.length === 0) {
+  console.error(`Could not find event payload type ${typeName}`);
+  process.exit(1);
+}
+
+for (const match of matches) {
+  print(typeName, match.file, extractMembers(match.body));
+}
+
+function parseArgs(items) {
+  const result = {};
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item.startsWith("--")) continue;
+    const key = item.slice(2);
+    const value = items[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      result[key] = true;
+      continue;
+    }
+    result[key] = value;
+    i++;
+  }
+  return result;
+}
+
+function requireArg(values, name) {
+  const value = values[name];
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  console.error(`Missing --${name}`);
+  process.exit(1);
+}
+
+function walk(folder) {
+  const output = [];
+  for (const entry of readdirSync(folder)) {
+    const path = join(folder, entry);
+    const stats = statSync(path);
+    if (stats.isDirectory()) {
+      output.push(...walk(path));
+      continue;
+    }
+    output.push(path);
+  }
+  return output;
+}
+
+function extractNamedBody(text, name) {
+  const declaration = new RegExp(`(?:export\\s+declare\\s+|export\\s+|declare\\s+)?(?:interface|class)\\s+${escapeRegExp(name)}\\b[^\\{]*\\{`, "g");
+  const match = declaration.exec(text);
+  if (!match) return null;
+  const open = text.indexOf("{", match.index);
+  return readBalancedBody(text, open);
+}
+
+function readBalancedBody(text, open) {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const char = text[i];
+    if (char === "{") depth++;
+    if (char === "}") depth--;
+    if (depth === 0) return text.slice(open + 1, i);
+  }
+  return "";
+}
+
+function extractMembers(body) {
+  const members = [];
+  for (const declaration of splitDeclarations(stripComments(body))) {
+    const line = declaration.trim().replace(/\s+/g, " ");
+    if (!line) continue;
+    if (line.startsWith("private ") || line.startsWith("protected ")) continue;
+
+    const property = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\??:\s*([^;]+);$/);
+    if (property) {
+      members.push({ kind: "property", name: property[1], type: property[2] });
+      continue;
+    }
+
+    const method = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\(([^)]*)\):\s*([^;]+);$/);
+    if (method) {
+      members.push({ kind: "method", name: method[1], type: `${method[2]}) => ${method[3]}` });
+      continue;
+    }
+  }
+  return members;
+}
+
+function stripComments(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "");
+}
+
+function splitDeclarations(body) {
+  const declarations = [];
+  let current = "";
+  let parenDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+
+  for (const char of body) {
+    current += char;
+    if (char === "(") parenDepth++;
+    if (char === ")") parenDepth--;
+    if (char === "{") braceDepth++;
+    if (char === "}") braceDepth--;
+    if (char === "[") bracketDepth++;
+    if (char === "]") bracketDepth--;
+
+    if (char === ";" && parenDepth === 0 && braceDepth === 0 && bracketDepth === 0) {
+      declarations.push(current);
+      current = "";
+    }
+  }
+
+  if (current.trim().length > 0) declarations.push(current);
+  return declarations;
+}
+
+function print(type, file, members) {
+  console.log(`# ${type} Payload`);
+  console.log("");
+  console.log(`Source: \`${file}\``);
+  console.log("");
+  console.log("| Member | Kind | Type | C# candidate | Proof needed |");
+  console.log("|---|---|---|---|---|");
+  for (const member of members) {
+    const candidate = member.kind === "method"
+      ? `event arg extension -> PayloadSource.Event().${member.name}(...)`
+      : `event arg property -> ${pascal(member.name)}`;
+    const proof = member.kind === "method"
+      ? "call in raw event handler and verify visible/runtime effect"
+      : "read from raw event handler payload and verify value during real interaction";
+    console.log(`| \`${member.name}\` | ${member.kind} | \`${member.type}\` | ${candidate} | ${proof} |`);
+  }
+  console.log("");
+}
+
+function pascal(value) {
+  return value.slice(0, 1).toUpperCase() + value.slice(1);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/.claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-surface.mjs
+++ b/.claude/skills/onboard-fusion-component/scripts/inspect-syncfusion-surface.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const args = parseArgs(process.argv.slice(2));
+const className = requireArg(args, "class");
+const dtsPath = requireArg(args, "dts");
+const xmlPath = args.xml;
+const builderName = args.builder ?? `${className}Builder`;
+
+const classBody = extractClassBody(readFileSync(dtsPath, "utf8"), className);
+const builderMembers = xmlPath
+  ? extractBuilderMembers(readFileSync(xmlPath, "utf8"), builderName)
+  : new Set();
+
+const rows = extractMembers(classBody)
+  .filter(member => !ignoredMember(member))
+  .map(member => toRow(member, builderMembers));
+
+printMarkdown(className, builderName, rows);
+
+function parseArgs(items) {
+  const result = {};
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item.startsWith("--")) continue;
+    const key = item.slice(2);
+    const value = items[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      result[key] = true;
+      continue;
+    }
+    result[key] = value;
+    i++;
+  }
+  return result;
+}
+
+function requireArg(values, name) {
+  const value = values[name];
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  console.error(`Missing --${name}`);
+  process.exit(1);
+}
+
+function extractClassBody(text, className) {
+  const classStart = text.indexOf(`class ${className} `);
+  if (classStart < 0) {
+    throw new Error(`Could not find class ${className}`);
+  }
+
+  const open = text.indexOf("{", classStart);
+  if (open < 0) {
+    throw new Error(`Could not find class body for ${className}`);
+  }
+
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const char = text[i];
+    if (char === "{") depth++;
+    if (char === "}") depth--;
+    if (depth === 0) return text.slice(open + 1, i);
+  }
+
+  throw new Error(`Unclosed class body for ${className}`);
+}
+
+function extractBuilderMembers(xml, builderName) {
+  const members = new Set();
+  const expression = new RegExp(`M:Syncfusion\\.EJ2\\.[^"]+\\.${escapeRegExp(builderName)}\\.([A-Za-z_][A-Za-z0-9_]*)\\(`, "g");
+  let match;
+  while ((match = expression.exec(xml)) !== null) {
+    members.add(match[1]);
+  }
+  return members;
+}
+
+function extractMembers(body) {
+  const members = [];
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("*") || line.startsWith("/")) continue;
+    if (line.startsWith("private ") || line.startsWith("protected ")) continue;
+
+    const property = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\??:\s*([^;]+);$/);
+    if (property) {
+      const [, name, type] = property;
+      members.push({
+        name,
+        kind: type.startsWith("EmitType<") ? "event" : "property",
+        type: type.replace(/^EmitType<(.+)>$/, "$1")
+      });
+      continue;
+    }
+
+    const method = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\(([^)]*)\):\s*([^;]+);$/);
+    if (method) {
+      const [, name, parameters, returns] = method;
+      members.push({ name, kind: "method", type: `${parameters}) => ${returns}` });
+    }
+  }
+  return members;
+}
+
+function ignoredMember(member) {
+  return [
+    "constructor",
+    "preRender",
+    "getDirective",
+    "getModuleName",
+    "getPersistData",
+    "render",
+    "onPropertyChanged"
+  ].includes(member.name);
+}
+
+function toRow(member, builderMembers) {
+  const builderMember = pascal(member.name);
+  const covered = builderMembers.has(builderMember);
+  return {
+    ...member,
+    builder: covered ? builderMember : "",
+    decision: decisionFor(member, covered)
+  };
+}
+
+function decisionFor(member, builderCovered) {
+  if (member.kind === "method") {
+    if (member.name === "destroy") return "skip: lifecycle cleanup, not plan behavior";
+    return "candidate: post-render behavior";
+  }
+
+  if (member.kind === "event") {
+    return "candidate: typed event if plan needs payload/mutation";
+  }
+
+  return builderCovered
+    ? "skip unless runtime read/write is needed"
+    : "candidate: runtime state if proven";
+}
+
+function printMarkdown(className, builderName, rows) {
+  console.log(`# ${className} Surface`);
+  console.log("");
+  console.log(`Builder coverage: ${builderName}`);
+  console.log("");
+  console.log("| JS member | Kind | Type | Builder member | Decision |");
+  console.log("|---|---|---|---|---|");
+  for (const row of rows) {
+    console.log(`| \`${row.name}\` | ${row.kind} | \`${row.type}\` | ${row.builder || "-"} | ${row.decision} |`);
+  }
+}
+
+function pascal(value) {
+  return value.slice(0, 1).toUpperCase() + value.slice(1);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/Events/FusionAIAssistViewPromptChangedArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/Events/FusionAIAssistViewPromptChangedArgs.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload for AIAssistView promptChanged.
+    /// </summary>
+    public sealed class FusionAIAssistViewPromptChangedArgs
+    {
+        public string Value { get; set; } = "";
+        public string PreviousValue { get; set; } = "";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/Events/FusionAIAssistViewPromptRequestArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/Events/FusionAIAssistViewPromptRequestArgs.cs
@@ -1,0 +1,29 @@
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload for AIAssistView promptRequest.
+    /// </summary>
+    public sealed class FusionAIAssistViewPromptRequestArgs
+    {
+        public bool Cancel { get; set; }
+        public string Prompt { get; set; } = "";
+        public string[] PromptSuggestions { get; set; } = Array.Empty<string>();
+    }
+
+    public static class FusionAIAssistViewPromptRequestArgsExtensions
+    {
+        public static void CancelRequest(
+            this FusionAIAssistViewPromptRequestArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/Events/FusionAIAssistViewStopRespondingClickArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/Events/FusionAIAssistViewStopRespondingClickArgs.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload for AIAssistView stopRespondingClick.
+    /// </summary>
+    public sealed class FusionAIAssistViewStopRespondingClickArgs
+    {
+        public string Prompt { get; set; } = "";
+        public int DataIndex { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistView.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistView.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 AIAssistView. Non-input component; runtime behavior is exposed
+    /// through typed methods, state reads, and events.
+    /// </summary>
+    public sealed class FusionAIAssistView : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewBuilder.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Carries rendered Syncfusion AIAssistView markup and the reactive plan for event wiring.
+    /// </summary>
+    public sealed class FusionAIAssistViewBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionAIAssistViewBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewEvents.cs
@@ -1,0 +1,23 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed AIAssistView events available to reactive plans.
+    /// </summary>
+    public sealed class FusionAIAssistViewEvents
+    {
+        public static readonly FusionAIAssistViewEvents Instance = new FusionAIAssistViewEvents();
+        private FusionAIAssistViewEvents() { }
+
+        public TypedEvent<FusionAIAssistViewPromptRequestArgs> PromptRequest =>
+            new TypedEvent<FusionAIAssistViewPromptRequestArgs>(
+                "promptRequest", new FusionAIAssistViewPromptRequestArgs());
+
+        public TypedEvent<FusionAIAssistViewPromptChangedArgs> PromptChanged =>
+            new TypedEvent<FusionAIAssistViewPromptChangedArgs>(
+                "promptChanged", new FusionAIAssistViewPromptChangedArgs());
+
+        public TypedEvent<FusionAIAssistViewStopRespondingClickArgs> StopRespondingClick =>
+            new TypedEvent<FusionAIAssistViewStopRespondingClickArgs>(
+                "stopRespondingClick", new FusionAIAssistViewStopRespondingClickArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewExtensions.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Runtime behavior for Syncfusion AIAssistView. Initial render options remain on
+    /// Syncfusion's AIAssistViewBuilder.
+    /// </summary>
+    public static class FusionAIAssistViewExtensions
+    {
+        private static readonly ComponentProperty<string> PromptProperty =
+            ComponentProperty<string>.Named("prompt");
+
+        private static readonly ComponentProperty<int> ActiveViewProperty =
+            ComponentProperty<int>.Named("activeView");
+
+        private static readonly ComponentMethod ExecutePromptMethod =
+            ComponentMethod.Named("executePrompt").WithArgs<string>();
+
+        private static readonly ComponentMethod AddPromptResponseTextMethod =
+            ComponentMethod.Mapped("addPromptResponseText", "addPromptResponse").WithArgs<string, bool>();
+
+        private static readonly ComponentMethod AddPromptResponseObjectMethod =
+            ComponentMethod.Mapped("addPromptResponseObject", "addPromptResponse").WithArgs<object, bool>();
+
+        private static readonly ComponentMethod ScrollToBottomMethod =
+            ComponentMethod.Named("scrollToBottom");
+
+        public static TypedComponentSource<string> Prompt<TModel>(
+            this ComponentRef<FusionAIAssistView, TModel> self)
+            where TModel : class
+            => self.Read(PromptProperty);
+
+        public static TypedComponentSource<int> ActiveView<TModel>(
+            this ComponentRef<FusionAIAssistView, TModel> self)
+            where TModel : class
+            => self.Read(ActiveViewProperty);
+
+        public static ComponentRef<FusionAIAssistView, TModel> SetPrompt<TModel>(
+            this ComponentRef<FusionAIAssistView, TModel> self,
+            string prompt)
+            where TModel : class
+            => self.EmitSet(PromptProperty, ValueExpression.Literal(prompt));
+
+        public static ComponentRef<FusionAIAssistView, TModel> ExecutePrompt<TModel>(
+            this ComponentRef<FusionAIAssistView, TModel> self,
+            string prompt)
+            where TModel : class
+            => self.EmitCall(
+                ExecutePromptMethod,
+                new List<ValueExpression> { ValueExpression.Literal(prompt) });
+
+        public static ComponentRef<FusionAIAssistView, TModel> AddPromptResponse<TModel>(
+            this ComponentRef<FusionAIAssistView, TModel> self,
+            string response,
+            bool isFinalUpdate = true)
+            where TModel : class
+            => self.EmitCall(
+                AddPromptResponseTextMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.Literal(response),
+                    ValueExpression.Literal(isFinalUpdate)
+                });
+
+        public static ComponentRef<FusionAIAssistView, TModel> AddPromptResponse<TModel>(
+            this ComponentRef<FusionAIAssistView, TModel> self,
+            string prompt,
+            string response,
+            bool isFinalUpdate = true)
+            where TModel : class
+        {
+            var promptResponse = ValueExpression.Object(new Dictionary<string, ValueExpression>
+            {
+                ["prompt"] = ValueExpression.Literal(prompt),
+                ["response"] = ValueExpression.Literal(response)
+            });
+
+            return self.EmitCall(
+                AddPromptResponseObjectMethod,
+                new List<ValueExpression>
+                {
+                    promptResponse,
+                    ValueExpression.Literal(isFinalUpdate)
+                });
+        }
+
+        public static ComponentRef<FusionAIAssistView, TModel> ScrollToBottom<TModel>(
+            this ComponentRef<FusionAIAssistView, TModel> self)
+            where TModel : class
+            => self.EmitCall(ScrollToBottomMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewHtmlExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.InteractiveChat;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for rendering Syncfusion AIAssistView with reactive event support.
+    /// Static component configuration stays on Syncfusion's MVC builder.
+    /// </summary>
+    public static class FusionAIAssistViewHtmlExtensions
+    {
+        public static FusionAIAssistViewBuilder<TModel> FusionAIAssistView<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<AIAssistViewBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().AIAssistView(elementId);
+            build(builder);
+
+            return new FusionAIAssistViewBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAIAssistView/FusionAIAssistViewReactiveExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires AIAssistView events into the reactive plan.
+    /// </summary>
+    public static class FusionAIAssistViewReactiveExtensions
+    {
+        private static readonly FusionAIAssistView Component = new FusionAIAssistView();
+
+        public static FusionAIAssistViewBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionAIAssistViewBuilder<TModel> builder,
+            Func<FusionAIAssistViewEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionAIAssistViewEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipData.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipData.cs
@@ -1,0 +1,8 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionChipData
+    {
+        public string Text { get; set; } = "";
+        public int Index { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipListClickArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipListClickArgs.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionChipListClickArgs
+    {
+        public string Text { get; set; } = "";
+        public int Index { get; set; }
+        public bool Selected { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipListDeletedArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipListDeletedArgs.cs
@@ -1,0 +1,8 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionChipListDeletedArgs
+    {
+        public string Text { get; set; } = "";
+        public int Index { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionSelectedChips.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionSelectedChips.cs
@@ -1,0 +1,8 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionSelectedChips
+    {
+        public string[] Texts { get; set; } = System.Array.Empty<string>();
+        public int[] Indexes { get; set; } = System.Array.Empty<int>();
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipList.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipList.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 ChipList. Static chip rendering stays on the MVC builder;
+    /// this type scopes typed post-render behavior and event wiring.
+    /// </summary>
+    public sealed class FusionChipList : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionChipListBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionChipListBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListEvents.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionChipListEvents
+    {
+        public static readonly FusionChipListEvents Instance = new FusionChipListEvents();
+        private FusionChipListEvents() { }
+
+        public TypedEvent<FusionChipListClickArgs> Clicked =>
+            new TypedEvent<FusionChipListClickArgs>(
+                "click", new FusionChipListClickArgs());
+
+        public TypedEvent<FusionChipListDeletedArgs> Deleted =>
+            new TypedEvent<FusionChipListDeletedArgs>(
+                "deleted", new FusionChipListDeletedArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListExtensions.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionChipListExtensions
+    {
+        private static readonly ComponentMethod AddMethod =
+            ComponentMethod.Named("add").WithArgs<string>();
+
+        private static readonly ComponentMethod SelectByIndexMethod =
+            ComponentMethod.Mapped("selectByIndex", "select").WithArgs<int>();
+
+        private static readonly ComponentMethod SelectByIndexesMethod =
+            ComponentMethod.Mapped("selectByIndexes", "select").WithArgs<int[]>();
+
+        private static readonly ComponentMethod SelectByTextMethod =
+            ComponentMethod.Mapped("selectByText", "select").WithArgs<string[], string>();
+
+        private static readonly ComponentMethod RemoveMethod =
+            ComponentMethod.Named("remove").WithArgs<int>();
+
+        private static readonly ComponentMethod RemoveIndexesMethod =
+            ComponentMethod.Mapped("removeIndexes", "remove").WithArgs<int[]>();
+
+        private static readonly ComponentMethod FindMethod =
+            ComponentMethod.Named("find").WithArgs<int>();
+
+        private static readonly ComponentMethod GetSelectedChipsMethod =
+            ComponentMethod.Named("getSelectedChips");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentProperty<string[]> SelectedChipValuesProperty =
+            ComponentProperty<string[]>.Mapped("selectedChipValues", "selectedChips");
+
+        private static readonly ComponentProperty<int[]> SelectedChipIndexesProperty =
+            ComponentProperty<int[]>.Mapped("selectedChipIndexes", "selectedChips");
+
+        public static ComponentRef<FusionChipList, TModel> Add<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            string text)
+            where TModel : class
+            => self.EmitCall(
+                AddMethod,
+                new List<ValueExpression> { ValueExpression.Literal(text) });
+
+        public static ComponentRef<FusionChipList, TModel> SelectByIndex<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            int index)
+            where TModel : class
+            => self.EmitCall(
+                SelectByIndexMethod,
+                new List<ValueExpression> { ValueExpression.Literal(index) });
+
+        public static ComponentRef<FusionChipList, TModel> SelectByIndexes<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            params int[] indexes)
+            where TModel : class
+            => self.EmitCall(
+                SelectByIndexesMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.LiteralRaw(indexes, Shape.ArrayOf(Shape.Number))
+                });
+
+        public static ComponentRef<FusionChipList, TModel> SelectByText<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            params string[] text)
+            where TModel : class
+            => self.EmitCall(
+                SelectByTextMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.LiteralRaw(text, Shape.ArrayOf(Shape.String)),
+                    ValueExpression.Literal("text")
+                });
+
+        public static ComponentRef<FusionChipList, TModel> RemoveByIndex<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            int index)
+            where TModel : class
+            => self.EmitCall(
+                RemoveMethod,
+                new List<ValueExpression> { ValueExpression.Literal(index) });
+
+        public static ComponentRef<FusionChipList, TModel> RemoveByIndexes<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            params int[] indexes)
+            where TModel : class
+            => self.EmitCall(
+                RemoveIndexesMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.LiteralRaw(indexes, Shape.ArrayOf(Shape.Number))
+                });
+
+        public static TypedComponentSource<FusionChipData> Find<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            int index)
+            where TModel : class
+            => self.Read<FusionChipData>(
+                FindMethod,
+                new List<ValueExpression> { ValueExpression.Literal(index) });
+
+        public static TypedComponentSource<FusionSelectedChips> SelectedChips<TModel>(
+            this ComponentRef<FusionChipList, TModel> self)
+            where TModel : class
+            => self.Read<FusionSelectedChips>(GetSelectedChipsMethod);
+
+        public static TypedComponentSource<string[]> SelectedChipValues<TModel>(
+            this ComponentRef<FusionChipList, TModel> self)
+            where TModel : class
+            => self.Read(SelectedChipValuesProperty);
+
+        public static TypedComponentSource<int[]> SelectedChipIndexes<TModel>(
+            this ComponentRef<FusionChipList, TModel> self)
+            where TModel : class
+            => self.Read(SelectedChipIndexesProperty);
+
+        public static ComponentRef<FusionChipList, TModel> SetSelectedChipIndexes<TModel>(
+            this ComponentRef<FusionChipList, TModel> self,
+            params int[] indexes)
+            where TModel : class
+            => self
+                .EmitSet(
+                    SelectedChipIndexesProperty,
+                    ValueExpression.LiteralRaw(indexes, Shape.ArrayOf(Shape.Number)))
+                .EmitCall(DataBindMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListHtmlExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Buttons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionChipListHtmlExtensions
+    {
+        public static FusionChipListBuilder<TModel> FusionChipList<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<ChipListBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().ChipList(elementId);
+            build(builder);
+
+            return new FusionChipListBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/FusionChipListReactiveExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionChipListReactiveExtensions
+    {
+        private static readonly FusionChipList Component = new FusionChipList();
+
+        public static FusionChipListBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionChipListBuilder<TModel> builder,
+            Func<FusionChipListEvents, TypedEvent<TArgs>> on,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = on(FusionChipListEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionKanban/Events/FusionKanbanEventArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/Events/FusionKanbanEventArgs.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionKanbanEmptyArgs
+    {
+    }
+
+    public sealed class FusionKanbanActionArgs<TCard>
+        where TCard : class, new()
+    {
+        public string RequestType { get; set; } = "";
+        public bool Cancel { get; set; }
+        public List<TCard> AddedRecords { get; set; } = new List<TCard>();
+        public List<TCard> ChangedRecords { get; set; } = new List<TCard>();
+        public List<TCard> DeletedRecords { get; set; } = new List<TCard>();
+    }
+
+    public sealed class FusionKanbanDataBindingArgs<TCard>
+        where TCard : class, new()
+    {
+        public List<TCard> Result { get; set; } = new List<TCard>();
+        public int? Count { get; set; }
+    }
+
+    public sealed class FusionKanbanCardClickArgs<TCard>
+        where TCard : class, new()
+    {
+        public TCard Data { get; set; } = new TCard();
+        public bool Cancel { get; set; }
+    }
+
+    public sealed class FusionKanbanCardRenderedArgs<TCard>
+        where TCard : class, new()
+    {
+        public TCard Data { get; set; } = new TCard();
+        public bool Cancel { get; set; }
+    }
+
+    public sealed class FusionKanbanDialogArgs<TCard>
+        where TCard : class, new()
+    {
+        public TCard Data { get; set; } = new TCard();
+        public bool Cancel { get; set; }
+        public string RequestType { get; set; } = "";
+    }
+
+    public sealed class FusionKanbanDragArgs<TCard>
+        where TCard : class, new()
+    {
+        public List<TCard> Data { get; set; } = new List<TCard>();
+        public bool Cancel { get; set; }
+        public int DropIndex { get; set; }
+    }
+
+    public sealed class FusionKanbanHeaderArgs
+    {
+        public string KeyField { get; set; } = "";
+        public string TextField { get; set; } = "";
+        public int Count { get; set; }
+    }
+
+    public sealed class FusionKanbanQueryCellInfoArgs
+    {
+        public List<FusionKanbanHeaderArgs> Data { get; set; } = new List<FusionKanbanHeaderArgs>();
+        public bool Cancel { get; set; }
+        public string RequestType { get; set; } = "";
+    }
+
+    public sealed class FusionKanbanDataSourceChangedArgs<TCard>
+        where TCard : class, new()
+    {
+        public string RequestType { get; set; } = "";
+        public List<TCard> AddedRecords { get; set; } = new List<TCard>();
+        public List<TCard> ChangedRecords { get; set; } = new List<TCard>();
+        public List<TCard> DeletedRecords { get; set; } = new List<TCard>();
+        public int Index { get; set; }
+    }
+
+    public static class FusionKanbanEventArgsExtensions
+    {
+        public static void Cancel<TCard>(
+            this FusionKanbanActionArgs<TCard> args,
+            IReactionEmitter pipeline)
+            where TCard : class, new()
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void Cancel<TCard>(
+            this FusionKanbanCardClickArgs<TCard> args,
+            IReactionEmitter pipeline)
+            where TCard : class, new()
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void Cancel<TCard>(
+            this FusionKanbanDialogArgs<TCard> args,
+            IReactionEmitter pipeline)
+            where TCard : class, new()
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void Cancel(
+            this FusionKanbanQueryCellInfoArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void Cancel<TCard>(
+            this FusionKanbanDragArgs<TCard> args,
+            IReactionEmitter pipeline)
+            where TCard : class, new()
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void EndEdit<TCard>(
+            this FusionKanbanDataSourceChangedArgs<TCard> args,
+            IReactionEmitter pipeline)
+            where TCard : class, new()
+        {
+            pipeline.AddStep(ReactionGraph.Call(
+                PayloadSource.Event(),
+                "endEdit",
+                System.Array.Empty<ValueExpression>()));
+        }
+
+        public static void CancelEdit<TCard>(
+            this FusionKanbanDataSourceChangedArgs<TCard> args,
+            IReactionEmitter pipeline)
+            where TCard : class, new()
+        {
+            pipeline.AddStep(ReactionGraph.Call(
+                PayloadSource.Event(),
+                "cancelEdit",
+                System.Array.Empty<ValueExpression>()));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanban.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanban.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 Kanban. Initial board configuration stays on Syncfusion's
+    /// KanbanBuilder; this type scopes typed post-render behavior for reactive plans.
+    /// </summary>
+    public sealed class FusionKanban : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanBuilder.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Carries rendered Syncfusion Kanban markup and the reactive plan for event wiring.
+    /// </summary>
+    public sealed class FusionKanbanBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionKanbanBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanEvents.cs
@@ -1,0 +1,79 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed Kanban events available to reactive plans.
+    /// </summary>
+    public sealed class FusionKanbanEvents
+    {
+        public static readonly FusionKanbanEvents Instance = new FusionKanbanEvents();
+        private FusionKanbanEvents() { }
+
+        public TypedEvent<FusionKanbanActionArgs<TCard>> ActionBegin<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanActionArgs<TCard>>(
+                "actionBegin", new FusionKanbanActionArgs<TCard>());
+
+        public TypedEvent<FusionKanbanActionArgs<TCard>> ActionComplete<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanActionArgs<TCard>>(
+                "actionComplete", new FusionKanbanActionArgs<TCard>());
+
+        public TypedEvent<FusionKanbanDataBindingArgs<TCard>> DataBinding<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanDataBindingArgs<TCard>>(
+                "dataBinding", new FusionKanbanDataBindingArgs<TCard>());
+
+        public TypedEvent<FusionKanbanEmptyArgs> DataBound =>
+            new TypedEvent<FusionKanbanEmptyArgs>(
+                "dataBound", new FusionKanbanEmptyArgs());
+
+        public TypedEvent<FusionKanbanCardClickArgs<TCard>> CardClick<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanCardClickArgs<TCard>>(
+                "cardClick", new FusionKanbanCardClickArgs<TCard>());
+
+        public TypedEvent<FusionKanbanCardClickArgs<TCard>> CardDoubleClick<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanCardClickArgs<TCard>>(
+                "cardDoubleClick", new FusionKanbanCardClickArgs<TCard>());
+
+        public TypedEvent<FusionKanbanQueryCellInfoArgs> QueryCellInfo =>
+            new TypedEvent<FusionKanbanQueryCellInfoArgs>(
+                "queryCellInfo", new FusionKanbanQueryCellInfoArgs());
+
+        public TypedEvent<FusionKanbanCardRenderedArgs<TCard>> CardRendered<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanCardRenderedArgs<TCard>>(
+                "cardRendered", new FusionKanbanCardRenderedArgs<TCard>());
+
+        public TypedEvent<FusionKanbanDragArgs<TCard>> DragStart<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanDragArgs<TCard>>(
+                "dragStart", new FusionKanbanDragArgs<TCard>());
+
+        public TypedEvent<FusionKanbanDragArgs<TCard>> Drag<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanDragArgs<TCard>>(
+                "drag", new FusionKanbanDragArgs<TCard>());
+
+        public TypedEvent<FusionKanbanDragArgs<TCard>> DragStop<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanDragArgs<TCard>>(
+                "dragStop", new FusionKanbanDragArgs<TCard>());
+
+        public TypedEvent<FusionKanbanDialogArgs<TCard>> DialogOpen<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanDialogArgs<TCard>>(
+                "dialogOpen", new FusionKanbanDialogArgs<TCard>());
+
+        public TypedEvent<FusionKanbanDialogArgs<TCard>> DialogClose<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanDialogArgs<TCard>>(
+                "dialogClose", new FusionKanbanDialogArgs<TCard>());
+
+        public TypedEvent<FusionKanbanDataSourceChangedArgs<TCard>> DataSourceChanged<TCard>()
+            where TCard : class, new()
+            => new TypedEvent<FusionKanbanDataSourceChangedArgs<TCard>>(
+                "dataSourceChanged", new FusionKanbanDataSourceChangedArgs<TCard>());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanExtensions.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Runtime behavior for Syncfusion Kanban. Initial board setup remains on
+    /// Syncfusion's KanbanBuilder; these members cover post-render reads,
+    /// mutations, and method-return sources.
+    /// </summary>
+    public static class FusionKanbanExtensions
+    {
+        private static readonly ComponentProperty<object> DataSourceProperty =
+            ComponentProperty<object>.Named("dataSource");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod GetColumnDataByStringMethod =
+            ComponentMethod.Named("getColumnData").WithArgs<string>();
+
+        private static readonly ComponentMethod GetSwimlaneDataMethod =
+            ComponentMethod.Named("getSwimlaneData").WithArgs<string>();
+
+        private static readonly ComponentMethod AddCardAtMethod =
+            ComponentMethod.Mapped("addCardAt", "addCard").WithArgs<object, int>();
+
+        private static readonly ComponentMethod UpdateCardMethod =
+            ComponentMethod.Named("updateCard").WithArgs<object>();
+
+        private static readonly ComponentMethod DeleteCardMethod =
+            ComponentMethod.Named("deleteCard").WithArgs<object>();
+
+        private static readonly ComponentMethod AddColumnMethod =
+            ComponentMethod.Named("addColumn").WithArgs<object, int>();
+
+        private static readonly ComponentMethod DeleteColumnMethod =
+            ComponentMethod.Named("deleteColumn").WithArgs<int>();
+
+        private static readonly ComponentMethod ShowColumnByStringMethod =
+            ComponentMethod.Named("showColumn").WithArgs<string>();
+
+        private static readonly ComponentMethod HideColumnByStringMethod =
+            ComponentMethod.Named("hideColumn").WithArgs<string>();
+
+        private static readonly ComponentMethod ShowSpinnerMethod =
+            ComponentMethod.Named("showSpinner");
+
+        private static readonly ComponentMethod HideSpinnerMethod =
+            ComponentMethod.Named("hideSpinner");
+
+        private static readonly ComponentMethod OpenDialogMethod =
+            ComponentMethod.Named("openDialog").WithArgs<string, object>();
+
+        private static readonly ComponentMethod CloseDialogMethod =
+            ComponentMethod.Named("closeDialog");
+
+        public static TypedComponentSource<TCard[]> Cards<TModel, TCard>(
+            this ComponentRef<FusionKanban, TModel> self)
+            where TModel : class
+            where TCard : class
+            => self.Read(ComponentProperty<TCard[]>.Named("dataSource"));
+
+        public static TypedComponentSource<TCard[]> ColumnData<TModel, TCard>(
+            this ComponentRef<FusionKanban, TModel> self,
+            string columnKey)
+            where TModel : class
+            where TCard : class
+            => self.Read<TCard[]>(
+                GetColumnDataByStringMethod,
+                new List<ValueExpression> { ValueExpression.Literal(columnKey) });
+
+        public static TypedComponentSource<TCard[]> SwimlaneData<TModel, TCard>(
+            this ComponentRef<FusionKanban, TModel> self,
+            string swimlaneKey)
+            where TModel : class
+            where TCard : class
+            => self.Read<TCard[]>(
+                GetSwimlaneDataMethod,
+                new List<ValueExpression> { ValueExpression.Literal(swimlaneKey) });
+
+        public static ComponentRef<FusionKanban, TModel> SetDataSource<TModel, TResponse>(
+            this ComponentRef<FusionKanban, TModel> self,
+            ResponseBody<TResponse> source,
+            Expression<Func<TResponse, object?>> path)
+            where TModel : class
+            where TResponse : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, sourcePath));
+            return self.EmitCall(DataBindMethod);
+        }
+
+        public static ComponentRef<FusionKanban, TModel> AddCard<TModel, TResponse>(
+            this ComponentRef<FusionKanban, TModel> self,
+            ResponseBody<TResponse> source,
+            Expression<Func<TResponse, object?>> path,
+            int index)
+            where TModel : class
+            where TResponse : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            var card = ValueExpression.Read(source.Scope, sourcePath);
+            return self.EmitCall(AddCardAtMethod, new List<ValueExpression> { card, ValueExpression.Literal(index) });
+        }
+
+        public static ComponentRef<FusionKanban, TModel> UpdateCard<TModel, TResponse>(
+            this ComponentRef<FusionKanban, TModel> self,
+            ResponseBody<TResponse> source,
+            Expression<Func<TResponse, object?>> path)
+            where TModel : class
+            where TResponse : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            var card = ValueExpression.Read(source.Scope, sourcePath);
+            return self.EmitCall(UpdateCardMethod, new List<ValueExpression> { card });
+        }
+
+        public static ComponentRef<FusionKanban, TModel> DeleteCard<TModel, TResponse>(
+            this ComponentRef<FusionKanban, TModel> self,
+            ResponseBody<TResponse> source,
+            Expression<Func<TResponse, object?>> path)
+            where TModel : class
+            where TResponse : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            return self.EmitCall(DeleteCardMethod, new List<ValueExpression> { ValueExpression.Read(source.Scope, sourcePath) });
+        }
+
+        public static ComponentRef<FusionKanban, TModel> AddColumn<TModel>(
+            this ComponentRef<FusionKanban, TModel> self,
+            FusionKanbanColumn column,
+            int index)
+            where TModel : class
+            => self.EmitCall(
+                AddColumnMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.LiteralRaw(column, Shape.Any),
+                    ValueExpression.Literal(index)
+                });
+
+        public static ComponentRef<FusionKanban, TModel> DeleteColumn<TModel>(
+            this ComponentRef<FusionKanban, TModel> self,
+            int index)
+            where TModel : class
+            => self.EmitCall(DeleteColumnMethod, new List<ValueExpression> { ValueExpression.Literal(index) });
+
+        public static ComponentRef<FusionKanban, TModel> ShowColumn<TModel>(
+            this ComponentRef<FusionKanban, TModel> self,
+            string key)
+            where TModel : class
+            => self.EmitCall(ShowColumnByStringMethod, new List<ValueExpression> { ValueExpression.Literal(key) });
+
+        public static ComponentRef<FusionKanban, TModel> HideColumn<TModel>(
+            this ComponentRef<FusionKanban, TModel> self,
+            string key)
+            where TModel : class
+            => self.EmitCall(HideColumnByStringMethod, new List<ValueExpression> { ValueExpression.Literal(key) });
+
+        public static ComponentRef<FusionKanban, TModel> ShowSpinner<TModel>(
+            this ComponentRef<FusionKanban, TModel> self)
+            where TModel : class
+            => self.EmitCall(ShowSpinnerMethod);
+
+        public static ComponentRef<FusionKanban, TModel> HideSpinner<TModel>(
+            this ComponentRef<FusionKanban, TModel> self)
+            where TModel : class
+            => self.EmitCall(HideSpinnerMethod);
+
+        public static ComponentRef<FusionKanban, TModel> OpenAddDialog<TModel, TCard>(
+            this ComponentRef<FusionKanban, TModel> self,
+            TCard card)
+            where TModel : class
+            where TCard : class
+            => self.EmitCall(OpenDialogMethod, DialogArgs("Add", card));
+
+        public static ComponentRef<FusionKanban, TModel> OpenEditDialog<TModel, TCard>(
+            this ComponentRef<FusionKanban, TModel> self,
+            TCard card)
+            where TModel : class
+            where TCard : class
+            => self.EmitCall(OpenDialogMethod, DialogArgs("Edit", card));
+
+        public static ComponentRef<FusionKanban, TModel> CloseDialog<TModel>(
+            this ComponentRef<FusionKanban, TModel> self)
+            where TModel : class
+            => self.EmitCall(CloseDialogMethod);
+
+        private static List<ValueExpression> DialogArgs<TCard>(string action, TCard card)
+            where TCard : class
+            => new List<ValueExpression>
+            {
+                ValueExpression.Literal(action),
+                ValueExpression.LiteralRaw(card, Shape.Any)
+            };
+    }
+
+    public sealed class FusionKanbanColumn
+    {
+        public string HeaderText { get; set; } = "";
+        public string KeyField { get; set; } = "";
+        public bool AllowToggle { get; set; }
+        public bool IsExpanded { get; set; } = true;
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanHtmlExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Kanban;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for rendering Syncfusion Kanban with reactive event support.
+    /// Static board setup stays on Syncfusion's MVC builder.
+    /// </summary>
+    public static class FusionKanbanHtmlExtensions
+    {
+        public static FusionKanbanBuilder<TModel> FusionKanban<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<KanbanBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Kanban(elementId);
+            build(builder);
+
+            return new FusionKanbanBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanReactiveExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires Kanban events into the reactive plan.
+    /// </summary>
+    public static class FusionKanbanReactiveExtensions
+    {
+        private static readonly FusionKanban Component = new FusionKanban();
+
+        public static FusionKanbanBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionKanbanBuilder<TModel> builder,
+            Func<FusionKanbanEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionKanbanEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/Events/FusionMentionChangedArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/Events/FusionMentionChangedArgs.cs
@@ -1,0 +1,8 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionMentionChangedArgs
+    {
+        public string? Value { get; set; }
+        public bool IsInteracted { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/Events/FusionMentionPopupArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/Events/FusionMentionPopupArgs.cs
@@ -1,0 +1,6 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionMentionPopupArgs
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/FusionMention.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/FusionMention.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 Mention. The MVC builder owns static list configuration;
+    /// this type scopes typed post-render behavior and event wiring.
+    /// </summary>
+    public sealed class FusionMention : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionMentionBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionMentionBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionEvents.cs
@@ -1,0 +1,20 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionMentionEvents
+    {
+        public static readonly FusionMentionEvents Instance = new FusionMentionEvents();
+        private FusionMentionEvents() { }
+
+        public TypedEvent<FusionMentionChangedArgs> Changed =>
+            new TypedEvent<FusionMentionChangedArgs>(
+                "change", new FusionMentionChangedArgs());
+
+        public TypedEvent<FusionMentionPopupArgs> Opened =>
+            new TypedEvent<FusionMentionPopupArgs>(
+                "opened", new FusionMentionPopupArgs());
+
+        public TypedEvent<FusionMentionPopupArgs> Closed =>
+            new TypedEvent<FusionMentionPopupArgs>(
+                "closed", new FusionMentionPopupArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionExtensions.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionMentionExtensions
+    {
+        private static readonly ComponentMethod SearchMethod =
+            ComponentMethod.Named("search").WithArgs<string, int, int>();
+
+        private static readonly ComponentMethod ShowPopupMethod =
+            ComponentMethod.Named("showPopup");
+
+        private static readonly ComponentMethod HidePopupMethod =
+            ComponentMethod.Named("hidePopup");
+
+        public static ComponentRef<FusionMention, TModel> Search<TModel>(
+            this ComponentRef<FusionMention, TModel> self,
+            string text,
+            int positionX,
+            int positionY)
+            where TModel : class
+            => self.EmitCall(
+                SearchMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.Literal(text),
+                    ValueExpression.Literal(positionX),
+                    ValueExpression.Literal(positionY)
+                });
+
+        public static ComponentRef<FusionMention, TModel> ShowPopup<TModel>(
+            this ComponentRef<FusionMention, TModel> self)
+            where TModel : class
+            => self.EmitCall(ShowPopupMethod);
+
+        public static ComponentRef<FusionMention, TModel> HidePopup<TModel>(
+            this ComponentRef<FusionMention, TModel> self)
+            where TModel : class
+            => self.EmitCall(HidePopupMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionHtmlExtensions.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq.Expressions;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.DropDowns;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionMentionHtmlExtensions
+    {
+        public static FusionMentionBuilder<TModel> FusionMention<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<MentionBuilder> build)
+            where TModel : class
+        {
+            var hostId = elementId + "-host";
+            var builder = html.EJS().Mention(hostId);
+            build(builder);
+
+            var content = new HtmlContentBuilder();
+            content.AppendHtml(RenderBridge(elementId, hostId, builder.model.Target));
+            content.AppendHtml(builder.Render());
+
+            return new FusionMentionBuilder<TModel>(plan, elementId, content);
+        }
+
+        public static MentionBuilder Fields<TItem>(
+            this MentionBuilder builder,
+            Expression<Func<TItem, object?>> text,
+            Expression<Func<TItem, object?>> value)
+        {
+            return builder.Fields(new MentionFieldSettings
+            {
+                Text = ToCamelCase(GetMemberName(text)),
+                Value = ToCamelCase(GetMemberName(value))
+            });
+        }
+
+        private static string GetMemberName<T>(Expression<Func<T, object?>> expr)
+        {
+            var body = expr.Body;
+            if (body is UnaryExpression unary) body = unary.Operand;
+            if (body is MemberExpression member) return member.Member.Name;
+            throw new ArgumentException("Expression must be a member access.");
+        }
+
+        private static string ToCamelCase(string name) =>
+            string.IsNullOrEmpty(name) ? name : char.ToLowerInvariant(name[0]) + name.Substring(1);
+
+        private static string RenderBridge(string elementId, string hostId, string targetSelector)
+        {
+            var encodedElementId = JavaScriptEncoder.Default.Encode(elementId);
+            var encodedHostId = JavaScriptEncoder.Default.Encode(hostId);
+            var encodedTargetSelector = JavaScriptEncoder.Default.Encode(targetSelector);
+
+            return "<span id=\"" + HtmlEncoder.Default.Encode(elementId) + "\" hidden></span>"
+                + "<script>(function(){document.addEventListener('DOMContentLoaded',function(){"
+                + "var bridge=document.getElementById('" + encodedElementId + "');"
+                + "var host=document.getElementById('" + encodedHostId + "');"
+                + "var target=document.querySelector('" + encodedTargetSelector + "');"
+                + "var source=(host&&host.ej2_instances)?host:target;"
+                + "if(bridge&&source&&source.ej2_instances){bridge.ej2_instances=source.ej2_instances;}"
+                + "});})();</script>";
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMention/FusionMentionReactiveExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionMentionReactiveExtensions
+    {
+        private static readonly FusionMention Component = new FusionMention();
+
+        public static FusionMentionBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionMentionBuilder<TModel> builder,
+            Func<FusionMentionEvents, TypedEvent<TArgs>> on,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = on(FusionMentionEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/Events/FusionPivotViewCellSelectingArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/Events/FusionPivotViewCellSelectingArgs.cs
@@ -1,0 +1,29 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload for PivotView cellSelecting. This event is emitted during normal
+    /// late event subscription, which matches reactive runtime wiring.
+    /// </summary>
+    public sealed class FusionPivotViewCellSelectingArgs
+    {
+        public FusionPivotViewCellData Data { get; set; } = new FusionPivotViewCellData();
+    }
+
+    /// <summary>
+    /// Pivot cell data exposed by Syncfusion inside cellSelecting args.
+    /// </summary>
+    public sealed class FusionPivotViewCellData
+    {
+        public string Axis { get; set; } = "";
+        public string ActualText { get; set; } = "";
+        public string FormattedText { get; set; } = "";
+        public decimal Value { get; set; }
+        public decimal ActualValue { get; set; }
+        public int RowIndex { get; set; }
+        public int ColIndex { get; set; }
+        public string RowHeaders { get; set; } = "";
+        public string ColumnHeaders { get; set; } = "";
+        public bool IsSum { get; set; }
+        public bool IsGrandSum { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/Events/FusionPivotViewDataBoundArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/Events/FusionPivotViewDataBoundArgs.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload for PivotView dataBound. Syncfusion raises this after the pivot data renders.
+    /// </summary>
+    public sealed class FusionPivotViewDataBoundArgs
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotView.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotView.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 PivotView. Static report setup stays on the Syncfusion MVC builder;
+    /// this type scopes typed post-render behavior for reactive plans.
+    /// </summary>
+    public sealed class FusionPivotView : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewBuilder.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Carries rendered Syncfusion PivotView markup and the reactive plan for event wiring.
+    /// </summary>
+    public sealed class FusionPivotViewBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionPivotViewBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewEvents.cs
@@ -1,0 +1,19 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed PivotView events available to reactive plans.
+    /// </summary>
+    public sealed class FusionPivotViewEvents
+    {
+        public static readonly FusionPivotViewEvents Instance = new FusionPivotViewEvents();
+        private FusionPivotViewEvents() { }
+
+        public TypedEvent<FusionPivotViewDataBoundArgs> DataBound =>
+            new TypedEvent<FusionPivotViewDataBoundArgs>(
+                "dataBound", new FusionPivotViewDataBoundArgs());
+
+        public TypedEvent<FusionPivotViewCellSelectingArgs> CellSelecting =>
+            new TypedEvent<FusionPivotViewCellSelectingArgs>(
+                "cellSelecting", new FusionPivotViewCellSelectingArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewExtensions.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Runtime behavior for Syncfusion PivotView. Initial report configuration stays on
+    /// Syncfusion's PivotViewBuilder.
+    /// </summary>
+    public static class FusionPivotViewExtensions
+    {
+        private static readonly ComponentProperty<string> CurrentViewProperty =
+            ComponentProperty<string>.Named("currentView");
+
+        private static readonly ComponentProperty<object> DataSourceProperty =
+            ComponentProperty<object>.Mapped("dataSource", "dataSourceSettings.dataSource");
+
+        private static readonly ComponentMethod RefreshMethod =
+            ComponentMethod.Named("refresh");
+
+        private static readonly ComponentMethod GetPersistDataMethod =
+            ComponentMethod.Named("getPersistData").WithArgs<bool>();
+
+        private static readonly ComponentMethod LoadPersistDataMethod =
+            ComponentMethod.Named("loadPersistData").WithArgs<string>();
+
+        private static readonly ComponentMethod ConditionalFormattingDialogMethod =
+            ComponentMethod.Named("showConditionalFormattingDialog");
+
+        private static readonly ComponentMethod CalculatedFieldDialogMethod =
+            ComponentMethod.Named("createCalculatedFieldDialog");
+
+        public static TypedComponentSource<string> CurrentView<TModel>(
+            this ComponentRef<FusionPivotView, TModel> self)
+            where TModel : class
+            => self.Read(CurrentViewProperty);
+
+        public static TypedComponentSource<string> PersistedLayout<TModel>(
+            this ComponentRef<FusionPivotView, TModel> self,
+            bool removeDataSource = true)
+            where TModel : class
+            => self.Read<string>(
+                GetPersistDataMethod,
+                new List<ValueExpression> { ValueExpression.Literal(removeDataSource) });
+
+        public static ComponentRef<FusionPivotView, TModel> SetDataSource<TModel, TResponse>(
+            this ComponentRef<FusionPivotView, TModel> self,
+            ResponseBody<TResponse> source,
+            Expression<System.Func<TResponse, object?>> path)
+            where TModel : class
+            where TResponse : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, sourcePath));
+            return self.Refresh();
+        }
+
+        public static ComponentRef<FusionPivotView, TModel> SetDataSource<TModel, TResponse>(
+            this ComponentRef<FusionPivotView, TModel> self,
+            ResponseBody<TResponse> source)
+            where TModel : class
+            where TResponse : class
+        {
+            self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, "responseBody"));
+            return self.Refresh();
+        }
+
+        public static ComponentRef<FusionPivotView, TModel> LoadPersistedLayout<TModel>(
+            this ComponentRef<FusionPivotView, TModel> self,
+            string persistedLayout)
+            where TModel : class
+            => self.EmitCall(
+                LoadPersistDataMethod,
+                new List<ValueExpression> { ValueExpression.Literal(persistedLayout) });
+
+        public static ComponentRef<FusionPivotView, TModel> LoadPersistedLayout<TModel, TResponse>(
+            this ComponentRef<FusionPivotView, TModel> self,
+            ResponseBody<TResponse> source,
+            Expression<System.Func<TResponse, string>> path)
+            where TModel : class
+            where TResponse : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            return self.EmitCall(
+                LoadPersistDataMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.Read(source.Scope, sourcePath, Shape.String)
+                });
+        }
+
+        public static ComponentRef<FusionPivotView, TModel> Refresh<TModel>(
+            this ComponentRef<FusionPivotView, TModel> self)
+            where TModel : class
+            => self.EmitCall(RefreshMethod);
+
+        public static ComponentRef<FusionPivotView, TModel> ShowConditionalFormattingDialog<TModel>(
+            this ComponentRef<FusionPivotView, TModel> self)
+            where TModel : class
+            => self.EmitCall(ConditionalFormattingDialogMethod);
+
+        public static ComponentRef<FusionPivotView, TModel> CreateCalculatedFieldDialog<TModel>(
+            this ComponentRef<FusionPivotView, TModel> self)
+            where TModel : class
+            => self.EmitCall(CalculatedFieldDialogMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewHtmlExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.PivotView;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for rendering Syncfusion PivotView with reactive event support.
+    /// </summary>
+    public static class FusionPivotViewHtmlExtensions
+    {
+        public static FusionPivotViewBuilder<TModel> FusionPivotView<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<PivotViewBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().PivotView(elementId);
+            build(builder);
+
+            return new FusionPivotViewBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionPivotView/FusionPivotViewReactiveExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires PivotView events into the reactive plan.
+    /// </summary>
+    public static class FusionPivotViewReactiveExtensions
+    {
+        private static readonly FusionPivotView Component = new FusionPivotView();
+
+        public static FusionPivotViewBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionPivotViewBuilder<TModel> builder,
+            Func<FusionPivotViewEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionPivotViewEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButton.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButton.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 SmartPasteButton. Syncfusion does not ship an MVC builder for this
+    /// package version, so this vertical slice owns the typed render helper.
+    /// </summary>
+    public sealed class FusionSmartPasteButton : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButtonExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButtonExtensions.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionSmartPasteButtonExtensions
+    {
+        private static readonly ComponentProperty<bool> DisabledProperty =
+            ComponentProperty<bool>.Named("disabled");
+
+        private static readonly ComponentMethod ClickMethod =
+            ComponentMethod.Named("click");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        public static ComponentRef<FusionSmartPasteButton, TModel> Click<TModel>(
+            this ComponentRef<FusionSmartPasteButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClickMethod);
+
+        public static ComponentRef<FusionSmartPasteButton, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionSmartPasteButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        public static ComponentRef<FusionSmartPasteButton, TModel> SetDisabled<TModel>(
+            this ComponentRef<FusionSmartPasteButton, TModel> self,
+            bool disabled)
+            where TModel : class
+            => self.EmitSet(DisabledProperty, ValueExpression.Literal(disabled));
+
+        public static TypedComponentSource<bool> Disabled<TModel>(
+            this ComponentRef<FusionSmartPasteButton, TModel> self)
+            where TModel : class
+            => self.Read(DisabledProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButtonHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButtonHtmlExtensions.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionSmartPasteButtonHtmlExtensions
+    {
+        public static IHtmlContent FusionSmartPasteButton<TModel>(
+            this IHtmlHelper<TModel> html,
+            string elementId,
+            Action<FusionSmartPasteButtonOptions> configure)
+        {
+            var options = new FusionSmartPasteButtonOptions();
+            configure(options);
+
+            return new HtmlString(RenderButton(elementId, options) + RenderInitializer(elementId, options));
+        }
+
+        private static string RenderButton(string elementId, FusionSmartPasteButtonOptions options)
+        {
+            var attributes = new Dictionary<string, string>
+            {
+                ["id"] = elementId,
+                ["type"] = "button"
+            };
+
+            if (!string.IsNullOrWhiteSpace(options.CssClass))
+            {
+                attributes["class"] = options.CssClass;
+            }
+
+            var writer = new System.Text.StringBuilder("<button");
+            foreach (var attribute in attributes)
+            {
+                writer.Append(' ')
+                    .Append(HtmlEncoder.Default.Encode(attribute.Key))
+                    .Append("=\"")
+                    .Append(HtmlEncoder.Default.Encode(attribute.Value))
+                    .Append('"');
+            }
+
+            writer.Append('>')
+                .Append(HtmlEncoder.Default.Encode(options.Content))
+                .Append("</button>");
+
+            return writer.ToString();
+        }
+
+        private static string RenderInitializer(string elementId, FusionSmartPasteButtonOptions options)
+        {
+            var payload = new
+            {
+                content = options.Content,
+                isPrimary = options.IsPrimary,
+                aiAssistEndpoint = options.AiAssistEndpoint
+            };
+
+            var json = JsonSerializer.Serialize(payload);
+            var encodedId = JavaScriptEncoder.Default.Encode(elementId);
+
+            return "<script>(function(){document.addEventListener('DOMContentLoaded',function(){"
+                + "var options=" + json + ";"
+                + "var endpoint=options.aiAssistEndpoint;delete options.aiAssistEndpoint;"
+                + "if(endpoint){options.aiAssistHandler=async function(settings){"
+                + "var response=await fetch(endpoint,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(settings)});"
+                + "return await response.text();};}"
+                + "new ej.buttons.SmartPasteButton(options).appendTo('#" + encodedId + "');"
+                + "});})();</script>";
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButtonOptions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartPasteButton/FusionSmartPasteButtonOptions.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionSmartPasteButtonOptions
+    {
+        public string Content { get; set; } = "Smart Paste";
+        public string AiAssistEndpoint { get; set; } = "";
+        public string CssClass { get; set; } = "";
+        public bool IsPrimary { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/Events/FusionSmartTextAreaAfterSuggestionInsertArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/Events/FusionSmartTextAreaAfterSuggestionInsertArgs.cs
@@ -1,0 +1,7 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionSmartTextAreaAfterSuggestionInsertArgs
+    {
+        public string InsertedText { get; set; } = "";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/Events/FusionSmartTextAreaBeforeSuggestionInsertArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/Events/FusionSmartTextAreaBeforeSuggestionInsertArgs.cs
@@ -1,0 +1,8 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionSmartTextAreaBeforeSuggestionInsertArgs
+    {
+        public string Text { get; set; } = "";
+        public bool Cancel { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextArea.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextArea.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 SmartTextArea. Syncfusion does not ship an MVC builder for this
+    /// package version, so this vertical slice owns the typed render helper.
+    /// </summary>
+    public sealed class FusionSmartTextArea : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionSmartTextArea(), "smarttextarea");
+
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaEvents.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionSmartTextAreaEvents
+    {
+        public static readonly FusionSmartTextAreaEvents Instance = new FusionSmartTextAreaEvents();
+        private FusionSmartTextAreaEvents() { }
+
+        public TypedEvent<FusionSmartTextAreaBeforeSuggestionInsertArgs> BeforeSuggestionInsert =>
+            new TypedEvent<FusionSmartTextAreaBeforeSuggestionInsertArgs>(
+                "beforeSuggestionInsert", new FusionSmartTextAreaBeforeSuggestionInsertArgs());
+
+        public TypedEvent<FusionSmartTextAreaAfterSuggestionInsertArgs> AfterSuggestionInsert =>
+            new TypedEvent<FusionSmartTextAreaAfterSuggestionInsertArgs>(
+                "afterSuggestionInsert", new FusionSmartTextAreaAfterSuggestionInsertArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaExtensions.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionSmartTextAreaExtensions
+    {
+        private static readonly FusionSmartTextArea Component = new FusionSmartTextArea();
+
+        private static readonly ComponentProperty<string> ValueProperty =
+            ComponentProperty<string>.Named(Component.ValueMember);
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        public static ComponentRef<FusionSmartTextArea, TModel> SetValue<TModel>(
+            this ComponentRef<FusionSmartTextArea, TModel> self,
+            string value)
+            where TModel : class
+            => self.EmitSet(ValueProperty, ValueExpression.Literal(value));
+
+        public static TypedComponentSource<string> Value<TModel>(
+            this ComponentRef<FusionSmartTextArea, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+
+        public static ComponentRef<FusionSmartTextArea, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionSmartTextArea, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaHtmlExtensions.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionSmartTextAreaHtmlExtensions
+    {
+        public static void FusionSmartTextArea<TModel, TProp>(
+            this InputBoundField<TModel, TProp> setup,
+            Action<FusionSmartTextAreaOptions> configure)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionSmartTextArea.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var options = new FusionSmartTextAreaOptions();
+            configure(options);
+
+            var attributes = new Dictionary<string, string>
+            {
+                ["id"] = setup.ElementId,
+                ["name"] = setup.BindingPath,
+                ["rows"] = options.Rows.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            };
+
+            if (!string.IsNullOrWhiteSpace(options.CssClass))
+            {
+                attributes["class"] = options.CssClass;
+            }
+
+            var content = new HtmlString(RenderTextArea(attributes, options.Value) + RenderInitializer(setup.ElementId, options));
+            setup.Render(content);
+        }
+
+        private static string RenderTextArea(
+            IReadOnlyDictionary<string, string> attributes,
+            string value)
+        {
+            var writer = new System.Text.StringBuilder("<textarea");
+            foreach (var attribute in attributes)
+            {
+                writer.Append(' ')
+                    .Append(HtmlEncoder.Default.Encode(attribute.Key))
+                    .Append("=\"")
+                    .Append(HtmlEncoder.Default.Encode(attribute.Value))
+                    .Append('"');
+            }
+
+            writer.Append('>')
+                .Append(HtmlEncoder.Default.Encode(value))
+                .Append("</textarea>");
+
+            return writer.ToString();
+        }
+
+        private static string RenderInitializer(
+            string elementId,
+            FusionSmartTextAreaOptions options)
+        {
+            var payload = new
+            {
+                value = options.Value,
+                userRole = options.UserRole,
+                UserPhrases = options.UserPhrases,
+                showSuggestionOnPopup = ToSyncfusionMode(options.SuggestionMode),
+                suggestionEndpoint = options.SuggestionEndpoint
+            };
+
+            var json = JsonSerializer.Serialize(payload);
+            var encodedId = JavaScriptEncoder.Default.Encode(elementId);
+
+            return "<script>(function(){document.addEventListener('DOMContentLoaded',function(){"
+                + "var options=" + json + ";"
+                + "var endpoint=options.suggestionEndpoint;delete options.suggestionEndpoint;"
+                + "if(endpoint){options.aiSuggestionHandler=async function(settings){"
+                + "var response=await fetch(endpoint,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(settings)});"
+                + "return await response.text();};}"
+                + "new ej.inputs.SmartTextArea(options).appendTo('#" + encodedId + "');"
+                + "});})();</script>";
+        }
+
+        private static string ToSyncfusionMode(FusionSmartSuggestionMode mode)
+        {
+            switch (mode)
+            {
+                case FusionSmartSuggestionMode.Inline:
+                    return "Disable";
+                case FusionSmartSuggestionMode.Popup:
+                    return "Enable";
+                default:
+                    return "None";
+            }
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaOptions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaOptions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public sealed class FusionSmartTextAreaOptions
+    {
+        public string Value { get; set; } = "";
+        public string UserRole { get; set; } = "";
+        public IReadOnlyList<string> UserPhrases { get; set; } = System.Array.Empty<string>();
+        public string SuggestionEndpoint { get; set; } = "";
+        public FusionSmartSuggestionMode SuggestionMode { get; set; } = FusionSmartSuggestionMode.None;
+        public string CssClass { get; set; } = "";
+        public int Rows { get; set; } = 4;
+    }
+
+    public enum FusionSmartSuggestionMode
+    {
+        None,
+        Inline,
+        Popup
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSmartTextArea/FusionSmartTextAreaReactiveExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static class FusionSmartTextAreaReactiveExtensions
+    {
+        private static readonly FusionSmartTextArea Component = new FusionSmartTextArea();
+
+        public static void Reactive<TModel, TArgs>(
+            this ReactivePlan<TModel> plan,
+            string componentId,
+            Func<FusionSmartTextAreaEvents, TypedEvent<TArgs>> on,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = on(FusionSmartTextAreaEvents.Instance);
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+        }
+
+        public static void Reactive<TModel, TProp, TArgs>(
+            this ReactivePlan<TModel> plan,
+            Expression<Func<TModel, TProp>> component,
+            Func<FusionSmartTextAreaEvents, TypedEvent<TArgs>> on,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var componentId = IdGenerator.For(component);
+            plan.Reactive(componentId, on, pipeline);
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/AIAssistViewController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/AIAssistViewController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/AIAssistView")]
+    public class AIAssistViewController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/AIAssistView/Index.cshtml",
+                new AIAssistViewModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ChipListController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ChipListController.cs
@@ -1,0 +1,44 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/ChipList")]
+    public class ChipListController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/ChipList/Index.cshtml",
+                new ChipListModel());
+        }
+
+        [HttpPost("QuickFilter")]
+        public IActionResult QuickFilter([FromBody] ChipQuickFilterRequest? request)
+        {
+            var filters = request?.Filters ?? [];
+            var residents = new[]
+            {
+                new { Name = "Ava Stone", Tags = new[] { "fall", "hydration" } },
+                new { Name = "Mateo Reed", Tags = new[] { "meds" } },
+                new { Name = "Leah Kim", Tags = new[] { "hydration" } },
+                new { Name = "Nora Gray", Tags = new[] { "fall", "meds" } }
+            };
+
+            var names = residents
+                .Where(resident => filters.Length == 0 || resident.Tags.Any(filters.Contains))
+                .Select(resident => resident.Name)
+                .ToArray();
+
+            return Json(new ChipQuickFilterResponse
+            {
+                Filters = filters,
+                Names = names,
+                Count = names.Length
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/KanbanController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/KanbanController.cs
@@ -1,0 +1,189 @@
+using System.Collections.Generic;
+using System.Linq;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/Kanban")]
+    public class KanbanController : Controller
+    {
+        private static readonly object BoardLock = new object();
+        private static List<KanbanTaskCard> BoardCards = KanbanSeedData.Cards.ToList();
+        private static int NextCardId = 900;
+
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Kanban/Index.cshtml",
+                new KanbanModel());
+        }
+
+        [HttpGet("~/api/kanban/board")]
+        public IActionResult Board(string? selectedFacilityId)
+        {
+            var cards = CardsForFacility(selectedFacilityId);
+            return Ok(new KanbanBoardResponse
+            {
+                Message = $"loaded:{(string.IsNullOrWhiteSpace(selectedFacilityId) ? "ALL" : selectedFacilityId)}:{cards.Count}",
+                Cards = cards,
+                OpenCount = cards.Count(card => card.Status == "Open"),
+                ReviewCount = cards.Count(card => card.Status == "Review"),
+                AssistedLivingCount = cards.Count(card => card.FacilityId == "AL")
+            });
+        }
+
+        [HttpPost("~/api/kanban/reset")]
+        public IActionResult Reset()
+        {
+            lock (BoardLock)
+            {
+                BoardCards = KanbanSeedData.Cards.ToList();
+                NextCardId = 900;
+            }
+
+            return Ok(new { message = "reset" });
+        }
+
+        [HttpPost("~/api/kanban/audit")]
+        public IActionResult Audit([FromBody] KanbanAuditRequest request)
+        {
+            return Ok(new KanbanAuditResponse
+            {
+                TotalCards = request.Cards.Count,
+                OpenCards = request.OpenCards.Count,
+                AssistedLivingCards = request.AssistedLivingCards.Count,
+                Summary = $"audit:{request.Cards.Count}:{request.OpenCards.Count}:{request.AssistedLivingCards.Count}"
+            });
+        }
+
+        [HttpPost("~/api/kanban/cards")]
+        public IActionResult Add()
+        {
+            KanbanTaskCard card;
+            lock (BoardLock)
+            {
+                card = KanbanSeedData.NewCard(NextCardId++, "AL");
+                BoardCards.Add(card);
+            }
+
+            return Ok(new KanbanCardMutationResponse
+            {
+                Message = $"post:{card.Id}",
+                Card = card,
+                CardId = card.Id
+            });
+        }
+
+        [HttpPut("~/api/kanban/cards/{cardId:int}")]
+        public IActionResult Update(int cardId)
+        {
+            var card = KanbanSeedData.UpdatedCard();
+            lock (BoardLock)
+            {
+                BoardCards = BoardCards
+                    .Select(existing => existing.Id == cardId ? card : existing)
+                    .ToList();
+            }
+
+            return Ok(new KanbanCardMutationResponse
+            {
+                Message = $"put:{card.Id}:{card.Status}",
+                Card = card,
+                CardId = card.Id
+            });
+        }
+
+        [HttpDelete("~/api/kanban/cards/{cardId:int}")]
+        public IActionResult Delete(int cardId)
+        {
+            lock (BoardLock)
+            {
+                BoardCards = BoardCards
+                    .Where(card => card.Id != cardId)
+                    .ToList();
+            }
+
+            return Ok(new KanbanCardMutationResponse
+            {
+                Message = $"delete:{cardId}",
+                CardId = cardId
+            });
+        }
+
+        [HttpPost("~/api/kanban/cards/commit")]
+        public IActionResult Commit([FromBody] KanbanCommitRequest request)
+        {
+            var changed = request.AddedRecords.Count + request.ChangedRecords.Count + request.DeletedRecords.Count;
+            lock (BoardLock)
+            {
+                foreach (var deleted in request.DeletedRecords)
+                    BoardCards.RemoveAll(card => card.Id == deleted.Id);
+
+                foreach (var changedCard in request.ChangedRecords)
+                    UpsertCard(changedCard);
+
+                foreach (var added in request.AddedRecords)
+                    UpsertCard(added);
+            }
+
+            return Ok(new KanbanCommitResponse
+            {
+                Message = $"commit:{request.RequestType}:{changed}",
+                TotalChanged = changed
+            });
+        }
+
+        [HttpPut("~/api/kanban/cards/move")]
+        public IActionResult Move([FromBody] KanbanMoveRequest request)
+        {
+            var moved = request.Cards[0];
+            lock (BoardLock)
+            {
+                BoardCards = BoardCards
+                    .Select(card => card.Id == moved.Id ? moved : card)
+                    .ToList();
+            }
+
+            return Ok(new KanbanMoveResponse
+            {
+                Message = $"move:{moved.Id}:{moved.Status}:{request.DropIndex}",
+                Card = moved,
+                DropIndex = request.DropIndex
+            });
+        }
+
+        [HttpGet("~/api/kanban/card/{cardId}/summary")]
+        public IActionResult Summary(int cardId)
+        {
+            return Ok(new KanbanCardSummaryResponse
+            {
+                Summary = $"card:{cardId}:summary"
+            });
+        }
+
+        private static List<KanbanTaskCard> CardsForFacility(string? facilityId)
+        {
+            lock (BoardLock)
+            {
+                var cards = BoardCards.AsEnumerable();
+                if (!string.IsNullOrWhiteSpace(facilityId) && facilityId != "ALL")
+                    cards = cards.Where(card => card.FacilityId == facilityId);
+
+                return cards.ToList();
+            }
+        }
+
+        private static void UpsertCard(KanbanTaskCard card)
+        {
+            var index = BoardCards.FindIndex(existing => existing.Id == card.Id);
+            if (index >= 0)
+                BoardCards[index] = card;
+            else
+                BoardCards.Add(card);
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MentionController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MentionController.cs
@@ -1,0 +1,26 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/Mention")]
+    public class MentionController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            ViewBag.CareTeam = new List<MentionPerson>
+            {
+                new() { Id = "nora", Name = "Nora Nurse", Role = "RN" },
+                new() { Id = "omar", Name = "Omar OT", Role = "Therapy" },
+                new() { Id = "liam", Name = "Liam LPN", Role = "Nursing" }
+            };
+
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Mention/Index.cshtml",
+                new MentionModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/PivotViewController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/PivotViewController.cs
@@ -1,0 +1,50 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/PivotView")]
+    public class PivotViewController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/PivotView/Index.cshtml",
+                new PivotViewModel());
+        }
+
+        [HttpGet("~/api/pivot/census")]
+        public IActionResult Census(string? facilityId)
+        {
+            var label = string.IsNullOrWhiteSpace(facilityId) ? "facility" : facilityId;
+            return Ok(new PivotCensusResponse
+            {
+                Message = $"March census loaded for {label}",
+                Rows = PivotCensusData.MarchRows
+            });
+        }
+
+        [HttpPost("~/api/pivot/{currentView}/audit")]
+        public IActionResult Audit(string currentView, [FromBody] PivotAuditRequest request)
+        {
+            return Ok(new PivotAuditResponse
+            {
+                Summary = $"{currentView}:{request.FacilityId}:{request.CurrentView}",
+                LayoutLength = request.Layout.Length
+            });
+        }
+
+        [HttpPost("~/api/pivot/layout/echo")]
+        public IActionResult EchoLayout([FromBody] PivotLayoutRequest request)
+        {
+            return Ok(new PivotLayoutResponse
+            {
+                Message = $"layout echoed:{request.Layout.Length}",
+                Layout = request.Layout
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SmartComponentsController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SmartComponentsController.cs
@@ -1,0 +1,33 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/SmartComponents")]
+    public class SmartComponentsController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/SmartComponents/Index.cshtml",
+                new SmartComponentsModel());
+        }
+
+        [HttpPost("~/api/smart-components/suggest")]
+        public IActionResult Suggest()
+        {
+            return Content("OK:[ hydrating well]", "text/plain");
+        }
+
+        [HttpPost("~/api/smart-components/paste")]
+        public IActionResult Paste()
+        {
+            return Content(
+                "FIELD Resident^^^Nora\nFIELD Room^^^212B\nFIELD Notes^^^Hydration rounds complete",
+                "text/plain");
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/AIAssistView/AIAssistViewModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/AIAssistView/AIAssistViewModel.cs
@@ -1,0 +1,6 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class AIAssistViewModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ChipList/ChipListModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ChipList/ChipListModel.cs
@@ -1,0 +1,26 @@
+using Alis.Reactive.Fusion.Components;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class ChipListModel
+    {
+    }
+
+    public sealed class ChipSelectionPayload
+    {
+        public FusionSelectedChips Selection { get; set; } = new FusionSelectedChips();
+        public FusionChipData Found { get; set; } = new FusionChipData();
+    }
+
+    public sealed class ChipQuickFilterRequest
+    {
+        public string[] Filters { get; set; } = System.Array.Empty<string>();
+    }
+
+    public sealed class ChipQuickFilterResponse
+    {
+        public string[] Filters { get; set; } = System.Array.Empty<string>();
+        public string[] Names { get; set; } = System.Array.Empty<string>();
+        public int Count { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Kanban/KanbanModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Kanban/KanbanModel.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class KanbanModel
+    {
+        public string SelectedFacilityId { get; set; } = "AL";
+    }
+
+    public sealed class KanbanFacility
+    {
+        public string Id { get; init; } = "";
+        public string Name { get; init; } = "";
+    }
+
+    public sealed class KanbanTaskCard
+    {
+        public int Id { get; init; }
+        public int CardId => Id;
+        public string Status { get; init; } = "";
+        public string Summary { get; init; } = "";
+        public string Priority { get; init; } = "";
+        public string Assignee { get; init; } = "";
+        public string FacilityId { get; init; } = "";
+        public string FacilityName { get; init; } = "";
+        public string Resident { get; init; } = "";
+        public string Due { get; init; } = "";
+        public string Tags { get; init; } = "";
+        public string CardColor { get; init; } = "";
+        public bool IsEscalated { get; init; }
+    }
+
+    public sealed class KanbanBoardResponse
+    {
+        public string Message { get; init; } = "";
+        public IReadOnlyList<KanbanTaskCard> Cards { get; init; } = Array.Empty<KanbanTaskCard>();
+        public int OpenCount { get; init; }
+        public int ReviewCount { get; init; }
+        public int AssistedLivingCount { get; init; }
+    }
+
+    public sealed class KanbanAuditRequest
+    {
+        public List<KanbanTaskCard> Cards { get; init; } = new List<KanbanTaskCard>();
+        public List<KanbanTaskCard> OpenCards { get; init; } = new List<KanbanTaskCard>();
+        public List<KanbanTaskCard> AssistedLivingCards { get; init; } = new List<KanbanTaskCard>();
+    }
+
+    public sealed class KanbanAuditResponse
+    {
+        public string Summary { get; init; } = "";
+        public int TotalCards { get; init; }
+        public int OpenCards { get; init; }
+        public int AssistedLivingCards { get; init; }
+    }
+
+    public sealed class KanbanCardMutationResponse
+    {
+        public string Message { get; init; } = "";
+        public KanbanTaskCard Card { get; init; } = new KanbanTaskCard();
+        public int CardId { get; init; }
+    }
+
+    public sealed class KanbanCommitRequest
+    {
+        public string RequestType { get; init; } = "";
+        public List<KanbanTaskCard> AddedRecords { get; init; } = new List<KanbanTaskCard>();
+        public List<KanbanTaskCard> ChangedRecords { get; init; } = new List<KanbanTaskCard>();
+        public List<KanbanTaskCard> DeletedRecords { get; init; } = new List<KanbanTaskCard>();
+    }
+
+    public sealed class KanbanCommitResponse
+    {
+        public string Message { get; init; } = "";
+        public int TotalChanged { get; init; }
+    }
+
+    public sealed class KanbanMoveRequest
+    {
+        public List<KanbanTaskCard> Cards { get; init; } = new List<KanbanTaskCard>();
+        public int DropIndex { get; init; }
+    }
+
+    public sealed class KanbanMoveResponse
+    {
+        public string Message { get; init; } = "";
+        public KanbanTaskCard Card { get; init; } = new KanbanTaskCard();
+        public int DropIndex { get; init; }
+    }
+
+    public sealed class KanbanCardSummaryResponse
+    {
+        public string Summary { get; init; } = "";
+    }
+
+    public static class KanbanSeedData
+    {
+        public static IReadOnlyList<KanbanFacility> Facilities { get; } =
+            new List<KanbanFacility>
+            {
+                new KanbanFacility { Id = "AL", Name = "Assisted Living" },
+                new KanbanFacility { Id = "MC", Name = "Memory Care" },
+                new KanbanFacility { Id = "SNF", Name = "Skilled Nursing" }
+            };
+
+        public static IReadOnlyList<KanbanTaskCard> Cards { get; } =
+            new List<KanbanTaskCard>
+            {
+                Card(101, "Open", "Assess fall risk", "High", "Ava Stone", "AL", "Assisted Living", "Eleanor Reed", "Today 10:00", "fall,assessment", "#ef4444", true),
+                Card(102, "InProgress", "Medication reconciliation", "High", "Mateo Cruz", "AL", "Assisted Living", "Harold Lane", "Today 13:00", "meds", "#f97316", true),
+                Card(103, "Review", "Care plan review", "Normal", "Nora Gray", "MC", "Memory Care", "Lena Brooks", "Tomorrow", "care-plan", "#3b82f6", false),
+                Card(104, "Done", "Hydration follow-up", "Low", "Leah Kim", "SNF", "Skilled Nursing", "Walter Finch", "Yesterday", "hydration", "#22c55e", false),
+                Card(105, "Open", "Room transfer checklist", "Normal", "Ira Bell", "MC", "Memory Care", "Miriam Chen", "Friday", "move-in", "#8b5cf6", false),
+                Card(106, "Review", "Therapy handoff", "High", "Dana Fox", "SNF", "Skilled Nursing", "Oscar Hale", "Today 16:00", "therapy", "#06b6d4", true)
+            };
+
+        public static IReadOnlyList<KanbanTaskCard> ForFacility(string? facilityId)
+        {
+            if (string.IsNullOrWhiteSpace(facilityId) || facilityId == "ALL")
+                return Cards;
+
+            return Cards
+                .Where(card => string.Equals(card.FacilityId, facilityId, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        public static KanbanTaskCard NewCard(int id, string facilityId)
+        {
+            var facility = Facilities.FirstOrDefault(x => x.Id == facilityId) ?? Facilities[0];
+            return Card(
+                id,
+                "Open",
+                "Remote wound consult",
+                "High",
+                "Rina Patel",
+                facility.Id,
+                facility.Name,
+                "Grace Taylor",
+                "Today 15:30",
+                "wound,remote",
+                "#dc2626",
+                true);
+        }
+
+        public static KanbanTaskCard UpdatedCard()
+        {
+            return Card(
+                102,
+                "Review",
+                "Medication reconciliation updated",
+                "High",
+                "Mateo Cruz",
+                "AL",
+                "Assisted Living",
+                "Harold Lane",
+                "Today 13:30",
+                "meds,updated",
+                "#2563eb",
+                true);
+        }
+
+        private static KanbanTaskCard Card(
+            int id,
+            string status,
+            string summary,
+            string priority,
+            string assignee,
+            string facilityId,
+            string facilityName,
+            string resident,
+            string due,
+            string tags,
+            string color,
+            bool escalated)
+        {
+            return new KanbanTaskCard
+            {
+                Id = id,
+                Status = status,
+                Summary = summary,
+                Priority = priority,
+                Assignee = assignee,
+                FacilityId = facilityId,
+                FacilityName = facilityName,
+                Resident = resident,
+                Due = due,
+                Tags = tags,
+                CardColor = color,
+                IsEscalated = escalated
+            };
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Mention/MentionModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Mention/MentionModel.cs
@@ -1,0 +1,13 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class MentionModel
+    {
+    }
+
+    public sealed class MentionPerson
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Role { get; set; } = "";
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/PivotView/PivotViewModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/PivotView/PivotViewModel.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class PivotViewModel
+    {
+        public IReadOnlyList<PivotCensusRow> InitialRows { get; init; } = PivotCensusData.InitialRows;
+    }
+
+    public sealed class PivotCensusRow
+    {
+        public string Wing { get; init; } = "";
+        public string CareLevel { get; init; } = "";
+        public string Month { get; init; } = "";
+        public int Residents { get; init; }
+        public decimal Revenue { get; init; }
+    }
+
+    public sealed class PivotCensusResponse
+    {
+        public string Message { get; init; } = "";
+        public IReadOnlyList<PivotCensusRow> Rows { get; init; } = new List<PivotCensusRow>();
+    }
+
+    public sealed class PivotAuditRequest
+    {
+        public string CurrentView { get; init; } = "";
+        public string FacilityId { get; init; } = "";
+        public string Layout { get; init; } = "";
+    }
+
+    public sealed class PivotAuditResponse
+    {
+        public string Summary { get; init; } = "";
+        public int LayoutLength { get; init; }
+    }
+
+    public sealed class PivotLayoutRequest
+    {
+        public string Layout { get; init; } = "";
+    }
+
+    public sealed class PivotLayoutResponse
+    {
+        public string Message { get; init; } = "";
+        public string Layout { get; init; } = "";
+    }
+
+    public static class PivotCensusData
+    {
+        public static IReadOnlyList<PivotCensusRow> InitialRows { get; } =
+            new List<PivotCensusRow>
+            {
+                Row("North", "Assisted", "Jan", 18, 126000),
+                Row("North", "Memory Care", "Jan", 9, 94500),
+                Row("South", "Assisted", "Jan", 21, 147000),
+                Row("South", "Independent", "Jan", 16, 72000),
+                Row("North", "Assisted", "Feb", 20, 140000),
+                Row("South", "Memory Care", "Feb", 11, 115500)
+            };
+
+        public static IReadOnlyList<PivotCensusRow> MarchRows { get; } =
+            new List<PivotCensusRow>
+            {
+                Row("North", "Assisted", "Mar", 12, 84000),
+                Row("South", "Memory Care", "Mar", 7, 73500),
+                Row("East", "Independent", "Mar", 14, 63000)
+            };
+
+        private static PivotCensusRow Row(
+            string wing,
+            string careLevel,
+            string month,
+            int residents,
+            decimal revenue)
+        {
+            return new PivotCensusRow
+            {
+                Wing = wing,
+                CareLevel = careLevel,
+                Month = month,
+                Residents = residents,
+                Revenue = revenue
+            };
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/SmartComponents/SmartComponentsModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/SmartComponents/SmartComponentsModel.cs
@@ -1,0 +1,7 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class SmartComponentsModel
+    {
+        public string CareNote { get; set; } = "";
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/AIAssistView/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/AIAssistView/Index.cshtml
@@ -1,0 +1,129 @@
+@model AIAssistViewModel
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionAIAssistView";
+
+    var plan = Html.ReactivePlan<AIAssistViewModel>();
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionAIAssistView</native-heading>
+    <native-text color="Secondary">
+        Syncfusion builder owns initial chat configuration. Reactive owns runtime prompt execution,
+        response updates, scroll behavior, and typed event payloads.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Runtime Commands</native-heading>
+        <native-hstack gap="Sm" class="mt-4">
+            @(Html.NativeButton("execute-prompt-btn", "Run Typed Prompt")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionAIAssistView>("care-ai")
+                        .ExecutePrompt("Summarize the medication changes");
+                    p.Element("command-status").SetText("executePrompt called");
+                }))
+
+            @(Html.NativeButton("append-object-response-btn", "Append Object Response")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionAIAssistView>("care-ai")
+                        .AddPromptResponse(
+                            "Care plan follow up",
+                            "Schedule hydration checks and confirm the updated medication list with the nurse.",
+                            true);
+                    p.Element("object-response-status").SetText("object response added");
+                }))
+
+            @(Html.NativeButton("set-prompt-btn", "Set Prompt")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var assist = p.Component<FusionAIAssistView>("care-ai");
+                    assist.SetPrompt("Prepare discharge summary");
+                    p.Element("current-prompt").SetText(assist.Prompt());
+                }))
+
+            @(Html.NativeButton("read-active-view-btn", "Read Active View")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Element("active-view").SetText(
+                        p.Component<FusionAIAssistView>("care-ai").ActiveView());
+                }))
+
+            @(Html.NativeButton("scroll-bottom-btn", "Scroll Bottom")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionAIAssistView>("care-ai").ScrollToBottom();
+                    p.Element("scroll-status").SetText("scrollToBottom called");
+                }))
+        </native-hstack>
+
+        <native-vstack gap="Xs" class="font-mono text-sm mt-4">
+            <p>Command: <span id="command-status" class="text-text-muted">-</span></p>
+            <p>Object response: <span id="object-response-status" class="text-text-muted">-</span></p>
+            <p>Current prompt: <span id="current-prompt" class="text-text-muted">-</span></p>
+            <p>Active view: <span id="active-view" class="text-text-muted">-</span></p>
+            <p>Scroll: <span id="scroll-status" class="text-text-muted">-</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">AIAssistView Component</native-heading>
+
+        @(Html.FusionAIAssistView(plan, "care-ai", b =>
+        {
+            b.Height("420px");
+            b.Width("100%");
+            b.PromptPlaceholder("Ask about care coordination");
+            b.PromptSuggestions(new[]
+            {
+                "Summarize today notes",
+                "Draft family update",
+                "List fall-risk interventions"
+            });
+            b.PromptSuggestionsHeader("Care prompts");
+            b.ShowClearButton(true);
+        })
+        .Reactive(evt => evt.PromptChanged, (args, p) =>
+        {
+            p.Element("prompt-changed-value").SetText(args, x => x.Value);
+        })
+        .Reactive(evt => evt.PromptRequest, (args, p) =>
+        {
+            p.Element("request-prompt").SetText(args, x => x.Prompt);
+            p.Element("request-status").SetText("promptRequest fired");
+            p.Component<FusionAIAssistView>("care-ai")
+                .AddPromptResponse("Reactive response added from promptRequest.", true);
+        })
+        .Reactive(evt => evt.StopRespondingClick, (args, p) =>
+        {
+            p.Element("stop-prompt").SetText(args, x => x.Prompt);
+            p.Element("stop-index").SetText(args, x => x.DataIndex);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Event Signals</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm mt-4">
+            <p>Prompt changed: <span id="prompt-changed-value" class="text-text-muted">-</span></p>
+            <p>Request status: <span id="request-status" class="text-text-muted">-</span></p>
+            <p>Request prompt: <span id="request-prompt" class="text-text-muted">-</span></p>
+            <p>Stop prompt: <span id="stop-prompt" class="text-text-muted">-</span></p>
+            <p>Stop index: <span id="stop-index" class="text-text-muted">-</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ChipList/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ChipList/Index.cshtml
@@ -1,0 +1,165 @@
+@model ChipListModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Buttons
+@{
+    ViewData["Title"] = "ChipList";
+
+    var plan = Html.ReactivePlan<ChipListModel>();
+
+    Html.On(plan, t => t.CustomEvent<ChipSelectionPayload>("chip-selection-read", (payload, p) =>
+    {
+        p.Element("selected-chip-texts").SetText(payload, x => x.Selection.Texts);
+        p.Element("found-chip-text").SetText(payload, x => x.Found.Text);
+    }));
+
+    var chips = new List<ChipCollection>
+    {
+        new() { Text = "Fall Risk", Value = "fall" },
+        new() { Text = "Hydration", Value = "hydration" },
+        new() { Text = "Medication Review", Value = "meds" }
+    };
+
+    var indexChips = new[] { "Routine", "Urgent", "Follow Up" };
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionChipList</native-heading>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <native-vstack gap="Base">
+            @(Html.FusionChipList(plan, "care-tags", b => b
+                .Chips(chips)
+                .Selection(Selection.Multiple)
+                .EnableDelete(true))
+                .Reactive(evt => evt.Clicked, (args, p) =>
+                {
+                    p.Element("chip-clicked").SetText(args, x => x.Text);
+                })
+                .Reactive(evt => evt.Deleted, (args, p) =>
+                {
+                    p.Element("chip-deleted").SetText(args, x => x.Text);
+                }))
+
+            <native-hstack gap="Sm" class="flex-wrap">
+                @(Html.NativeButton("add-chip-btn", "Add Wound Care")
+                    .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionChipList>("care-tags").Add("Wound Care");
+                        p.Element("chip-command-status").SetText("add called");
+                    }))
+                @(Html.NativeButton("select-index-chip-btn", "Select Index")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionChipList>("care-tags").SelectByIndex(1);
+                        p.Element("chip-command-status").SetText("select index called");
+                    }))
+                @(Html.NativeButton("select-text-chip-btn", "Select Text")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        var tagList = p.Component<FusionChipList>("care-tags");
+                        tagList.Add("Wound Care");
+                        tagList.SelectByText("Hydration", "Wound Care");
+                        p.DispatchWith<ChipSelectionPayload>("chip-selection-read", payload =>
+                        {
+                            payload.Set(x => x.Selection, tagList.SelectedChips());
+                            payload.Set(x => x.Found, tagList.Find(1));
+                        });
+                        p.Element("chip-command-status").SetText("select text called");
+                    }))
+                @(Html.NativeButton("remove-chip-btn", "Remove First")
+                    .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionChipList>("care-tags").RemoveByIndex(0);
+                        p.Element("chip-command-status").SetText("remove called");
+                    }))
+                @(Html.NativeButton("read-selected-values-btn", "Read Selected Values")
+                    .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        var tagList = p.Component<FusionChipList>("care-tags");
+                        tagList.SelectByText("Hydration", "Medication Review");
+                        p.Element("selected-chip-values").SetText(tagList.SelectedChipValues());
+                        p.Element("chip-command-status").SetText("selected values read");
+                    }))
+                @(Html.NativeButton("apply-chip-filters-btn", "Apply Filters")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        var tagList = p.Component<FusionChipList>("care-tags");
+                        p.Post("/Sandbox/Components/ChipList/QuickFilter")
+                         .Gather(g => g.Include(tagList.SelectedChipValues(), "filters"))
+                         .Response(r => r.OnSuccess<ChipQuickFilterResponse>((json, s) =>
+                         {
+                             s.Element("quick-filter-values").SetText(json, x => x.Filters);
+                             s.Element("quick-filter-count").SetText(json, x => x.Count);
+                             s.Element("quick-filter-names").SetText(json, x => x.Names);
+                             s.Element("chip-command-status").SetText("filters applied");
+                         }));
+                    }))
+            </native-hstack>
+
+            <native-vstack gap="Xs" class="font-mono text-sm">
+                <p>Command: <span id="chip-command-status">idle</span></p>
+                <p>Clicked: <span id="chip-clicked">none</span></p>
+                <p>Deleted: <span id="chip-deleted">none</span></p>
+                <p>Selected texts: <span id="selected-chip-texts">none</span></p>
+                <p>Selected values: <span id="selected-chip-values">none</span></p>
+                <p>Found chip: <span id="found-chip-text">none</span></p>
+                <p>Quick filter values: <span id="quick-filter-values">none</span></p>
+                <p>Quick filter count: <span id="quick-filter-count">none</span></p>
+                <p>Quick filter names: <span id="quick-filter-names">none</span></p>
+            </native-vstack>
+        </native-vstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <native-vstack gap="Base">
+            @(Html.FusionChipList(plan, "index-tags", b => b
+                .Chips(indexChips)
+                .Selection(Selection.Multiple)))
+
+            <native-hstack gap="Sm" class="flex-wrap">
+                @(Html.NativeButton("select-indexes-chip-btn", "Select Indexes")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionChipList>("index-tags").SelectByIndexes(0, 2);
+                        p.Element("index-chip-command-status").SetText("select indexes called");
+                    }))
+                @(Html.NativeButton("set-selected-indexes-btn", "Set Selected Indexes")
+                    .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        var tagList = p.Component<FusionChipList>("index-tags");
+                        tagList.SetSelectedChipIndexes(0, 2);
+                        p.Element("selected-chip-indexes").SetText(tagList.SelectedChipIndexes());
+                        p.Element("index-chip-command-status").SetText("selected indexes set");
+                    }))
+                @(Html.NativeButton("remove-indexes-chip-btn", "Remove Indexes")
+                    .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionChipList>("index-tags").RemoveByIndexes(0, 2);
+                        p.Element("index-chip-command-status").SetText("remove indexes called");
+                    }))
+            </native-hstack>
+
+            <native-vstack gap="Xs" class="font-mono text-sm">
+                <p>Index command: <span id="index-chip-command-status">idle</span></p>
+                <p>Selected indexes: <span id="selected-chip-indexes">none</span></p>
+            </native-vstack>
+        </native-vstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </section>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Kanban/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Kanban/Index.cshtml
@@ -1,0 +1,336 @@
+@model KanbanModel
+@using Alis.Reactive
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Fusion.Templates
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Kanban
+@{
+    ViewData["Title"] = "Kanban";
+
+    var plan = Html.ReactivePlan<KanbanModel>();
+
+    var cardTemplate = FusionTemplate.Create<KanbanTaskCard>()
+        .Class("kanban-task-card space-y-2 text-sm")
+        .Div(row => row.Class("flex items-start justify-between gap-2")
+            .Span(m => m.Summary, "font-semibold text-slate-900")
+            .Badge(m => m.Priority, "rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700"))
+        .Div(row => row.Class("text-xs text-slate-600")
+            .Span("Resident: ", "font-medium text-slate-500")
+            .Span(m => m.Resident))
+        .Div(row => row.Class("flex items-center justify-between text-xs")
+            .Span(m => m.Assignee, "text-slate-700")
+            .Span(m => m.Due, "font-medium text-slate-500"))
+        .When(m => m.IsEscalated,
+            then: t => t.Badge("ESCALATED", "rounded bg-red-100 px-2 py-0.5 text-xs font-bold text-red-700"),
+            @else: e => e.Badge(m => m.FacilityName, "rounded bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700"))
+        .Render();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        p.Get("/api/kanban/board")
+         .Gather(g => g.Static("selectedFacilityId", "AL"))
+         .Response(r => r.OnSuccess<KanbanBoardResponse>((json, s) =>
+         {
+             s.Component<FusionKanban>("care-kanban").SetDataSource(json, x => x.Cards);
+             s.Element("kanban-status").SetText(json, x => x.Message);
+             s.Element("kanban-open-count").SetText(json, x => x.OpenCount);
+             s.Element("kanban-review-count").SetText(json, x => x.ReviewCount);
+             s.Element("kanban-al-count").SetText(json, x => x.AssistedLivingCount);
+         }));
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionKanban</native-heading>
+
+    <section class="rounded-lg border border-border bg-white p-4 shadow-sm">
+        <native-hstack gap="Base" wrap="true" align="End">
+            @{ Html.InputField(plan, m => m.SelectedFacilityId, o => o.Label("Facility"))
+                    .FusionDropDownList(b => b
+                        .Placeholder("Select facility")
+                        .DataSource(KanbanSeedData.Facilities)
+                        .Fields<KanbanFacility>(t => t.Name, v => v.Id)
+                        .Value("AL")
+                        .Reactive(plan, evt => evt.Changed, (args, p) =>
+                        {
+                            p.Element("kanban-status").SetText("loading");
+                            p.Get("/api/kanban/board")
+                             .Gather(g => g.Include<FusionDropDownList, KanbanModel>(m => m.SelectedFacilityId))
+                             .Response(r => r.OnSuccess<KanbanBoardResponse>((json, s) =>
+                             {
+                                 s.Component<FusionKanban>("care-kanban").SetDataSource(json, x => x.Cards);
+                                 s.Element("kanban-status").SetText(json, x => x.Message);
+                                 s.Element("kanban-open-count").SetText(json, x => x.OpenCount);
+                                 s.Element("kanban-review-count").SetText(json, x => x.ReviewCount);
+                                 s.Element("kanban-al-count").SetText(json, x => x.AssistedLivingCount);
+                             }));
+                        })); }
+
+            <native-hstack gap="Sm" class="ml-auto text-sm">
+                <span>Status: <span id="kanban-status" class="font-medium">booting</span></span>
+                <span>Open: <span id="kanban-open-count" class="font-medium">0</span></span>
+                <span>Review: <span id="kanban-review-count" class="font-medium">0</span></span>
+                <span>AL: <span id="kanban-al-count" class="font-medium">0</span></span>
+            </native-hstack>
+        </native-hstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-4 shadow-sm">
+        <native-hstack gap="Sm" class="flex-wrap">
+            @(Html.NativeButton("kanban-add-card-btn", "Add Remote Card")
+                .CssClass("rounded-md bg-primary px-3 py-2 text-sm font-medium text-white")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/api/kanban/cards")
+                     .Response(r => r.OnSuccess<KanbanCardMutationResponse>((json, s) =>
+                     {
+                         s.Component<FusionKanban>("care-kanban").AddCard(json, x => x.Card, 0);
+                         s.Element("kanban-command-status").SetText(json, x => x.Message);
+                     }));
+                }))
+            @(Html.NativeButton("kanban-update-card-btn", "Update Remote Card")
+                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Put("/api/kanban/cards/102", g => g.Static("source", "button"))
+                     .Response(r => r.OnSuccess<KanbanCardMutationResponse>((json, s) =>
+                     {
+                         s.Component<FusionKanban>("care-kanban").UpdateCard(json, x => x.Card);
+                         s.Element("kanban-command-status").SetText(json, x => x.Message);
+                     }));
+                }))
+            @(Html.NativeButton("kanban-delete-card-btn", "Delete Remote Card")
+                .CssClass("rounded-md bg-rose-600 px-3 py-2 text-sm font-medium text-white")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Delete("/api/kanban/cards/101")
+                     .Response(r => r.OnSuccess<KanbanCardMutationResponse>((json, s) =>
+                     {
+                         s.Component<FusionKanban>("care-kanban").DeleteCard(json, x => x.CardId);
+                         s.Element("kanban-command-status").SetText(json, x => x.Message);
+                     }));
+                }))
+            @(Html.NativeButton("kanban-hide-done-btn", "Hide Done")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").HideColumn("Done");
+                    p.Element("kanban-column-status").SetText("done hidden");
+                }))
+            @(Html.NativeButton("kanban-show-done-btn", "Show Done")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").ShowColumn("Done");
+                    p.Element("kanban-column-status").SetText("done shown");
+                }))
+            @(Html.NativeButton("kanban-add-column-btn", "Add Blocked")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").AddColumn(
+                        new FusionKanbanColumn { HeaderText = "Blocked", KeyField = "Blocked" },
+                        2);
+                    p.Element("kanban-column-status").SetText("blocked added");
+                }))
+            @(Html.NativeButton("kanban-delete-column-btn", "Delete Blocked")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").DeleteColumn(2);
+                    p.Element("kanban-column-status").SetText("blocked deleted");
+                }))
+            @(Html.NativeButton("kanban-spinner-btn", "Spinner")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").ShowSpinner();
+                    p.Component<FusionKanban>("care-kanban").HideSpinner();
+                    p.Element("kanban-spinner-status").SetText("spinner toggled");
+                }))
+            @(Html.NativeButton("kanban-open-dialog-btn", "Open Dialog")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").OpenAddDialog(KanbanSeedData.NewCard(950, "AL"));
+                }))
+            @(Html.NativeButton("kanban-open-edit-dialog-btn", "Open Edit Dialog")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").OpenEditDialog(KanbanSeedData.UpdatedCard());
+                }))
+            @(Html.NativeButton("kanban-open-close-dialog-btn", "Open + Close Dialog")
+                .CssClass("rounded-md border border-border px-3 py-2 text-sm font-medium")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionKanban>("care-kanban").OpenAddDialog(KanbanSeedData.NewCard(951, "AL"));
+                    p.Component<FusionKanban>("care-kanban").CloseDialog();
+                    p.Element("kanban-dialog-status").SetText("open close requested");
+                }))
+            @(Html.NativeButton("kanban-audit-btn", "Audit Board")
+                .CssClass("rounded-md bg-accent px-3 py-2 text-sm font-medium text-white")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var board = p.Component<FusionKanban>("care-kanban");
+                    p.Post("/api/kanban/audit")
+                     .Gather(g => g
+                         .Include(board.Cards<KanbanModel, KanbanTaskCard>(), "cards")
+                         .Include(board.ColumnData<KanbanModel, KanbanTaskCard>("Open"), "openCards")
+                         .Include(board.SwimlaneData<KanbanModel, KanbanTaskCard>("AL"), "assistedLivingCards"))
+                     .Response(r => r.OnSuccess<KanbanAuditResponse>((json, s) =>
+                     {
+                         s.Element("kanban-audit-summary").SetText(json, x => x.Summary);
+                         s.Element("kanban-audit-total").SetText(json, x => x.TotalCards);
+                         s.Element("kanban-audit-open").SetText(json, x => x.OpenCards);
+                         s.Element("kanban-audit-al").SetText(json, x => x.AssistedLivingCards);
+                     }));
+                }))
+        </native-hstack>
+
+        <native-vstack gap="Xs" class="mt-4 font-mono text-sm">
+            <p>Command: <span id="kanban-command-status">idle</span></p>
+            <p>Column: <span id="kanban-column-status">idle</span></p>
+            <p>Spinner: <span id="kanban-spinner-status">idle</span></p>
+            <p>Dialog: <span id="kanban-dialog-status">idle</span></p>
+            <p>Dialog close: <span id="kanban-dialog-close-status">none</span></p>
+            <p>Action begin: <span id="kanban-action-begin">none</span></p>
+            <p>Action: <span id="kanban-action-request">none</span></p>
+            <p>Data: <span id="kanban-data-binding-status">none</span>/<span id="kanban-data-bound-status">none</span></p>
+            <p>Query cell: <span id="kanban-query-cell-status">none</span></p>
+            <p>Drag start: <span id="kanban-drag-start-summary">none</span></p>
+            <p>Dragging: <span id="kanban-drag-status">none</span></p>
+            <p>Commit: <span id="kanban-commit-status">none</span></p>
+            <p>Move: <span id="kanban-move-status">none</span></p>
+            <p>Clicked: <span id="kanban-clicked-summary">none</span></p>
+            <p>Double clicked: <span id="kanban-double-clicked-summary">none</span></p>
+            <p>Rendered: <span id="kanban-rendered-summary">none</span></p>
+            <p>Route summary: <span id="kanban-route-summary">none</span></p>
+            <p>Audit: <span id="kanban-audit-summary">none</span></p>
+            <p>Audit counts: <span id="kanban-audit-total">0</span>/<span id="kanban-audit-open">0</span>/<span id="kanban-audit-al">0</span></p>
+        </native-vstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-4 shadow-sm" style="height: 640px;">
+        @(Html.FusionKanban(plan, "care-kanban", b =>
+            {
+                b.Width("100%");
+                b.Height("100%");
+                b.KeyField("status");
+                b.DataSource(new List<KanbanTaskCard>());
+                b.AllowDragAndDrop(true);
+                b.AllowColumnDragAndDrop(true);
+                b.ShowEmptyColumn(true);
+                b.EnableTooltip(true);
+                b.CardSettings(new KanbanCardSettings
+                {
+                    HeaderField = "cardId",
+                    ContentField = "summary",
+                    TagsField = "tags",
+                    GrabberField = "cardColor",
+                    SelectionType = SelectionType.Multiple,
+                    Template = cardTemplate
+                });
+                b.SwimlaneSettings(new KanbanSwimlaneSettings
+                {
+                    KeyField = "facilityId",
+                    TextField = "facilityName",
+                    ShowEmptyRow = true,
+                    ShowItemCount = true
+                });
+                b.Columns(new List<KanbanColumn>
+                {
+                    new KanbanColumn { HeaderText = "Open", KeyField = "Open", ShowAddButton = true },
+                    new KanbanColumn { HeaderText = "In Progress", KeyField = "InProgress" },
+                    new KanbanColumn { HeaderText = "Review", KeyField = "Review" },
+                    new KanbanColumn { HeaderText = "Done", KeyField = "Done" }
+                });
+            })
+            .Reactive(evt => evt.DataBinding<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-data-binding-status").SetText(args, x => x.Result[0].Summary);
+            })
+            .Reactive(evt => evt.DataBound, (args, p) =>
+            {
+                p.Element("kanban-data-bound-status").SetText("bound");
+            })
+            .Reactive(evt => evt.CardClick<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-clicked-summary").SetText(args, x => x.Data.Summary);
+                p.Get("/api/kanban/card/{cardId}/summary")
+                 .Gather(g => g.RouteParam("cardId", args, x => x.Data.Id))
+                 .Response(r => r.OnSuccess<KanbanCardSummaryResponse>((json, s) =>
+                 {
+                     s.Element("kanban-route-summary").SetText(json, x => x.Summary);
+                 }));
+            })
+            .Reactive(evt => evt.CardDoubleClick<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-double-clicked-summary").SetText(args, x => x.Data.Summary);
+            })
+            .Reactive(evt => evt.QueryCellInfo, (args, p) =>
+            {
+                p.Element("kanban-query-cell-status").SetText(args, x => x.RequestType);
+            })
+            .Reactive(evt => evt.CardRendered<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-rendered-summary").SetText(args, x => x.Data.Summary);
+            })
+            .Reactive(evt => evt.DragStart<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-drag-start-summary").SetText(args, x => x.Data[0].Summary);
+            })
+            .Reactive(evt => evt.Drag<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-drag-status").SetText(args, x => x.Data[0].Summary);
+            })
+            .Reactive(evt => evt.ActionBegin<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-action-begin").SetText(args, x => x.RequestType);
+            })
+            .Reactive(evt => evt.ActionComplete<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-action-request").SetText(args, x => x.RequestType);
+            })
+            .Reactive(evt => evt.DataSourceChanged<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Post("/api/kanban/cards/commit")
+                 .Gather(g => g
+                     .FromEvent(args, x => x.RequestType, "requestType")
+                     .FromEvent(args, x => x.AddedRecords, "addedRecords")
+                     .FromEvent(args, x => x.ChangedRecords, "changedRecords")
+                     .FromEvent(args, x => x.DeletedRecords, "deletedRecords"))
+                 .Response(r => r.OnSuccess<KanbanCommitResponse>((json, s) =>
+                 {
+                     args.EndEdit(s);
+                     s.Element("kanban-commit-status").SetText(json, x => x.Message);
+                 }));
+            })
+            .Reactive(evt => evt.DragStop<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Put("/api/kanban/cards/move", g => g
+                     .FromEvent(args, x => x.Data, "cards")
+                     .FromEvent(args, x => x.DropIndex, "dropIndex"))
+                 .Response(r => r.OnSuccess<KanbanMoveResponse>((json, s) =>
+                 {
+                     s.Component<FusionKanban>("care-kanban").UpdateCard(json, x => x.Card);
+                     s.Element("kanban-move-status").SetText(json, x => x.Message);
+                 }));
+            })
+            .Reactive(evt => evt.DialogOpen<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-dialog-status").SetText(args, x => x.RequestType);
+            })
+            .Reactive(evt => evt.DialogClose<KanbanTaskCard>(), (args, p) =>
+            {
+                p.Element("kanban-dialog-close-status").SetText(args, x => x.RequestType);
+            }))
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </section>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Mention/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Mention/Index.cshtml
@@ -1,0 +1,113 @@
+@model MentionModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@{
+    ViewData["Title"] = "Mention";
+
+    var plan = Html.ReactivePlan<MentionModel>();
+    var careTeam = (List<MentionPerson>)ViewBag.CareTeam;
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionMention</native-heading>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <native-vstack gap="Base">
+            <label for="care-note" class="text-sm font-medium text-text-primary">Care note target</label>
+            <textarea id="care-note" rows="4" class="w-full rounded-md border border-border p-3 text-sm">No</textarea>
+
+            @(Html.FusionMention(plan, "care-mention", b => b
+                .Target("#care-note")
+                .DataSource(careTeam)
+                .Fields<MentionPerson>(x => x.Name, x => x.Id)
+                .MentionChar('@')
+                .MinLength(0)
+                .RequireLeadingSpace(false)
+                .ShowMentionChar(true)
+                .Highlight(true)
+                .PopupWidth("280px"))
+                .Reactive(evt => evt.Opened, (args, p) =>
+                {
+                    p.Element("mention-popup-status").SetText("opened");
+                })
+                .Reactive(evt => evt.Closed, (args, p) =>
+                {
+                    p.Element("mention-popup-status").SetText("closed");
+                })
+                .Reactive(evt => evt.Changed, (args, p) =>
+                {
+                    p.Element("mention-value").SetHtml(args, x => x.Value);
+                }))
+
+            <native-hstack gap="Sm">
+                @(Html.NativeButton("mention-search-btn", "Search Nora")
+                    .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionMention>("care-mention").Search("No", 96, 160);
+                        p.Element("mention-command-status").SetText("search called");
+                    }))
+                @(Html.NativeButton("mention-show-btn", "Show")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionMention>("care-mention").ShowPopup();
+                        p.Element("mention-command-status").SetText("show called");
+                    }))
+            </native-hstack>
+
+            <native-vstack gap="Xs" class="font-mono text-sm">
+                <p>Command: <span id="mention-command-status">idle</span></p>
+                <p>Popup: <span id="mention-popup-status">idle</span></p>
+                <p>Value: <span id="mention-value">none</span></p>
+            </native-vstack>
+        </native-vstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <native-vstack gap="Base">
+            <label for="auto-hide-note" class="text-sm font-medium text-text-primary">Auto-hide target</label>
+            <textarea id="auto-hide-note" rows="2" class="w-full rounded-md border border-border p-3 text-sm">No</textarea>
+
+            @(Html.FusionMention(plan, "auto-hide-mention", b => b
+                .Target("#auto-hide-note")
+                .DataSource(careTeam)
+                .Fields<MentionPerson>(x => x.Name, x => x.Id)
+                .MentionChar('@')
+                .MinLength(0)
+                .RequireLeadingSpace(false)
+                .ShowMentionChar(true)
+                .PopupWidth("280px"))
+                .Reactive(evt => evt.Opened, (args, p) =>
+                {
+                    p.Component<FusionMention>("auto-hide-mention").HidePopup();
+                    p.Element("mention-hide-status").SetText("hide called");
+                })
+                .Reactive(evt => evt.Closed, (args, p) =>
+                {
+                    p.Element("mention-auto-hide-popup-status").SetText("closed");
+                }))
+
+            @(Html.NativeButton("mention-auto-hide-btn", "Open And Hide")
+                .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionMention>("auto-hide-mention").Search("No", 96, 160);
+                    p.Element("mention-auto-hide-command-status").SetText("search called");
+                }))
+
+            <native-vstack gap="Xs" class="font-mono text-sm">
+                <p>Auto-hide command: <span id="mention-auto-hide-command-status">idle</span></p>
+                <p>Hide: <span id="mention-hide-status">idle</span></p>
+                <p>Auto-hide popup: <span id="mention-auto-hide-popup-status">idle</span></p>
+            </native-vstack>
+        </native-vstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </section>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/PivotView/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/PivotView/Index.cshtml
@@ -1,0 +1,181 @@
+@model PivotViewModel
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@using Syncfusion.EJ2.PivotView
+@{
+    ViewData["Title"] = "FusionPivotView";
+
+    var plan = Html.ReactivePlan<PivotViewModel>();
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionPivotView</native-heading>
+    <native-text color="Secondary">
+        Syncfusion builder owns report setup. Reactive owns post-render data refresh,
+        layout persistence, typed value sources, and typed PivotView event payloads.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Runtime Commands</native-heading>
+        <native-hstack gap="Sm" class="mt-4" wrap="true">
+            @(Html.NativeButton("read-pivot-btn", "Read View + Layout")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var pivot = p.Component<FusionPivotView>("care-pivot");
+                    p.Element("current-view").SetText(pivot.CurrentView());
+                    p.Element("layout-json").SetText(pivot.PersistedLayout());
+                }))
+
+            @(Html.NativeButton("load-march-btn", "Load March Census")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Get("/api/pivot/census")
+                     .Gather(g => g.FromUrl("facilityId"))
+                     .Response(r => r.OnSuccess<PivotCensusResponse>((json, s) =>
+                     {
+                         s.Component<FusionPivotView>("care-pivot")
+                             .SetDataSource(json, x => x.Rows);
+                         s.Element("data-status").SetText(json, x => x.Message);
+                     }));
+                }))
+
+            @(Html.NativeButton("refresh-pivot-btn", "Refresh")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionPivotView>("care-pivot").Refresh();
+                    p.Element("refresh-status").SetText("refresh called");
+                }))
+
+            @(Html.NativeButton("audit-pivot-btn", "Audit Layout")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var pivot = p.Component<FusionPivotView>("care-pivot");
+                    p.Post("/api/pivot/{currentView}/audit")
+                     .Gather(g => g
+                         .RouteParam("currentView", pivot.CurrentView())
+                         .FromUrl("facilityId")
+                         .Include(pivot.CurrentView(), "currentView")
+                         .Include(pivot.PersistedLayout(), "layout"))
+                     .Response(r => r.OnSuccess<PivotAuditResponse>((json, s) =>
+                     {
+                         s.Element("audit-summary").SetText(json, x => x.Summary);
+                         s.Element("layout-length").SetText(json, x => x.LayoutLength);
+                     }));
+                }))
+
+            @(Html.NativeButton("load-layout-btn", "Round Trip Layout")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var pivot = p.Component<FusionPivotView>("care-pivot");
+                    p.Post("/api/pivot/layout/echo")
+                     .Gather(g => g.Include(pivot.PersistedLayout(), "layout"))
+                     .Response(r => r.OnSuccess<PivotLayoutResponse>((json, s) =>
+                     {
+                         s.Component<FusionPivotView>("care-pivot")
+                             .LoadPersistedLayout(json, x => x.Layout);
+                         s.Element("layout-status").SetText(json, x => x.Message);
+                     }));
+                }))
+
+            @(Html.NativeButton("formatting-dialog-btn", "Formatting Dialog")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionPivotView>("care-pivot").ShowConditionalFormattingDialog();
+                    p.Element("dialog-status").SetText("conditional formatting opened");
+                }))
+
+            @(Html.NativeButton("calculated-dialog-btn", "Calculated Field Dialog")
+                .CssClass("rounded-md border border-border bg-white px-4 py-2 text-sm font-medium hover:bg-surface-muted transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionPivotView>("care-pivot").CreateCalculatedFieldDialog();
+                    p.Element("dialog-status").SetText("calculated field opened");
+                }))
+        </native-hstack>
+
+        <native-vstack gap="Xs" class="font-mono text-sm mt-4">
+            <p>Current view: <span id="current-view" class="text-text-muted">-</span></p>
+            <p>Data status: <span id="data-status" class="text-text-muted">-</span></p>
+            <p>Refresh: <span id="refresh-status" class="text-text-muted">-</span></p>
+            <p>Data bound: <span id="data-bound-status" class="text-text-muted">-</span></p>
+            <p>Audit: <span id="audit-summary" class="text-text-muted">-</span></p>
+            <p>Layout length: <span id="layout-length" class="text-text-muted">-</span></p>
+            <p>Layout status: <span id="layout-status" class="text-text-muted">-</span></p>
+            <p>Dialog: <span id="dialog-status" class="text-text-muted">-</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Care Census Pivot</native-heading>
+        @(Html.FusionPivotView(plan, "care-pivot", b =>
+        {
+            b.Height("420px");
+            b.Width("100%");
+            b.ShowGroupingBar(true);
+            b.AllowConditionalFormatting(true);
+            b.AllowCalculatedField(true);
+            b.DataSourceSettings(new PivotViewDataSourceSettings
+            {
+                DataSource = Model.InitialRows,
+                ExpandAll = true,
+                EnableSorting = true,
+                Rows = new List<PivotViewRow>
+                {
+                    new PivotViewRow { Name = "wing", Caption = "Wing" },
+                    new PivotViewRow { Name = "careLevel", Caption = "Care Level" }
+                },
+                Columns = new List<PivotViewRow>
+                {
+                    new PivotViewRow { Name = "month", Caption = "Month" }
+                },
+                Values = new List<PivotViewRow>
+                {
+                    new PivotViewRow { Name = "residents", Caption = "Residents", Type = SummaryTypes.Sum },
+                    new PivotViewRow { Name = "revenue", Caption = "Revenue", Type = SummaryTypes.Sum }
+                }
+            });
+        })
+        .Reactive(evt => evt.DataBound, (_, p) =>
+        {
+            p.Element("data-bound-status").SetText("dataBound fired");
+        })
+        .Reactive(evt => evt.CellSelecting, (args, p) =>
+        {
+            p.Element("cell-axis").SetText(args, x => x.Data.Axis);
+            p.Element("cell-text").SetText(args, x => x.Data.FormattedText);
+            p.Element("cell-row").SetText(args, x => x.Data.RowHeaders);
+            p.Element("cell-column").SetText(args, x => x.Data.ColumnHeaders);
+            p.Element("cell-value").SetText(args, x => x.Data.Value);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Cell Event</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm mt-4">
+            <p>Axis: <span id="cell-axis" class="text-text-muted">-</span></p>
+            <p>Formatted: <span id="cell-text" class="text-text-muted">-</span></p>
+            <p>Row: <span id="cell-row" class="text-text-muted">-</span></p>
+            <p>Column: <span id="cell-column" class="text-text-muted">-</span></p>
+            <p>Value: <span id="cell-value" class="text-text-muted">-</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Persisted Layout</native-heading>
+        <pre id="layout-json" class="text-xs overflow-auto max-h-40">-</pre>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/SmartComponents/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/SmartComponents/Index.cshtml
@@ -1,0 +1,138 @@
+@model SmartComponentsModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@{
+    ViewData["Title"] = "Smart Components";
+
+    var plan = Html.ReactivePlan<SmartComponentsModel>();
+
+    plan.Reactive(m => m.CareNote, evt => evt.BeforeSuggestionInsert, (args, p) =>
+    {
+        p.Element("before-suggestion").SetText(args, x => x.Text);
+    });
+
+    plan.Reactive(m => m.CareNote, evt => evt.AfterSuggestionInsert, (args, p) =>
+    {
+        p.Element("after-suggestion").SetText(args, x => x.InsertedText);
+    });
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var note = p.Component<FusionSmartTextArea>(m => m.CareNote);
+        note.SetValue("Resident is");
+        p.Element("smart-note-value").SetText(note.Value());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">Fusion Smart Components</native-heading>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <native-vstack gap="Base">
+            @{ Html.InputField(plan, m => m.CareNote, o => o.Label("Smart care note"))
+                .FusionSmartTextArea(o =>
+                {
+                    o.Value = Model.CareNote;
+                    o.UserRole = "Care coordinator writing concise senior living notes";
+                    o.UserPhrases = new[] { "hydrating well", "fall precautions reviewed" };
+                    o.SuggestionEndpoint = "/api/smart-components/suggest";
+                    o.SuggestionMode = FusionSmartSuggestionMode.Inline;
+                    o.Rows = 4;
+                    o.CssClass = "w-full rounded-md border border-border p-3 text-sm";
+                }); }
+
+            <native-hstack gap="Sm">
+                @(Html.NativeButton("set-smart-note-btn", "Set Note")
+                    .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        var note = p.Component<FusionSmartTextArea>(m => m.CareNote);
+                        note.SetValue("Resident prefers morning therapy");
+                        p.Element("smart-note-value").SetText(note.Value());
+                    }))
+                @(Html.NativeButton("focus-smart-note-btn", "Focus Note")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionSmartTextArea>(m => m.CareNote).FocusIn();
+                        p.Element("smart-note-focus-status").SetText("focus called");
+                    }))
+            </native-hstack>
+
+            <native-vstack gap="Xs" class="font-mono text-sm">
+                <p>Value: <span id="smart-note-value">none</span></p>
+                <p>Before: <span id="before-suggestion">none</span></p>
+                <p>After: <span id="after-suggestion">none</span></p>
+                <p>Focus: <span id="smart-note-focus-status">idle</span></p>
+            </native-vstack>
+        </native-vstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <native-vstack gap="Base">
+            <textarea id="custom-clipboard" class="sr-only">Resident Nora is moving to room 212B. Hydration rounds complete.</textarea>
+
+            <form id="smart-paste-form" class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                    <label for="Resident" class="block text-sm font-medium text-text-primary mb-1">Resident</label>
+                    <input id="Resident" name="Resident" class="w-full rounded-md border border-border p-2 text-sm" />
+                </div>
+                <div>
+                    <label for="Room" class="block text-sm font-medium text-text-primary mb-1">Room</label>
+                    <input id="Room" name="Room" class="w-full rounded-md border border-border p-2 text-sm" />
+                </div>
+                <div>
+                    <label for="Notes" class="block text-sm font-medium text-text-primary mb-1">Notes</label>
+                    <input id="Notes" name="Notes" class="w-full rounded-md border border-border p-2 text-sm" />
+                </div>
+                <div class="md:col-span-3">
+                    @Html.FusionSmartPasteButton("smart-paste", o =>
+                    {
+                        o.Content = "Smart Paste";
+                        o.AiAssistEndpoint = "/api/smart-components/paste";
+                        o.IsPrimary = true;
+                        o.CssClass = "rounded-md bg-accent px-4 py-2 text-sm font-medium text-white";
+                    })
+                </div>
+            </form>
+
+            <native-hstack gap="Sm">
+                @(Html.NativeButton("run-smart-paste-btn", "Run Smart Paste")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionSmartPasteButton>("smart-paste").Click();
+                        p.Element("paste-command-status").SetText("click called");
+                    }))
+                @(Html.NativeButton("focus-smart-paste-btn", "Focus Paste")
+                    .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        p.Component<FusionSmartPasteButton>("smart-paste").FocusIn();
+                        p.Element("paste-focus-status").SetText("focus called");
+                    }))
+                @(Html.NativeButton("disable-smart-paste-btn", "Disable Paste")
+                    .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white")
+                    .Reactive(plan, evt => evt.Click, (args, p) =>
+                    {
+                        var paste = p.Component<FusionSmartPasteButton>("smart-paste");
+                        paste.SetDisabled(true);
+                        p.Element("paste-disabled-value").SetText(paste.Disabled());
+                    }))
+            </native-hstack>
+
+            <native-vstack gap="Xs" class="font-mono text-sm">
+                <p>Command: <span id="paste-command-status">idle</span></p>
+                <p>Focus: <span id="paste-focus-status">idle</span></p>
+                <p>Disabled: <span id="paste-disabled-value">false</span></p>
+            </native-vstack>
+        </native-vstack>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-6 shadow-sm">
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </section>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -345,6 +345,84 @@
                 Calendar scheduler with event CRUD — create, drag, and resize appointments with reactive validation
             </p>
         </a>
+
+        <a asp-area="Sandbox" asp-controller="Mention" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Mention
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Mention picker with typed search, popup lifecycle, and selected-value event payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="ChipList" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    ChipList
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Chips with typed add, select, remove, return-value sources, and click/delete events
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="SmartComponents" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    SmartComponents
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Smart textarea and paste button with endpoint-backed typed render helpers and runtime methods
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="AIAssistView" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    AIAssistView
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                AI assist chat with typed runtime prompt execution, response updates, and event payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="PivotView" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    PivotView
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Pivot table with typed runtime data refresh, layout persistence, and cell event payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Kanban" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Kanban
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Care task board with remote data, typed templates, method-return sources, and CRUD event payloads
+            </p>
+        </a>
     </div>
 </section>
 

--- a/Alis.Reactive/ExpressionPathHelper.cs
+++ b/Alis.Reactive/ExpressionPathHelper.cs
@@ -31,7 +31,7 @@ namespace Alis.Reactive
         public static string ToPath<TSource>(string prefix, Expression<Func<TSource, object?>> expression)
         {
             var members = ExtractMemberChain(expression.Body);
-            return prefix + "." + string.Join(".", members);
+            return prefix + "." + ToRuntimePath(members);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Alis.Reactive
         public static string ToPath<TSource, TProp>(string prefix, Expression<Func<TSource, TProp>> expression)
         {
             var members = ExtractMemberChain(expression.Body);
-            return prefix + "." + string.Join(".", members);
+            return prefix + "." + ToRuntimePath(members);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Alis.Reactive
         public static string ToEventPath<TSource>(Expression<Func<TSource, object?>> expression)
         {
             var members = ExtractMemberChain(expression.Body);
-            return string.Join(".", members);
+            return ToRuntimePath(members);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Alis.Reactive
         public static string ToEventPath<TSource, TProp>(Expression<Func<TSource, TProp>> expression)
         {
             var members = ExtractMemberChain(expression.Body);
-            return string.Join(".", members);
+            return ToRuntimePath(members);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Alis.Reactive
         public static string ToResponsePath<TSource>(Expression<Func<TSource, object?>> expression)
         {
             var members = ExtractMemberChain(expression.Body);
-            return string.Join(".", members);
+            return ToRuntimePath(members);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Alis.Reactive
         public static string ToResponsePath<TSource, TProp>(Expression<Func<TSource, TProp>> expression)
         {
             var members = ExtractMemberChain(expression.Body);
-            return string.Join(".", members);
+            return ToRuntimePath(members);
         }
 
         private static List<string> ExtractMemberChain(Expression expr)
@@ -111,7 +111,11 @@ namespace Alis.Reactive
             if (TryIndexAccess(expr, out var collection, out var index))
             {
                 var members = ExtractMemberChain(collection);
-                members[members.Count - 1] += "[" + index + "]";
+                var suffix = "[" + index.ToString(System.Globalization.CultureInfo.InvariantCulture) + "]";
+                if (members.Count == 0)
+                    members.Add(suffix);
+                else
+                    members[members.Count - 1] += suffix;
                 return members;
             }
 
@@ -187,6 +191,36 @@ namespace Alis.Reactive
                 .Replace(".", "_")
                 .Replace("[", "_")
                 .Replace("]", "_");
+
+        private static string ToRuntimePath(List<string> members)
+        {
+            var segments = new List<string>();
+            foreach (var member in members)
+                AddRuntimePathSegments(member, segments);
+
+            return string.Join(".", segments);
+        }
+
+        private static void AddRuntimePathSegments(string member, List<string> segments)
+        {
+            var position = 0;
+            while (position < member.Length)
+            {
+                var bracket = member.IndexOf('[', position);
+                if (bracket < 0)
+                {
+                    segments.Add(member.Substring(position));
+                    return;
+                }
+
+                if (bracket > position)
+                    segments.Add(member.Substring(position, bracket - position));
+
+                var close = member.IndexOf(']', bracket + 1);
+                segments.Add(member.Substring(bracket + 1, close - bracket - 1));
+                position = close + 1;
+            }
+        }
 
         private static bool TryIndexAccess(
             Expression expr,

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionAIAssistView.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionAIAssistView.cs
@@ -1,0 +1,145 @@
+using System.Text.RegularExpressions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionAIAssistView : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/AIAssistView";
+
+    private async Task NavigateAndWaitForAssistView()
+    {
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("#care-ai")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-ai .e-assist-textarea"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task builder_renders_initial_prompt_suggestions()
+    {
+        await NavigateAndWaitForAssistView();
+
+        await Expect(Page.Locator("#care-ai"))
+            .ToContainTextAsync("Care prompts", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-ai"))
+            .ToContainTextAsync("Draft family update", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task typing_prompt_fires_typed_prompt_changed_event()
+    {
+        await NavigateAndWaitForAssistView();
+
+        await Page.Locator("#care-ai .e-assist-textarea").FillAsync("fall risk update");
+
+        await Expect(Page.Locator("#prompt-changed-value"))
+            .ToHaveTextAsync("fall risk update", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task execute_prompt_calls_js_method_and_prompt_request_adds_text_response()
+    {
+        await NavigateAndWaitForAssistView();
+
+        await Page.Locator("#execute-prompt-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-status"))
+            .ToHaveTextAsync("executePrompt called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#request-status"))
+            .ToHaveTextAsync("promptRequest fired", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#request-prompt"))
+            .ToHaveTextAsync("Summarize the medication changes", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-ai"))
+            .ToContainTextAsync("Reactive response added from promptRequest.", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task object_prompt_response_appends_prompt_and_response()
+    {
+        await NavigateAndWaitForAssistView();
+
+        await Page.Locator("#append-object-response-btn").ClickAsync();
+
+        await Expect(Page.Locator("#object-response-status"))
+            .ToHaveTextAsync("object response added", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-ai"))
+            .ToContainTextAsync("Care plan follow up", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-ai"))
+            .ToContainTextAsync(
+                "Schedule hydration checks and confirm the updated medication list with the nurse.",
+                new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_prompt_mutates_component_and_prompt_source_reads_current_value()
+    {
+        await NavigateAndWaitForAssistView();
+
+        await Page.Locator("#set-prompt-btn").ClickAsync();
+
+        await Expect(Page.Locator("#current-prompt"))
+            .ToHaveTextAsync("Prepare discharge summary", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-ai .e-assist-textarea"))
+            .ToContainTextAsync("Prepare discharge summary", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task active_view_source_reads_current_view_index()
+    {
+        await NavigateAndWaitForAssistView();
+
+        await Page.Locator("#read-active-view-btn").ClickAsync();
+
+        await Expect(Page.Locator("#active-view"))
+            .ToHaveTextAsync("0", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task scroll_to_bottom_calls_js_method()
+    {
+        await NavigateAndWaitForAssistView();
+
+        await Page.Locator("#append-object-response-btn").ClickAsync();
+        await Page.Locator("#scroll-bottom-btn").ClickAsync();
+
+        await Expect(Page.Locator("#scroll-status"))
+            .ToHaveTextAsync("scrollToBottom called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-ai"))
+            .ToContainTextAsync("Care plan follow up", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_declares_typed_runtime_members()
+    {
+        await NavigateAndWaitForAssistView();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("care-ai"));
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("executePrompt"));
+        Assert.That(planJson, Does.Contain("addPromptResponseText"));
+        Assert.That(planJson, Does.Contain("addPromptResponseObject"));
+        Assert.That(planJson, Does.Contain("scrollToBottom"));
+        Assert.That(planJson, Does.Contain("prompt"));
+        Assert.That(planJson, Does.Contain("activeView"));
+        Assert.That(planJson, Does.Match(new Regex("promptChanged|promptRequest|stopRespondingClick")));
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionChipList.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionChipList.cs
@@ -1,0 +1,193 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionChipList : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/ChipList";
+
+    private async Task NavigateAndWaitForChipList()
+    {
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("#care-tags.e-chip-list"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task add_method_appends_new_visible_chip()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#add-chip-btn").ClickAsync();
+
+        await Expect(Page.Locator("#chip-command-status"))
+            .ToHaveTextAsync("add called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-tags"))
+            .ToContainTextAsync("Wound Care", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_by_index_method_selects_existing_chip()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#select-index-chip-btn").ClickAsync();
+
+        await Expect(Page.Locator("#chip-command-status"))
+            .ToHaveTextAsync("select index called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-tags .e-chip").Nth(1))
+            .ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-active"), new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_by_indexes_method_selects_multiple_existing_chips()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#select-indexes-chip-btn").ClickAsync();
+
+        await Expect(Page.Locator("#index-chip-command-status"))
+            .ToHaveTextAsync("select indexes called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-tags .e-chip").Nth(0))
+            .ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-active"), new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-tags .e-chip").Nth(2))
+            .ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-active"), new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_by_text_and_return_sources_read_selected_and_found_chips()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#select-text-chip-btn").ClickAsync();
+
+        await Expect(Page.Locator("#chip-command-status"))
+            .ToHaveTextAsync("select text called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-chip-texts"))
+            .ToContainTextAsync("Hydration", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-chip-texts"))
+            .ToContainTextAsync("Wound Care", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#found-chip-text"))
+            .ToHaveTextAsync("Hydration", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_chip_values_property_can_be_read_after_selection()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#read-selected-values-btn").ClickAsync();
+
+        await Expect(Page.Locator("#chip-command-status"))
+            .ToHaveTextAsync("selected values read", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-chip-values"))
+            .ToHaveTextAsync("hydration,meds", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-tags .e-chip").Nth(1))
+            .ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-active"), new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-tags .e-chip").Nth(2))
+            .ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-active"), new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_chip_values_can_drive_quick_filter_payload()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#care-tags .e-chip").Filter(new() { HasTextString = "Fall Risk" }).ClickAsync();
+        await Page.Locator("#care-tags .e-chip").Filter(new() { HasTextString = "Medication Review" }).ClickAsync();
+
+        var request = await Page.RunAndWaitForRequestAsync(
+            async () => await Page.Locator("#apply-chip-filters-btn").ClickAsync(),
+            "**/Sandbox/Components/ChipList/QuickFilter");
+
+        var body = request.PostData ?? "";
+        Assert.That(body, Does.Contain("fall"), $"Quick filter payload must include fall but was '{body}'");
+        Assert.That(body, Does.Contain("meds"), $"Quick filter payload must include meds but was '{body}'");
+
+        await Expect(Page.Locator("#chip-command-status"))
+            .ToHaveTextAsync("filters applied", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#quick-filter-values"))
+            .ToHaveTextAsync("fall,meds", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#quick-filter-count"))
+            .ToHaveTextAsync("3", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#quick-filter-names"))
+            .ToHaveTextAsync("Ava Stone,Mateo Reed,Nora Gray", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_chip_indexes_property_can_be_set_and_read()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#set-selected-indexes-btn").ClickAsync();
+
+        await Expect(Page.Locator("#index-chip-command-status"))
+            .ToHaveTextAsync("selected indexes set", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-chip-indexes"))
+            .ToHaveTextAsync("0,2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-tags .e-chip").Nth(0))
+            .ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-active"), new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-tags .e-chip").Nth(2))
+            .ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-active"), new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task click_and_remove_events_surface_typed_payloads()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#care-tags .e-chip").Filter(new() { HasTextString = "Hydration" }).ClickAsync();
+        await Expect(Page.Locator("#chip-clicked"))
+            .ToHaveTextAsync("Hydration", new() { Timeout = 5000 });
+
+        await Page.Locator("#remove-chip-btn").ClickAsync();
+        await Expect(Page.Locator("#chip-command-status"))
+            .ToHaveTextAsync("remove called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#chip-deleted"))
+            .ToHaveTextAsync("Fall Risk", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task remove_by_indexes_method_removes_multiple_chips()
+    {
+        await NavigateAndWaitForChipList();
+
+        await Page.Locator("#remove-indexes-chip-btn").ClickAsync();
+
+        await Expect(Page.Locator("#index-chip-command-status"))
+            .ToHaveTextAsync("remove indexes called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-tags"))
+            .Not.ToContainTextAsync("Routine", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-tags"))
+            .Not.ToContainTextAsync("Follow Up", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-tags"))
+            .ToContainTextAsync("Urgent", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_index_links_to_chiplist_sandbox()
+    {
+        await NavigateTo("/Sandbox/Components");
+        await Expect(Page.Locator("a[href='/Sandbox/Components/ChipList/Index']"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionKanban.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionKanban.cs
@@ -1,0 +1,388 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionKanban : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Kanban";
+
+    private async Task ResetKanbanBoard()
+    {
+        using var client = new System.Net.Http.HttpClient();
+        var response = await client.PostAsync($"{BaseUrl}/api/kanban/reset", null);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task NavigateAndWaitForKanban(
+        bool reset = true,
+        int cardCount = 2,
+        string expectedCardText = "Assess fall risk")
+    {
+        if (reset)
+            await ResetKanbanBoard();
+
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("#care-kanban.e-kanban"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban .e-card"))
+            .ToHaveCountAsync(cardCount, new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync(expectedCardText, new() { Timeout = 10000 });
+    }
+
+    private async Task DragCardToColumn(int cardId, string columnKey)
+    {
+        var card = Page.Locator($"#care-kanban .e-card[data-id='{cardId}']").First;
+        var column = Page.Locator($"#care-kanban .e-content-cells[data-key='{columnKey}']")
+            .First;
+
+        await Expect(card).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(column).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await card.ScrollIntoViewIfNeededAsync();
+        await column.ScrollIntoViewIfNeededAsync();
+
+        var sourceBox = await card.BoundingBoxAsync();
+        var targetBox = await column.BoundingBoxAsync();
+        Assert.That(sourceBox, Is.Not.Null);
+        Assert.That(targetBox, Is.Not.Null);
+
+        var sourceX = sourceBox!.X + sourceBox.Width / 2;
+        var sourceY = sourceBox.Y + sourceBox.Height / 2;
+        var targetX = targetBox!.X + targetBox.Width / 2;
+        var targetY = targetBox.Y + Math.Min(72, targetBox.Height / 2);
+
+        await Page.Mouse.MoveAsync(
+            sourceX,
+            sourceY);
+        await Page.Mouse.DownAsync();
+        await Page.Mouse.MoveAsync(sourceX + 24, sourceY + 12, new() { Steps = 8 });
+        await Page.Mouse.MoveAsync(
+            targetX,
+            targetY,
+            new() { Steps = 30 });
+        await Page.Mouse.UpAsync();
+    }
+
+    [Test]
+    public async Task remote_data_renders_with_typed_card_template()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Expect(Page.Locator("#kanban-status"))
+            .ToHaveTextAsync("loaded:AL:2", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-open-count"))
+            .ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#kanban-al-count"))
+            .ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#kanban-data-binding-status"))
+            .ToHaveTextAsync("Assess fall risk", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-data-bound-status"))
+            .ToHaveTextAsync("bound", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-query-cell-status"))
+            .ToContainTextAsync("Row", new() { Timeout = 10000 });
+
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("Resident: Eleanor Reed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("ESCALATED", new() { Timeout = 5000 });
+
+        var renderedSummary = await Page.Locator("#kanban-rendered-summary").TextContentAsync();
+        Assert.That(renderedSummary, Is.Not.EqualTo("none"));
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_reads_board_column_and_swimlane_sources()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Page.Locator("#kanban-audit-btn").ClickAsync();
+
+        await Expect(Page.Locator("#kanban-audit-summary"))
+            .ToHaveTextAsync("audit:2:1:2", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-audit-total"))
+            .ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#kanban-audit-open"))
+            .ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#kanban-audit-al"))
+            .ToHaveTextAsync("2", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task card_click_event_exposes_card_payload_and_route_gather()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Page.Locator("#care-kanban .e-card").First.ClickAsync();
+
+        await Expect(Page.Locator("#kanban-clicked-summary"))
+            .ToHaveTextAsync("Assess fall risk", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-route-summary"))
+            .ToHaveTextAsync("card:101:summary", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task card_double_click_event_exposes_card_payload()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Page.Locator("#care-kanban .e-card").First.DblClickAsync();
+
+        await Expect(Page.Locator("#kanban-double-clicked-summary"))
+            .ToHaveTextAsync("Assess fall risk", new() { Timeout = 10000 });
+
+        if (await Page.Locator("#care-kanban_dialog_wrapper.e-popup-open").IsVisibleAsync())
+            await Page.Keyboard.PressAsync("Escape");
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task add_update_and_delete_card_methods_commit_through_datasource_changed_event()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Page.Locator("#kanban-add-card-btn").ClickAsync();
+
+        await Expect(Page.Locator("#kanban-command-status"))
+            .ToHaveTextAsync("post:900", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-begin"))
+            .ToHaveTextAsync("cardCreate", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-request"))
+            .ToHaveTextAsync("cardCreated", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-commit-status"))
+            .ToHaveTextAsync("commit:cardCreated:1", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban .e-card"))
+            .ToHaveCountAsync(3, new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("Remote wound consult", new() { Timeout = 5000 });
+
+        await Page.Locator("#kanban-update-card-btn").ClickAsync();
+
+        await Expect(Page.Locator("#kanban-command-status"))
+            .ToHaveTextAsync("put:102:Review", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-begin"))
+            .ToHaveTextAsync("cardChange", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-request"))
+            .ToHaveTextAsync("cardChanged", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-commit-status"))
+            .ToHaveTextAsync("commit:cardChanged:1", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("Medication reconciliation updated", new() { Timeout = 5000 });
+
+        await Page.Locator("#kanban-delete-card-btn").ClickAsync();
+
+        await Expect(Page.Locator("#kanban-command-status"))
+            .ToHaveTextAsync("delete:101", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-begin"))
+            .ToHaveTextAsync("cardRemove", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-request"))
+            .ToHaveTextAsync("cardRemoved", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-commit-status"))
+            .ToHaveTextAsync("commit:cardRemoved:1", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .Not.ToContainTextAsync("Assess fall risk", new() { Timeout = 10000 });
+
+        await NavigateAndWaitForKanban(
+            reset: false,
+            cardCount: 2,
+            expectedCardText: "Remote wound consult");
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("Medication reconciliation updated", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .Not.ToContainTextAsync("Assess fall risk", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task drag_stop_persists_move_through_reactive_http_put()
+    {
+        await NavigateAndWaitForKanban();
+
+        await DragCardToColumn(101, "Review");
+
+        await Expect(Page.Locator("#kanban-drag-start-summary"))
+            .ToHaveTextAsync("Assess fall risk", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-drag-status"))
+            .ToHaveTextAsync("Assess fall risk", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-move-status"))
+            .ToContainTextAsync("move:101:Review", new() { Timeout = 10000 });
+
+        await Page.Locator("#kanban-audit-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-audit-summary"))
+            .ToHaveTextAsync("audit:2:0:2", new() { Timeout = 10000 });
+
+        await NavigateAndWaitForKanban(reset: false);
+        await Page.Locator("#kanban-audit-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-audit-summary"))
+            .ToHaveTextAsync("audit:2:0:2", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task column_spinner_and_dialog_methods_execute_against_kanban_object()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Page.Locator("#kanban-hide-done-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-column-status"))
+            .ToHaveTextAsync("done hidden", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-kanban .e-header-text").Filter(new() { HasTextString = "Done" }))
+            .ToHaveCountAsync(0, new() { Timeout = 5000 });
+
+        await Page.Locator("#kanban-show-done-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-column-status"))
+            .ToHaveTextAsync("done shown", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-kanban .e-header-text").Filter(new() { HasTextString = "Done" }))
+            .ToHaveCountAsync(1, new() { Timeout = 5000 });
+
+        await Page.Locator("#kanban-add-column-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-column-status"))
+            .ToHaveTextAsync("blocked added", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-kanban .e-header-text").Filter(new() { HasTextString = "Blocked" }))
+            .ToHaveCountAsync(1, new() { Timeout = 5000 });
+
+        await Page.Locator("#kanban-delete-column-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-column-status"))
+            .ToHaveTextAsync("blocked deleted", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-kanban .e-header-text").Filter(new() { HasTextString = "Blocked" }))
+            .ToHaveCountAsync(0, new() { Timeout = 5000 });
+
+        await Page.Locator("#kanban-spinner-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-spinner-status"))
+            .ToHaveTextAsync("spinner toggled", new() { Timeout = 5000 });
+
+        await Page.Locator("#kanban-open-close-dialog-btn").ClickAsync();
+        await Expect(Page.Locator("#kanban-dialog-status"))
+            .ToHaveTextAsync("open close requested", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-kanban_dialog_wrapper.e-popup-open"))
+            .ToHaveCountAsync(0, new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task dialog_save_closes_and_persists_through_datasource_changed_event()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Page.Locator("#kanban-open-dialog-btn").ClickAsync();
+
+        await Expect(Page.Locator("#kanban-dialog-status"))
+            .ToHaveTextAsync("Add", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban_dialog_wrapper.e-dialog.e-popup-open"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await Page.Locator("#care-kanban_dialog_wrapper .e-footer-content .e-primary").ClickAsync();
+
+        await Expect(Page.Locator("#care-kanban_dialog_wrapper.e-popup-open"))
+            .ToHaveCountAsync(0, new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-dialog-close-status"))
+            .ToHaveTextAsync("Add", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-request"))
+            .ToHaveTextAsync("cardCreated", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-commit-status"))
+            .ToHaveTextAsync("commit:cardCreated:1", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban .e-card"))
+            .ToHaveCountAsync(3, new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("Remote wound consult", new() { Timeout = 10000 });
+
+        await NavigateAndWaitForKanban(
+            reset: false,
+            cardCount: 3,
+            expectedCardText: "Remote wound consult");
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task edit_dialog_save_closes_and_persists_updated_card()
+    {
+        await NavigateAndWaitForKanban();
+
+        await Page.Locator("#kanban-open-edit-dialog-btn").ClickAsync();
+
+        await Expect(Page.Locator("#kanban-dialog-status"))
+            .ToHaveTextAsync("Edit", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban_dialog_wrapper.e-dialog.e-popup-open"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await Page.Locator("#care-kanban_dialog_wrapper .e-footer-content .e-primary").ClickAsync();
+
+        await Expect(Page.Locator("#care-kanban_dialog_wrapper.e-popup-open"))
+            .ToHaveCountAsync(0, new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-dialog-close-status"))
+            .ToHaveTextAsync("Edit", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-action-request"))
+            .ToHaveTextAsync("cardChanged", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#kanban-commit-status"))
+            .ToHaveTextAsync("commit:cardChanged:1", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("Medication reconciliation updated", new() { Timeout = 10000 });
+
+        await NavigateAndWaitForKanban(reset: false);
+        await Expect(Page.Locator("#care-kanban"))
+            .ToContainTextAsync("Medication reconciliation updated", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_index_links_to_kanban_sandbox()
+    {
+        await NavigateTo("/Sandbox/Components");
+        await Expect(Page.Locator("a[href='/Sandbox/Components/Kanban/Index']"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_declares_typed_kanban_runtime_members()
+    {
+        await NavigateAndWaitForKanban();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("care-kanban"));
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("dataSource"));
+        Assert.That(planJson, Does.Contain("dataBind"));
+        Assert.That(planJson, Does.Contain("getColumnData"));
+        Assert.That(planJson, Does.Contain("getSwimlaneData"));
+        Assert.That(planJson, Does.Contain("addCard"));
+        Assert.That(planJson, Does.Contain("updateCard"));
+        Assert.That(planJson, Does.Contain("deleteCard"));
+        Assert.That(planJson, Does.Contain("addColumn"));
+        Assert.That(planJson, Does.Contain("deleteColumn"));
+        Assert.That(planJson, Does.Contain("showColumn"));
+        Assert.That(planJson, Does.Contain("hideColumn"));
+        Assert.That(planJson, Does.Contain("showSpinner"));
+        Assert.That(planJson, Does.Contain("hideSpinner"));
+        Assert.That(planJson, Does.Contain("openDialog"));
+        Assert.That(planJson, Does.Contain("closeDialog"));
+        Assert.That(planJson, Does.Contain("dataBinding"));
+        Assert.That(planJson, Does.Contain("dataBound"));
+        Assert.That(planJson, Does.Contain("cardClick"));
+        Assert.That(planJson, Does.Contain("cardDoubleClick"));
+        Assert.That(planJson, Does.Contain("queryCellInfo"));
+        Assert.That(planJson, Does.Contain("cardRendered"));
+        Assert.That(planJson, Does.Contain("actionBegin"));
+        Assert.That(planJson, Does.Contain("actionComplete"));
+        Assert.That(planJson, Does.Contain("dataSourceChanged"));
+        Assert.That(planJson, Does.Contain("dragStart"));
+        Assert.That(planJson, Does.Contain("drag"));
+        Assert.That(planJson, Does.Contain("dragStop"));
+        Assert.That(planJson, Does.Contain("dialogOpen"));
+        Assert.That(planJson, Does.Contain("dialogClose"));
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionMention.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionMention.cs
@@ -1,0 +1,80 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionMention : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Mention";
+
+    private async Task NavigateAndWaitForMention()
+    {
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("#care-note"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task search_method_opens_popup_with_matching_care_team_member()
+    {
+        await NavigateAndWaitForMention();
+
+        await Page.Locator("#care-note").EvaluateAsync("el => { el.focus(); el.setSelectionRange(2, 2); }");
+        await Page.Locator("#mention-search-btn").ClickAsync();
+
+        await Expect(Page.Locator("#mention-command-status"))
+            .ToHaveTextAsync("search called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#mention-popup-status"))
+            .ToHaveTextAsync("opened", new() { Timeout = 5000 });
+        await Expect(Page.Locator(".e-popup .e-list-item").Filter(new() { HasTextString = "Nora Nurse" }))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selecting_item_fires_typed_changed_event()
+    {
+        await NavigateAndWaitForMention();
+
+        await Page.Locator("#care-note").EvaluateAsync("el => { el.focus(); el.setSelectionRange(2, 2); }");
+        await Page.Locator("#mention-search-btn").ClickAsync();
+        await Page.Locator(".e-popup .e-list-item").Filter(new() { HasTextString = "Nora Nurse" }).ClickAsync();
+
+        await Expect(Page.Locator("#mention-value"))
+            .ToContainTextAsync("Nora Nurse", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task show_and_hide_methods_drive_popup_lifecycle_events()
+    {
+        await NavigateAndWaitForMention();
+
+        await Page.Locator("#mention-show-btn").ClickAsync();
+        await Expect(Page.Locator("#mention-command-status"))
+            .ToHaveTextAsync("show called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#mention-popup-status"))
+            .ToHaveTextAsync("opened", new() { Timeout = 10000 });
+
+        await Page.Locator("#auto-hide-note").EvaluateAsync("el => { el.focus(); el.setSelectionRange(2, 2); }");
+        await Page.Locator("#mention-auto-hide-btn").ClickAsync();
+        await Expect(Page.Locator("#mention-auto-hide-command-status"))
+            .ToHaveTextAsync("search called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#mention-hide-status"))
+            .ToHaveTextAsync("hide called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#mention-auto-hide-popup-status"))
+            .ToHaveTextAsync("closed", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_index_links_to_mention_sandbox()
+    {
+        await NavigateTo("/Sandbox/Components");
+        await Expect(Page.Locator("a[href='/Sandbox/Components/Mention/Index']"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionPivotView.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionPivotView.cs
@@ -1,0 +1,213 @@
+using System.Text.RegularExpressions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionPivotView : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/PivotView?facilityId=evergreen";
+
+    private async Task NavigateAndWaitForPivotView()
+    {
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("#care-pivot.e-pivotview"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-pivot"))
+            .ToContainTextAsync("Residents", new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task builder_renders_initial_care_census_pivot()
+    {
+        await NavigateAndWaitForPivotView();
+
+        var pivotText = await Page.Locator("#care-pivot").TextContentAsync();
+        var compactPivotText = Regex.Replace(pivotText ?? "", @"[\s,]+", "");
+
+        await Expect(Page.Locator("#care-pivot"))
+            .ToContainTextAsync("North", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#care-pivot"))
+            .ToContainTextAsync("Memory Care", new() { Timeout = 5000 });
+        Assert.Multiple(() =>
+        {
+            Assert.That(pivotText, Does.Contain("Jan"));
+            Assert.That(pivotText, Does.Contain("Feb"));
+            Assert.That(compactPivotText, Does.Contain("126000"));
+            Assert.That(compactPivotText, Does.Contain("140000"));
+        });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task typed_sources_read_current_view_and_persisted_layout()
+    {
+        await NavigateAndWaitForPivotView();
+
+        await Page.Locator("#read-pivot-btn").ClickAsync();
+
+        await Expect(Page.Locator("#current-view"))
+            .ToHaveTextAsync("Table", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#layout-json"))
+            .ToContainTextAsync("dataSourceSettings", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#layout-json"))
+            .ToContainTextAsync("\"dataSource\":[]", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task http_response_replaces_nested_datasource_and_refreshes_pivot()
+    {
+        await NavigateAndWaitForPivotView();
+
+        await Page.Locator("#load-march-btn").ClickAsync();
+
+        await Expect(Page.Locator("#data-status"))
+            .ToHaveTextAsync("March census loaded for evergreen", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#data-bound-status"))
+            .ToHaveTextAsync("dataBound fired", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-pivot"))
+            .ToContainTextAsync("Mar", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-pivot"))
+            .ToContainTextAsync("East", new() { Timeout = 10000 });
+
+        var pivotText = await Page.Locator("#care-pivot").TextContentAsync();
+        var compactPivotText = Regex.Replace(pivotText ?? "", @"[\s,]+", "");
+        Assert.Multiple(() =>
+        {
+            Assert.That(pivotText, Does.Contain("Independent"));
+            Assert.That(pivotText, Does.Not.Contain("Jan"));
+            Assert.That(pivotText, Does.Not.Contain("Feb"));
+            Assert.That(compactPivotText, Does.Contain("14"));
+            Assert.That(compactPivotText, Does.Contain("63000"));
+        });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task refresh_button_calls_public_refresh_method_and_updates_visible_status()
+    {
+        await NavigateAndWaitForPivotView();
+
+        await Page.Locator("#refresh-pivot-btn").ClickAsync();
+
+        await Expect(Page.Locator("#refresh-status"))
+            .ToHaveTextAsync("refresh called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#data-bound-status"))
+            .ToHaveTextAsync("dataBound fired", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_uses_route_url_and_method_return_sources()
+    {
+        await NavigateAndWaitForPivotView();
+
+        await Page.Locator("#audit-pivot-btn").ClickAsync();
+
+        await Expect(Page.Locator("#audit-summary"))
+            .ToHaveTextAsync("Table:evergreen:Table", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#layout-length"))
+            .ToHaveTextAsync(new Regex("^[1-9][0-9]+$"), new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task persisted_layout_can_round_trip_through_server_and_reload()
+    {
+        await NavigateAndWaitForPivotView();
+
+        await Page.Locator("#load-layout-btn").ClickAsync();
+
+        await Expect(Page.Locator("#layout-status"))
+            .ToHaveTextAsync(new Regex("^layout echoed:[1-9][0-9]+$"), new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task cell_selecting_event_exposes_typed_cell_payload()
+    {
+        await NavigateAndWaitForPivotView();
+
+        var valueCells = Page.Locator("#care-pivot .e-valuescontent");
+        await Expect(valueCells.First).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await valueCells.First.ClickAsync();
+
+        await Expect(Page.Locator("#cell-axis"))
+            .ToHaveTextAsync("value", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#cell-text"))
+            .Not.ToHaveTextAsync("-", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#cell-value"))
+            .ToHaveTextAsync(new Regex("^[0-9,.]+$"), new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task public_dialog_methods_open_visible_syncfusion_dialogs()
+    {
+        await NavigateAndWaitForPivotView();
+
+        await Page.Locator("#formatting-dialog-btn").ClickAsync();
+
+        await Expect(Page.Locator("#dialog-status"))
+            .ToHaveTextAsync("conditional formatting opened", new() { Timeout = 5000 });
+        await Expect(Page.Locator(".e-dialog").Filter(new() { HasTextString = "Conditional Formatting" }))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await Page.Locator(".e-dialog .e-dlg-closeicon-btn").First.ClickAsync();
+        await Page.Locator("#calculated-dialog-btn").ClickAsync();
+
+        await Expect(Page.Locator("#dialog-status"))
+            .ToHaveTextAsync("calculated field opened", new() { Timeout = 5000 });
+        await Expect(Page.Locator(".e-dialog").Filter(new() { HasTextString = "Calculated Field" }))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_index_links_to_pivotview_sandbox()
+    {
+        await NavigateTo("/Sandbox/Components");
+        await Expect(Page.Locator("a[href='/Sandbox/Components/PivotView/Index']"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await Page.Locator("a[href='/Sandbox/Components/PivotView/Index']").ClickAsync();
+        await Page.WaitForURLAsync("**/Sandbox/Components/PivotView/Index", new() { Timeout = 10000 });
+
+        await Expect(Page.Locator("#care-pivot.e-pivotview"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-pivot"))
+            .ToContainTextAsync("Residents", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_declares_typed_runtime_members()
+    {
+        await NavigateAndWaitForPivotView();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("care-pivot"));
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("currentView"));
+        Assert.That(planJson, Does.Contain("dataSource"));
+        Assert.That(planJson, Does.Contain("dataSourceSettings"));
+        Assert.That(planJson, Does.Contain("refresh"));
+        Assert.That(planJson, Does.Contain("getPersistData"));
+        Assert.That(planJson, Does.Contain("loadPersistData"));
+        Assert.That(planJson, Does.Contain("showConditionalFormattingDialog"));
+        Assert.That(planJson, Does.Contain("createCalculatedFieldDialog"));
+        Assert.That(planJson, Does.Match(new Regex("dataBound|cellSelecting")));
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSmartComponents.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSmartComponents.cs
@@ -1,0 +1,108 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionSmartComponents : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/SmartComponents";
+
+    private async Task NavigateAndWaitForSmartComponents()
+    {
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("textarea[id$='__CareNote']"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#smart-paste.e-control"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task smart_textarea_set_value_read_value_and_focus_methods_execute()
+    {
+        await NavigateAndWaitForSmartComponents();
+
+        await Expect(Page.Locator("#smart-note-value"))
+            .ToHaveTextAsync("Resident is", new() { Timeout = 10000 });
+
+        await Page.Locator("#set-smart-note-btn").ClickAsync();
+        await Expect(Page.Locator("#smart-note-value"))
+            .ToHaveTextAsync("Resident prefers morning therapy", new() { Timeout = 5000 });
+
+        await Page.Locator("#focus-smart-note-btn").ClickAsync();
+        await Expect(Page.Locator("#smart-note-focus-status"))
+            .ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("textarea[id$='__CareNote']"))
+            .ToBeFocusedAsync(new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task smart_textarea_suggestion_events_surface_before_and_after_payloads()
+    {
+        await NavigateAndWaitForSmartComponents();
+
+        var textarea = Page.Locator("textarea[id$='__CareNote']");
+        await textarea.ClickAsync();
+        await textarea.FillAsync("Resident is");
+        await textarea.PressAsync(" ");
+
+        await Expect(Page.Locator("#before-suggestion"))
+            .ToContainTextAsync("hydrating well", new() { Timeout = 10000 });
+
+        await textarea.PressAsync("Tab");
+        await Expect(Page.Locator("#after-suggestion"))
+            .ToContainTextAsync("hydrating well", new() { Timeout = 10000 });
+        await Expect(textarea)
+            .ToHaveValueAsync(new System.Text.RegularExpressions.Regex("Resident is hydrating well\\s*$"), new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task smart_paste_button_click_method_fills_form_from_endpoint()
+    {
+        await NavigateAndWaitForSmartComponents();
+
+        await Page.Locator("#run-smart-paste-btn").ClickAsync();
+
+        await Expect(Page.Locator("#paste-command-status"))
+            .ToHaveTextAsync("click called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#Resident"))
+            .ToHaveValueAsync("Nora", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#Room"))
+            .ToHaveValueAsync("212B", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#Notes"))
+            .ToHaveValueAsync("Hydration rounds complete", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task smart_paste_focus_and_disabled_members_execute()
+    {
+        await NavigateAndWaitForSmartComponents();
+
+        await Page.Locator("#focus-smart-paste-btn").ClickAsync();
+        await Expect(Page.Locator("#paste-focus-status"))
+            .ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#smart-paste"))
+            .ToBeFocusedAsync(new() { Timeout = 5000 });
+
+        await Page.Locator("#disable-smart-paste-btn").ClickAsync();
+        await Expect(Page.Locator("#paste-disabled-value"))
+            .ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#smart-paste"))
+            .ToBeDisabledAsync(new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_index_links_to_smart_components_sandbox()
+    {
+        await NavigateTo("/Sandbox/Components");
+        await Expect(Page.Locator("a[href='/Sandbox/Components/SmartComponents/Index']"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a source-grounded Syncfusion onboarding workflow and lands the typed Fusion component slices proven through sandbox behavior tests.

It intentionally excludes the browser approval-matrix app work. There are no `FusionOnboarding` files, no `App_Data` database, no SQLite package, and no sandbox `Program.cs` wiring in this PR.

## What Changed

| Area | Change | Why This Should Merge |
|---|---|---|
| Onboarding skill | Reworked `.claude/skills/onboard-fusion-component` around source discovery, raw HTML probes, Blazor metadata inspection, event payload tracing, and automation gates | Makes future Syncfusion onboarding repeatable and evidence-driven instead of docs-only or inferred |
| Skill scripts | Added discovery/probe/surface/event/Blazor metadata helpers | Gives agents a concrete automated process for finding real JS APIs and typed candidate shapes |
| AIAssistView | Added typed component slice, events, runtime methods, sandbox, and Playwright tests | Proves non-builder runtime methods and typed event payloads for interactive chat-style components |
| ChipList | Added typed add/select/remove/find/selected source APIs, events, sandbox, and Playwright tests | Covers array args, method return sources, selected values, and quick-filter payloads without public string APIs |
| Kanban | Added typed Kanban slice, event payloads, method-return sources, CRUD/move sandbox workflows, and Playwright tests | Stress-tests typed card payloads, remote data, templates, drag/drop event reads, and HTTP mutation flows |
| Mention | Added typed Mention slice with host bridge, methods/events, sandbox, and Playwright tests | Handles target-attached Syncfusion instances while keeping the developer-facing component id stable |
| PivotView | Added typed PivotView slice, data refresh/layout/cell events, sandbox, and Playwright tests | Proves complex data component onboarding with typed runtime refresh and event reads |
| Smart components | Added SmartTextArea and SmartPasteButton typed slices, render helpers, sandbox, and Playwright tests | Covers Syncfusion smart controls that are less MVC-builder-shaped while staying typed and isolated |
| Runtime path support | Updated `ExpressionPathHelper` event/response paths to serialize indexed reads as runtime-walkable dotted segments | Enables typed event payload reads like `args.Data[0].Status` to gather correctly |
| Sandbox index | Added links for the newly onboarded Fusion slices | Makes every new slice discoverable in the sandbox UI |

## Audit Notes

| Check | Result |
|---|---|
| Approval matrix app excluded | Confirmed: no `FusionOnboarding`, no SQLite package, no `App_Data`, no `Program.cs` changes |
| Public loose event DTO fields | Removed unused public `object` fields from ChipList/AIAssistView payload DTOs before commit |
| Public arbitrary string member APIs | Not introduced; component slices expose typed methods/properties/events |
| Core DSL changes | Not included, aside from the indexed expression path helper needed by typed event/response reads |
| Component isolation | New Fusion code stays under component vertical-slice folders |

## Verification

| Command | Result |
|---|---|
| `dotnet build tests/Alis.Reactive.PlaywrightTests/Alis.Reactive.PlaywrightTests.csproj --no-restore` | Passed |
| `dotnet test tests/Alis.Reactive.PlaywrightTests/Alis.Reactive.PlaywrightTests.csproj --no-build --filter "FullyQualifiedName~WhenUsingFusionAIAssistView|FullyQualifiedName~WhenUsingFusionChipList|FullyQualifiedName~WhenUsingFusionKanban|FullyQualifiedName~WhenUsingFusionMention|FullyQualifiedName~WhenUsingFusionPivotView|FullyQualifiedName~WhenUsingFusionSmartComponents"` | Passed: 48 tests |
