### PR TITLE
Onboard remaining Fusion components

### DIFF
--- a/Alis.Reactive.Fusion/Components/FusionBreadcrumb/Events/FusionBreadcrumbOnItemClick.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBreadcrumb/Events/FusionBreadcrumbOnItemClick.cs
@@ -1,0 +1,39 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a Breadcrumb item is clicked.
+    /// </summary>
+    public class FusionBreadcrumbItemClickArgs
+    {
+        /// <summary>Gets or sets the clicked item metadata from the Syncfusion event.</summary>
+        public FusionBreadcrumbItem Item { get; set; } = new FusionBreadcrumbItem();
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionBreadcrumbItemClickArgs()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Narrowed breadcrumb item payload proven from Syncfusion Breadcrumb item click behavior.
+    /// </summary>
+    public sealed class FusionBreadcrumbItem
+    {
+        /// <summary>Gets or sets the clicked item's text.</summary>
+        public string Text { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the clicked item's id.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the clicked item's URL.</summary>
+        public string Url { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the clicked item's icon CSS classes.</summary>
+        public string? IconCss { get; set; }
+
+        /// <summary>Gets or sets whether the clicked item is disabled.</summary>
+        public bool Disabled { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumb.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumb.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionBreadcrumb — non-input navigation component wrapping Syncfusion EJ2 Breadcrumb.
+    /// Exposes typed active-item state and typed item-click payloads.
+    /// </summary>
+    public sealed class FusionBreadcrumb : FusionComponent
+    {
+        // No ValueMember. This is a navigation component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps SF BreadcrumbBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionBreadcrumbBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionBreadcrumbBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbEvents.cs
@@ -1,0 +1,18 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionBreadcrumb"/> component.
+    /// </summary>
+    public sealed class FusionBreadcrumbEvents
+    {
+        public static readonly FusionBreadcrumbEvents Instance = new FusionBreadcrumbEvents();
+
+        private FusionBreadcrumbEvents()
+        {
+        }
+
+        /// <summary>Fires when a breadcrumb item is clicked.</summary>
+        public TypedEvent<FusionBreadcrumbItemClickArgs> ItemClick =>
+            new TypedEvent<FusionBreadcrumbItemClickArgs>("itemClick", new FusionBreadcrumbItemClickArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbExtensions.cs
@@ -1,0 +1,37 @@
+using Alis.Reactive.PlanModel;
+using Alis.Reactive.Builders.Conditions;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionBreadcrumb"/>.
+    /// </summary>
+    public static class FusionBreadcrumbExtensions
+    {
+        private static readonly FusionBreadcrumb Component = new FusionBreadcrumb();
+
+        private static readonly ComponentProperty<string> ActiveItemProperty =
+            ComponentProperty<string>.Named("activeItem");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        /// <summary>
+        /// Sets the active breadcrumb item URL or text and flushes the rendered state.
+        /// </summary>
+        public static ComponentRef<FusionBreadcrumb, TModel> SetActiveItem<TModel>(
+            this ComponentRef<FusionBreadcrumb, TModel> self,
+            string activeItem)
+            where TModel : class
+            => self.EmitSet(ActiveItemProperty, ValueExpression.Literal(activeItem))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>
+        /// Reads the current active breadcrumb item URL or text.
+        /// </summary>
+        public static TypedComponentSource<string> ActiveItem<TModel>(
+            this ComponentRef<FusionBreadcrumb, TModel> self)
+            where TModel : class
+            => self.Read(ActiveItemProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbHtmlExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Navigations;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating a typed FusionBreadcrumb slice.
+    /// Non-input component — no input registration wrapper.
+    /// </summary>
+    public static class FusionBreadcrumbHtmlExtensions
+    {
+        public static FusionBreadcrumbBuilder<TModel> FusionBreadcrumb<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<BreadcrumbBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Breadcrumb(elementId);
+            build(builder);
+
+            return new FusionBreadcrumbBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBreadcrumb/FusionBreadcrumbReactiveExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionBreadcrumb"/> into the reactive plan.
+    /// </summary>
+    public static class FusionBreadcrumbReactiveExtensions
+    {
+        private static readonly FusionBreadcrumb Component = new FusionBreadcrumb();
+
+        public static FusionBreadcrumbBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionBreadcrumbBuilder<TModel> builder,
+            Func<FusionBreadcrumbEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionBreadcrumbEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/Events/FusionBulletChartMouseClickArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/Events/FusionBulletChartMouseClickArgs.cs
@@ -1,0 +1,17 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered when the BulletChart is clicked.
+    /// </summary>
+    public sealed class FusionBulletChartMouseClickArgs
+    {
+        /// <summary>Clicked target element id.</summary>
+        public string Target { get; set; } = string.Empty;
+
+        /// <summary>Mouse X coordinate in chart space.</summary>
+        public double X { get; set; }
+
+        /// <summary>Mouse Y coordinate in chart space.</summary>
+        public double Y { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/Events/FusionBulletChartTooltipRenderArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/Events/FusionBulletChartTooltipRenderArgs.cs
@@ -1,0 +1,44 @@
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered before the BulletChart tooltip is rendered.
+    /// </summary>
+    public sealed class FusionBulletChartTooltipRenderArgs
+    {
+        /// <summary>The actual value of the feature bar.</summary>
+        public string Value { get; set; } = string.Empty;
+
+        /// <summary>The target values of the comparative bar.</summary>
+        public string[] Target { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>The event name.</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>The tooltip template markup, when template rendering is enabled.</summary>
+        public string? Template { get; set; }
+
+        /// <summary>The tooltip text, when template rendering is not enabled.</summary>
+        public string? Text { get; set; }
+    }
+
+    /// <summary>
+    /// Typed mutations on the tooltip render event args for <see cref="FusionBulletChart"/>.
+    /// </summary>
+    public static class FusionBulletChartTooltipRenderArgsExtensions
+    {
+        /// <summary>Replaces the tooltip text before Syncfusion renders it.</summary>
+        public static void SetText(
+            this FusionBulletChartTooltipRenderArgs args,
+            IReactionEmitter pipeline,
+            string text)
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "text",
+                ValueExpression.Literal(text)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChart.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChart.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionBulletChart - non-input chart component wrapping Syncfusion EJ2 BulletChart.
+    /// Exposes typed load, tooltip, mouse click, and navigation helper behavior.
+    /// </summary>
+    public sealed class FusionBulletChart : FusionComponent
+    {
+        // No ValueMember. This is a chart/view component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps BulletChartBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionBulletChartBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionBulletChartBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartEvents.cs
@@ -1,0 +1,23 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionBulletChart"/> component.
+    /// </summary>
+    public sealed class FusionBulletChartEvents
+    {
+        public static readonly FusionBulletChartEvents Instance = new FusionBulletChartEvents();
+
+        private FusionBulletChartEvents()
+        {
+        }
+
+        /// <summary>Fires before the tooltip renders.</summary>
+        public TypedEvent<FusionBulletChartTooltipRenderArgs> TooltipRender =>
+            new TypedEvent<FusionBulletChartTooltipRenderArgs>("tooltipRender", new FusionBulletChartTooltipRenderArgs());
+
+        /// <summary>Fires when the chart surface is clicked.</summary>
+        public TypedEvent<FusionBulletChartMouseClickArgs> BulletChartMouseClick =>
+            new TypedEvent<FusionBulletChartMouseClickArgs>("bulletChartMouseClick", new FusionBulletChartMouseClickArgs());
+
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartExtensions.cs
@@ -1,0 +1,30 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionBulletChart"/>.
+    /// </summary>
+    public static class FusionBulletChartExtensions
+    {
+        private static readonly ComponentMethod GetActualIndexMethod =
+            ComponentMethod.Named("getActualIndex").WithArgs<int, int>();
+
+        /// <summary>
+        /// Calculates the wrapped index used by the chart.
+        /// </summary>
+        public static TypedComponentSource<int> GetActualIndex<TModel>(
+            this ComponentRef<FusionBulletChart, TModel> self,
+            int index,
+            int totalLength)
+            where TModel : class
+            => self.Read<int>(
+                GetActualIndexMethod,
+                new System.Collections.Generic.List<ValueExpression>
+                {
+                    ValueExpression.Literal(index),
+                    ValueExpression.Literal(totalLength)
+                });
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartHtmlExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Charts;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating FusionBulletChartBuilder.
+    /// </summary>
+    public static class FusionBulletChartHtmlExtensions
+    {
+        /// <summary>
+        /// Creates a FusionBulletChart with the given element ID.
+        /// </summary>
+        public static FusionBulletChartBuilder<TModel> FusionBulletChart<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<BulletChartBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().BulletChart(elementId);
+            build(builder);
+
+            return new FusionBulletChartBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionBulletChart/FusionBulletChartReactiveExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionBulletChart"/> into the reactive plan.
+    /// </summary>
+    public static class FusionBulletChartReactiveExtensions
+    {
+        private static readonly FusionBulletChart Component = new FusionBulletChart();
+
+        public static FusionBulletChartBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionBulletChartBuilder<TModel> builder,
+            Func<FusionBulletChartEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionBulletChartEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionButton/FusionButton.cs
+++ b/Alis.Reactive.Fusion/Components/FusionButton/FusionButton.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionButton backed by Syncfusion EJ2 Button.
+    /// </summary>
+    public sealed class FusionButton : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonBuilder.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps Syncfusion ButtonBuilder output while carrying the component id.
+    /// </summary>
+    public sealed class FusionButtonBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionButtonBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonExtensions.cs
@@ -1,0 +1,149 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render mutations, reads, and methods for <see cref="FusionButton"/>.
+    /// </summary>
+    public static class FusionButtonExtensions
+    {
+        private static readonly ComponentProperty<string> ContentProperty =
+            ComponentProperty<string>.Named("content");
+
+        private static readonly ComponentProperty<bool> DisabledProperty =
+            ComponentProperty<bool>.Named("disabled");
+
+        private static readonly ComponentProperty<string> IconCssProperty =
+            ComponentProperty<string>.Named("iconCss");
+
+        private static readonly ComponentProperty<string> IconPositionProperty =
+            ComponentProperty<string>.Named("iconPosition");
+
+        private static readonly ComponentProperty<string> CssClassProperty =
+            ComponentProperty<string>.Named("cssClass");
+
+        private static readonly ComponentProperty<bool> IsPrimaryProperty =
+            ComponentProperty<bool>.Named("isPrimary");
+
+        private static readonly ComponentProperty<bool> IsToggleProperty =
+            ComponentProperty<bool>.Named("isToggle");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod ClickMethod =
+            ComponentMethod.Named("click");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        /// <summary>Sets the visible button content and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionButton, TModel> SetContent<TModel>(
+            this ComponentRef<FusionButton, TModel> self,
+            string content)
+            where TModel : class
+            => self
+                .EmitSet(ContentProperty, ValueExpression.Literal(content))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether the button is disabled and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionButton, TModel> SetDisabled<TModel>(
+            this ComponentRef<FusionButton, TModel> self,
+            bool disabled)
+            where TModel : class
+            => self
+                .EmitSet(DisabledProperty, ValueExpression.Literal(disabled))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets the button icon CSS and position, then flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionButton, TModel> SetIcon<TModel>(
+            this ComponentRef<FusionButton, TModel> self,
+            string iconCss,
+            FusionButtonIconPosition position)
+            where TModel : class
+            => self
+                .EmitSet(IconCssProperty, ValueExpression.Literal(iconCss))
+                .EmitSet(IconPositionProperty, ValueExpression.Literal(ToSyncfusion(position)))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets the button CSS classes and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionButton, TModel> SetCssClass<TModel>(
+            this ComponentRef<FusionButton, TModel> self,
+            string cssClass)
+            where TModel : class
+            => self
+                .EmitSet(CssClassProperty, ValueExpression.Literal(cssClass))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether the button has Syncfusion primary styling.</summary>
+        public static ComponentRef<FusionButton, TModel> SetPrimary<TModel>(
+            this ComponentRef<FusionButton, TModel> self,
+            bool isPrimary)
+            where TModel : class
+            => self
+                .EmitSet(IsPrimaryProperty, ValueExpression.Literal(isPrimary))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether the button toggles active state when clicked.</summary>
+        public static ComponentRef<FusionButton, TModel> SetToggle<TModel>(
+            this ComponentRef<FusionButton, TModel> self,
+            bool isToggle)
+            where TModel : class
+            => self
+                .EmitSet(IsToggleProperty, ValueExpression.Literal(isToggle))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Invokes the button's native click through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionButton, TModel> Click<TModel>(
+            this ComponentRef<FusionButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClickMethod);
+
+        /// <summary>Moves focus into the button through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionButton, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Reads the current Syncfusion content property.</summary>
+        public static TypedComponentSource<string> Content<TModel>(
+            this ComponentRef<FusionButton, TModel> self)
+            where TModel : class
+            => self.Read(ContentProperty);
+
+        /// <summary>Reads whether the button is currently disabled.</summary>
+        public static TypedComponentSource<bool> Disabled<TModel>(
+            this ComponentRef<FusionButton, TModel> self)
+            where TModel : class
+            => self.Read(DisabledProperty);
+
+        /// <summary>Reads the current CSS class property.</summary>
+        public static TypedComponentSource<string> CssClass<TModel>(
+            this ComponentRef<FusionButton, TModel> self)
+            where TModel : class
+            => self.Read(CssClassProperty);
+
+        /// <summary>Reads whether the button is currently primary.</summary>
+        public static TypedComponentSource<bool> IsPrimary<TModel>(
+            this ComponentRef<FusionButton, TModel> self)
+            where TModel : class
+            => self.Read(IsPrimaryProperty);
+
+        /// <summary>Reads whether the button currently toggles active state.</summary>
+        public static TypedComponentSource<bool> IsToggle<TModel>(
+            this ComponentRef<FusionButton, TModel> self)
+            where TModel : class
+            => self.Read(IsToggleProperty);
+
+        private static string ToSyncfusion(FusionButtonIconPosition position) =>
+            position switch
+            {
+                FusionButtonIconPosition.Left => "Left",
+                FusionButtonIconPosition.Right => "Right",
+                FusionButtonIconPosition.Top => "Top",
+                FusionButtonIconPosition.Bottom => "Bottom",
+                _ => throw new System.ArgumentOutOfRangeException(nameof(position), position, null)
+            };
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonHtmlExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Buttons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionButton with Syncfusion MVC builder-owned initial render.
+    /// </summary>
+    public static class FusionButtonHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a non-input FusionButton with a stable component id.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <param name="html">The MVC HTML helper.</param>
+        /// <param name="plan">The reactive plan that will reference this component.</param>
+        /// <param name="elementId">The controlled browser id used as the runtime join key.</param>
+        /// <param name="build">Configures initial Syncfusion Button options.</param>
+        /// <returns>The rendered Syncfusion button content.</returns>
+        public static FusionButtonBuilder<TModel> FusionButton<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<ButtonBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Button(elementId);
+            build(builder);
+
+            return new FusionButtonBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonIconPosition.cs
+++ b/Alis.Reactive.Fusion/Components/FusionButton/FusionButtonIconPosition.cs
@@ -1,0 +1,20 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Runtime icon placement values supported by Syncfusion EJ2 Button.
+    /// </summary>
+    public enum FusionButtonIconPosition
+    {
+        /// <summary>Place the icon before the text.</summary>
+        Left,
+
+        /// <summary>Place the icon after the text.</summary>
+        Right,
+
+        /// <summary>Place the icon above the text.</summary>
+        Top,
+
+        /// <summary>Place the icon below the text.</summary>
+        Bottom
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/Events/FusionCarouselOnSlideChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/Events/FusionCarouselOnSlideChanged.cs
@@ -1,0 +1,27 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered after a Carousel slide changes.
+    /// </summary>
+    public class FusionCarouselSlideChangedArgs
+    {
+        /// <summary>Current slide index.</summary>
+        public int CurrentIndex { get; set; }
+
+        /// <summary>Previous slide index.</summary>
+        public int PreviousIndex { get; set; }
+
+        /// <summary>Whether the slide change was triggered by swipe.</summary>
+        public bool IsSwiped { get; set; }
+
+        /// <summary>Slide direction: Previous or Next.</summary>
+        public string SlideDirection { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionCarouselSlideChangedArgs()
+        {
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/Events/FusionCarouselOnSlideChanging.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/Events/FusionCarouselOnSlideChanging.cs
@@ -1,0 +1,47 @@
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered before a Carousel slide changes.
+    /// </summary>
+    public class FusionCarouselSlideChangingArgs
+    {
+        /// <summary>Current slide index.</summary>
+        public int CurrentIndex { get; set; }
+
+        /// <summary>Next slide index.</summary>
+        public int NextIndex { get; set; }
+
+        /// <summary>Whether the slide change was triggered by swipe.</summary>
+        public bool IsSwiped { get; set; }
+
+        /// <summary>Slide direction: Previous or Next.</summary>
+        public string SlideDirection { get; set; } = string.Empty;
+
+        /// <summary>Whether the slide change should be cancelled.</summary>
+        public bool Cancel { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionCarouselSlideChangingArgs()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Typed mutations on the slideChanging event args for <see cref="FusionCarousel"/>.
+    /// </summary>
+    public static class FusionCarouselSlideChangingArgsExtensions
+    {
+        /// <summary>Cancels the pending slide transition.</summary>
+        public static void PreventTransition(
+            this FusionCarouselSlideChangingArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(PayloadSource.Event(), "cancel", ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarousel.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarousel.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionCarousel — non-input navigation component wrapping Syncfusion EJ2 Carousel.
+    /// Exposes typed selected-index state, slide navigation methods, and slide-change events.
+    /// </summary>
+    public sealed class FusionCarousel : FusionComponent
+    {
+        // No ValueMember. This is a navigation component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps SF CarouselBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionCarouselBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionCarouselBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselEvents.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionCarousel"/> component.
+    /// </summary>
+    public sealed class FusionCarouselEvents
+    {
+        public static readonly FusionCarouselEvents Instance = new FusionCarouselEvents();
+
+        private FusionCarouselEvents()
+        {
+        }
+
+        /// <summary>Fires before the slide changes.</summary>
+        public TypedEvent<FusionCarouselSlideChangingArgs> SlideChanging =>
+            new TypedEvent<FusionCarouselSlideChangingArgs>("slideChanging", new FusionCarouselSlideChangingArgs());
+
+        /// <summary>Fires after the slide changes.</summary>
+        public TypedEvent<FusionCarouselSlideChangedArgs> SlideChanged =>
+            new TypedEvent<FusionCarouselSlideChangedArgs>("slideChanged", new FusionCarouselSlideChangedArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselExtensions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionCarousel"/>.
+    /// </summary>
+    public static class FusionCarouselExtensions
+    {
+        private static readonly FusionCarousel Component = new FusionCarousel();
+
+        private static readonly ComponentProperty<int> SelectedIndexProperty =
+            ComponentProperty<int>.Named("selectedIndex");
+
+        private static readonly ComponentMethod NextMethod =
+            ComponentMethod.Named("next");
+
+        private static readonly ComponentMethod PreviousMethod =
+            ComponentMethod.Named("prev");
+
+        /// <summary>
+        /// Reads the current slide index.
+        /// </summary>
+        public static TypedComponentSource<int> SelectedIndex<TModel>(
+            this ComponentRef<FusionCarousel, TModel> self)
+            where TModel : class
+            => self.Read(SelectedIndexProperty);
+
+        /// <summary>
+        /// Advances to the next slide.
+        /// </summary>
+        public static ComponentRef<FusionCarousel, TModel> Next<TModel>(
+            this ComponentRef<FusionCarousel, TModel> self)
+            where TModel : class
+            => self.EmitCall(NextMethod);
+
+        /// <summary>
+        /// Moves to the previous slide.
+        /// </summary>
+        public static ComponentRef<FusionCarousel, TModel> Previous<TModel>(
+            this ComponentRef<FusionCarousel, TModel> self)
+            where TModel : class
+            => self.EmitCall(PreviousMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselHtmlExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Navigations;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating a typed FusionCarousel slice.
+    /// Non-input component — no input registration wrapper.
+    /// </summary>
+    public static class FusionCarouselHtmlExtensions
+    {
+        public static FusionCarouselBuilder<TModel> FusionCarousel<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<CarouselBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Carousel(elementId);
+            build(builder);
+
+            return new FusionCarouselBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCarousel/FusionCarouselReactiveExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionCarousel"/> into the reactive plan.
+    /// </summary>
+    public static class FusionCarouselReactiveExtensions
+    {
+        private static readonly FusionCarousel Component = new FusionCarousel();
+
+        public static FusionCarouselBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionCarouselBuilder<TModel> builder,
+            Func<FusionCarouselEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionCarouselEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCheckBox/Events/FusionCheckBoxOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCheckBox/Events/FusionCheckBoxOnChanged.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionCheckBox"/> checked state changes.
+    /// </summary>
+    public class FusionCheckBoxChangeArgs
+    {
+        /// <summary>Gets or sets whether the checkbox is checked after the change.</summary>
+        public bool Checked { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionCheckBoxChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBox.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBox.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionCheckBox backed by Syncfusion EJ2 CheckBox.
+    /// </summary>
+    public sealed class FusionCheckBox : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionCheckBox(), "checkbox");
+
+        /// <inheritdoc />
+        public string ValueMember => "checked";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxEvents.cs
@@ -1,0 +1,17 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionCheckBox"/> component.
+    /// </summary>
+    public sealed class FusionCheckBoxEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionCheckBoxEvents Instance = new FusionCheckBoxEvents();
+        private FusionCheckBoxEvents() { }
+
+        /// <summary>Fires when the checkbox state changes (SF "change" event).</summary>
+        public TypedEvent<FusionCheckBoxChangeArgs> Changed =>
+            new TypedEvent<FusionCheckBoxChangeArgs>(
+                "change", new FusionCheckBoxChangeArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxExtensions.cs
@@ -1,0 +1,88 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render mutations, reads, and methods for <see cref="FusionCheckBox"/>.
+    /// </summary>
+    public static class FusionCheckBoxExtensions
+    {
+        private static readonly FusionCheckBox Component = new FusionCheckBox();
+
+        private static readonly ComponentProperty<bool> CheckedProperty =
+            ComponentProperty<bool>.Named(Component.ValueMember);
+
+        private static readonly ComponentProperty<bool> IndeterminateProperty =
+            ComponentProperty<bool>.Named("indeterminate");
+
+        private static readonly ComponentProperty<bool> DisabledProperty =
+            ComponentProperty<bool>.Named("disabled");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod ClickMethod =
+            ComponentMethod.Named("click");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        /// <summary>Sets the checked state and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionCheckBox, TModel> SetChecked<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self,
+            bool isChecked)
+            where TModel : class
+            => self
+                .EmitSet(CheckedProperty, ValueExpression.Literal(isChecked))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets the indeterminate state and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionCheckBox, TModel> SetIndeterminate<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self,
+            bool isIndeterminate)
+            where TModel : class
+            => self
+                .EmitSet(IndeterminateProperty, ValueExpression.Literal(isIndeterminate))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether the checkbox is disabled and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionCheckBox, TModel> SetDisabled<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self,
+            bool disabled)
+            where TModel : class
+            => self
+                .EmitSet(DisabledProperty, ValueExpression.Literal(disabled))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Invokes the checkbox's native click through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionCheckBox, TModel> Click<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClickMethod);
+
+        /// <summary>Moves focus into the checkbox through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionCheckBox, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Reads whether the checkbox is currently checked.</summary>
+        public static TypedComponentSource<bool> Checked<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self)
+            where TModel : class
+            => self.Read(CheckedProperty);
+
+        /// <summary>Reads whether the checkbox is currently indeterminate.</summary>
+        public static TypedComponentSource<bool> Indeterminate<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self)
+            where TModel : class
+            => self.Read(IndeterminateProperty);
+
+        /// <summary>Reads whether the checkbox is currently disabled.</summary>
+        public static TypedComponentSource<bool> Disabled<TModel>(
+            this ComponentRef<FusionCheckBox, TModel> self)
+            where TModel : class
+            => self.Read(DisabledProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxHtmlExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Buttons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionCheckBox inside a field wrapper, bound to a boolean model property.
+    /// </summary>
+    public static class FusionCheckBoxHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionCheckBox bound to the field's boolean model property.
+        /// </summary>
+        public static void FusionCheckBox<TModel>(
+            this InputBoundField<TModel, bool> setup,
+            Action<CheckBoxBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionCheckBox.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().CheckBoxFor(setup.Expression)
+                .HtmlAttributes(new Dictionary<string, object> { ["id"] = setup.ElementId, ["name"] = setup.BindingPath });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionCheckBox/FusionCheckBoxReactiveExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.Buttons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionCheckBox"/> into the reactive plan.
+    /// </summary>
+    public static class FusionCheckBoxReactiveExtensions
+    {
+        private static readonly FusionCheckBox Component = new FusionCheckBox();
+
+        /// <summary>
+        /// Wires a FusionCheckBox event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        public static CheckBoxBuilder Reactive<TModel, TArgs>(
+            this CheckBoxBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionCheckBoxEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionCheckBoxEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/Events/FusionComboBoxOnBlur.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/Events/FusionComboBoxOnBlur.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionComboBox"/> loses focus.
+    /// </summary>
+    /// <remarks>
+    /// Blur carries no onboarded data. Use for triggering side effects on focus loss.
+    /// </remarks>
+    public class FusionComboBoxBlurArgs
+    {
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionComboBoxBlurArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/Events/FusionComboBoxOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/Events/FusionComboBoxOnChanged.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionComboBox"/> selection changes.
+    /// </summary>
+    /// <remarks>
+    /// Access properties in conditions: <c>p.When(args, x =&gt; x.Value).Eq("alice")</c>.
+    /// </remarks>
+    public class FusionComboBoxChangeArgs
+    {
+        /// <summary>Gets or sets the selected value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionComboBoxChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/Events/FusionComboBoxOnFocus.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/Events/FusionComboBoxOnFocus.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionComboBox"/> receives focus.
+    /// </summary>
+    /// <remarks>
+    /// Focus carries no onboarded data. Use for triggering side effects on focus gain.
+    /// </remarks>
+    public class FusionComboBoxFocusArgs
+    {
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionComboBoxFocusArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBox.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBox.cs
@@ -1,0 +1,18 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionComboBox for selecting or entering a single string value.
+    /// </summary>
+    /// <remarks>
+    /// Use as a type parameter in <c>p.Component&lt;FusionComboBox&gt;(m =&gt; m.Resident)</c>
+    /// to access ComboBox-specific mutations and value reading.
+    /// </remarks>
+    public sealed class FusionComboBox : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionComboBox(), "combobox");
+
+        /// <inheritdoc />
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxEvents.cs
@@ -1,0 +1,31 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionComboBox"/> component.
+    /// </summary>
+    /// <remarks>
+    /// Select an event via the <c>.Reactive()</c> lambda:
+    /// <c>.Reactive(plan, evt =&gt; evt.Changed, (args, p) =&gt; { ... })</c>.
+    /// </remarks>
+    public sealed class FusionComboBoxEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionComboBoxEvents Instance = new FusionComboBoxEvents();
+        private FusionComboBoxEvents() { }
+
+        /// <summary>Fires when the selected value changes (SF "change" event).</summary>
+        public TypedEvent<FusionComboBoxChangeArgs> Changed =>
+            new TypedEvent<FusionComboBoxChangeArgs>(
+                "change", new FusionComboBoxChangeArgs());
+
+        /// <summary>Fires when the component receives focus (SF "focus" event).</summary>
+        public TypedEvent<FusionComboBoxFocusArgs> Focus =>
+            new TypedEvent<FusionComboBoxFocusArgs>(
+                "focus", new FusionComboBoxFocusArgs());
+
+        /// <summary>Fires when the component loses focus (SF "blur" event).</summary>
+        public TypedEvent<FusionComboBoxBlurArgs> Blur =>
+            new TypedEvent<FusionComboBoxBlurArgs>(
+                "blur", new FusionComboBoxBlurArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxExtensions.cs
@@ -1,0 +1,131 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed mutations and value reading for <see cref="FusionComboBox"/> in a reactive pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Obtain a <see cref="ComponentRef{TComponent, TModel}"/> via the pipeline:
+    /// <c>p.Component&lt;FusionComboBox&gt;(m =&gt; m.Resident).SetValue("alice")</c>.
+    /// </remarks>
+    public static class FusionComboBoxExtensions
+    {
+        private static readonly FusionComboBox Component = new FusionComboBox();
+
+        private static readonly ComponentProperty<string?> ValueProperty =
+            ComponentProperty<string?>.Named(Component.ValueMember);
+
+        private static readonly ComponentProperty<string?> TextProperty =
+            ComponentProperty<string?>.Named("text");
+
+        private static readonly ComponentProperty<int?> IndexProperty =
+            ComponentProperty<int?>.Named("index");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        private static readonly ComponentMethod FocusOutMethod =
+            ComponentMethod.Named("focusOut");
+
+        private static readonly ComponentMethod ShowPopupMethod =
+            ComponentMethod.Named("showPopup");
+
+        private static readonly ComponentMethod HidePopupMethod =
+            ComponentMethod.Named("hidePopup");
+
+        private static readonly ComponentMethod ClearMethod =
+            ComponentMethod.Named("clear");
+
+        /// <summary>Sets the selected value, or clears it with <see langword="null"/>.</summary>
+        /// <param name="value">The string value to select.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> SetValue<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self, string? value)
+            where TModel : class
+            => self.EmitSet(ValueProperty, ValueExpression.LiteralRaw(value, Shape.String));
+
+        /// <summary>Sets the displayed text, or clears it with <see langword="null"/>.</summary>
+        /// <param name="text">The display text to select.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> SetText<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self, string? text)
+            where TModel : class
+            => self.EmitSet(TextProperty, ValueExpression.LiteralRaw(text, Shape.String));
+
+        /// <summary>Sets the selected list index.</summary>
+        /// <param name="index">The zero-based list index to select.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> SetIndex<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self, int index)
+            where TModel : class
+            => self.EmitSet(IndexProperty, ValueExpression.Literal(index));
+
+        /// <summary>Flushes pending property changes to the ComboBox in the browser.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> DataBind<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(DataBindMethod);
+
+        /// <summary>Moves focus into the ComboBox input.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Removes focus from the ComboBox input.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> FocusOut<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusOutMethod);
+
+        /// <summary>Opens the ComboBox popup.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> ShowPopup<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(ShowPopupMethod);
+
+        /// <summary>Closes the ComboBox popup.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> HidePopup<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(HidePopupMethod);
+
+        /// <summary>Clears the selected value, text, and index.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionComboBox, TModel> Clear<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClearMethod);
+
+        /// <summary>Reads the current selected value for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the ComboBox's current value.</returns>
+        public static TypedComponentSource<string?> Value<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+
+        /// <summary>Reads the current display text for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the ComboBox's current display text.</returns>
+        public static TypedComponentSource<string?> Text<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.Read(TextProperty);
+
+        /// <summary>Reads the current selected index for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the ComboBox's current selected index.</returns>
+        public static TypedComponentSource<int?> Index<TModel>(
+            this ComponentRef<FusionComboBox, TModel> self)
+            where TModel : class
+            => self.Read(IndexProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxHtmlExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.DropDowns;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionComboBox inside a field wrapper, bound to a model property.
+    /// </summary>
+    /// <remarks>
+    /// Syncfusion's MVC builder owns initial render configuration such as data source,
+    /// field names, placeholder, popup size, and allow-custom behavior.
+    /// </remarks>
+    public static class FusionComboBoxHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionComboBox bound to the field's model property.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TProp">The bound property type.</typeparam>
+        /// <param name="setup">The field wrapper created by <c>Html.InputField()</c>.</param>
+        /// <param name="build">Callback to build the Syncfusion ComboBox.</param>
+        public static void FusionComboBox<TModel, TProp>(
+            this InputBoundField<TModel, TProp> setup,
+            Action<ComboBoxBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionComboBox.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().ComboBoxFor(setup.Expression)
+                .HtmlAttributes(new Dictionary<string, object> { ["id"] = setup.ElementId, ["name"] = setup.BindingPath });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionComboBox/FusionComboBoxReactiveExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.DropDowns;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionComboBox"/> into the reactive plan.
+    /// </summary>
+    /// <remarks>
+    /// <c>.Reactive()</c> is always the last call inside the build callback passed to
+    /// <see cref="FusionComboBoxHtmlExtensions.FusionComboBox{TModel,TProp}"/>.
+    /// </remarks>
+    public static class FusionComboBoxReactiveExtensions
+    {
+        private static readonly FusionComboBox Component = new FusionComboBox();
+
+        /// <summary>
+        /// Wires a FusionComboBox event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TArgs">The event args type, inferred from the event selector.</typeparam>
+        /// <param name="builder">The Syncfusion ComboBox builder.</param>
+        /// <param name="plan">The plan to add the reactive behavior to.</param>
+        /// <param name="eventSelector">Selects which event to react to.</param>
+        /// <param name="pipeline">Configures the commands to run when the event fires.</param>
+        /// <returns>The builder for method chaining.</returns>
+        public static ComboBoxBuilder Reactive<TModel, TArgs>(
+            this ComboBoxBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionComboBoxEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionComboBoxEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeCloseArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeCloseArgs.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered before the context menu closes.
+    /// </summary>
+    public sealed class FusionContextMenuBeforeCloseArgs
+    {
+        public List<FusionContextMenuItem> Items { get; set; } = [];
+
+        public FusionContextMenuItem? ParentItem { get; set; }
+
+        public bool Cancel { get; set; }
+    }
+
+    /// <summary>
+    /// Typed mutations on the beforeClose event args for <see cref="FusionContextMenu"/>.
+    /// </summary>
+    public static class FusionContextMenuBeforeCloseArgsExtensions
+    {
+        public static void PreventClose(
+            this FusionContextMenuBeforeCloseArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(PayloadSource.Event(), "cancel", ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeItemRenderArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeItemRenderArgs.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered before a context menu item renders.
+    /// </summary>
+    public sealed class FusionContextMenuBeforeItemRenderArgs
+    {
+        public FusionContextMenuItem Item { get; set; } = new FusionContextMenuItem();
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeOpenArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeOpenArgs.cs
@@ -17,7 +17,7 @@ namespace Alis.Reactive.Fusion.Components
 
         public double Left { get; set; }
 
-        public bool IsFocused { get; set; }
+        public bool? IsFocused { get; set; }
 
         public bool Cancel { get; set; }
     }

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeOpenArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuBeforeOpenArgs.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered before the context menu opens.
+    /// </summary>
+    public sealed class FusionContextMenuBeforeOpenArgs
+    {
+        public List<FusionContextMenuItem> Items { get; set; } = [];
+
+        public FusionContextMenuItem? ParentItem { get; set; }
+
+        public double Top { get; set; }
+
+        public double Left { get; set; }
+
+        public bool IsFocused { get; set; }
+
+        public bool Cancel { get; set; }
+    }
+
+    /// <summary>
+    /// Typed mutations on the beforeOpen event args for <see cref="FusionContextMenu"/>.
+    /// </summary>
+    public static class FusionContextMenuBeforeOpenArgsExtensions
+    {
+        public static void PreventOpen(
+            this FusionContextMenuBeforeOpenArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(PayloadSource.Event(), "cancel", ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuItem.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuItem.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Narrow typed context menu item payload projected from Syncfusion ContextMenu item objects.
+    /// </summary>
+    public sealed class FusionContextMenuItem
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Text { get; set; } = string.Empty;
+
+        public string Url { get; set; } = string.Empty;
+
+        public string IconCss { get; set; } = string.Empty;
+
+        public bool Separator { get; set; }
+
+        public List<FusionContextMenuItem> Items { get; set; } = [];
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuOpenCloseArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuOpenCloseArgs.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered after the context menu opens or closes.
+    /// </summary>
+    public sealed class FusionContextMenuOpenCloseArgs
+    {
+        public List<FusionContextMenuItem> Items { get; set; } = [];
+
+        public FusionContextMenuItem? ParentItem { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuSelectArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/Events/FusionContextMenuSelectArgs.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered when a context menu item is selected.
+    /// </summary>
+    public sealed class FusionContextMenuSelectArgs
+    {
+        public FusionContextMenuItem Item { get; set; } = new FusionContextMenuItem();
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenu.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenu.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionContextMenu - non-input context menu component wrapping Syncfusion EJ2 ContextMenu.
+    /// Exposes typed open/close methods and lifecycle/item selection payloads.
+    /// </summary>
+    public sealed class FusionContextMenu : FusionComponent
+    {
+        // No ValueMember. This is a navigation/context component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps ContextMenuBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionContextMenuBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionContextMenuBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuEvents.cs
@@ -1,0 +1,40 @@
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionContextMenu"/> component.
+    /// </summary>
+    public sealed class FusionContextMenuEvents
+    {
+        public static readonly FusionContextMenuEvents Instance = new FusionContextMenuEvents();
+
+        private FusionContextMenuEvents()
+        {
+        }
+
+        /// <summary>Fires before each context menu item renders.</summary>
+        public TypedEvent<FusionContextMenuBeforeItemRenderArgs> BeforeItemRender =>
+            new TypedEvent<FusionContextMenuBeforeItemRenderArgs>("beforeItemRender", new FusionContextMenuBeforeItemRenderArgs());
+
+        /// <summary>Fires before the context menu opens.</summary>
+        public TypedEvent<FusionContextMenuBeforeOpenArgs> BeforeOpen =>
+            new TypedEvent<FusionContextMenuBeforeOpenArgs>("beforeOpen", new FusionContextMenuBeforeOpenArgs());
+
+        /// <summary>Fires after the context menu opens.</summary>
+        public TypedEvent<FusionContextMenuOpenCloseArgs> Opened =>
+            new TypedEvent<FusionContextMenuOpenCloseArgs>("onOpen", new FusionContextMenuOpenCloseArgs());
+
+        /// <summary>Fires before the context menu closes.</summary>
+        public TypedEvent<FusionContextMenuBeforeCloseArgs> BeforeClose =>
+            new TypedEvent<FusionContextMenuBeforeCloseArgs>("beforeClose", new FusionContextMenuBeforeCloseArgs());
+
+        /// <summary>Fires after the context menu closes.</summary>
+        public TypedEvent<FusionContextMenuOpenCloseArgs> Closed =>
+            new TypedEvent<FusionContextMenuOpenCloseArgs>("onClose", new FusionContextMenuOpenCloseArgs());
+
+        /// <summary>Fires when a menu item is selected.</summary>
+        public TypedEvent<FusionContextMenuSelectArgs> Select =>
+            new TypedEvent<FusionContextMenuSelectArgs>("select", new FusionContextMenuSelectArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuExtensions.cs
@@ -1,0 +1,38 @@
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionContextMenu"/>.
+    /// </summary>
+    public static class FusionContextMenuExtensions
+    {
+        private static readonly ComponentMethod OpenMethod =
+            ComponentMethod.Named("open").WithArgs<double, double>();
+
+        private static readonly ComponentMethod CloseMethod =
+            ComponentMethod.Named("close");
+
+        /// <summary>
+        /// Opens the context menu at the specified position.
+        /// </summary>
+        public static ComponentRef<FusionContextMenu, TModel> Open<TModel>(
+            this ComponentRef<FusionContextMenu, TModel> self,
+            double top,
+            double left)
+            where TModel : class
+            => self.EmitCall(OpenMethod, new System.Collections.Generic.List<ValueExpression>
+            {
+                ValueExpression.Literal(top),
+                ValueExpression.Literal(left)
+            });
+
+        /// <summary>
+        /// Closes the context menu.
+        /// </summary>
+        public static ComponentRef<FusionContextMenu, TModel> Close<TModel>(
+            this ComponentRef<FusionContextMenu, TModel> self)
+            where TModel : class
+            => self.EmitCall(CloseMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuHtmlExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Navigations;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating FusionContextMenuBuilder.
+    /// </summary>
+    public static class FusionContextMenuHtmlExtensions
+    {
+        /// <summary>
+        /// Creates a ContextMenu with the given element ID.
+        /// </summary>
+        public static FusionContextMenuBuilder<TModel> FusionContextMenu<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<ContextMenuBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().ContextMenu(elementId);
+            build(builder);
+
+            return new FusionContextMenuBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionContextMenu/FusionContextMenuReactiveExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionContextMenu"/> into the reactive plan.
+    /// </summary>
+    public static class FusionContextMenuReactiveExtensions
+    {
+        private static readonly FusionContextMenu Component = new FusionContextMenu();
+
+        public static FusionContextMenuBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionContextMenuBuilder<TModel> builder,
+            Func<FusionContextMenuEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionContextMenuEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownButton/Events/FusionDropDownButtonOnSelected.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownButton/Events/FusionDropDownButtonOnSelected.cs
@@ -1,0 +1,31 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionDropDownButton"/> action item is selected.
+    /// </summary>
+    public class FusionDropDownButtonSelectArgs
+    {
+        /// <summary>Gets or sets the selected item metadata from the Syncfusion select event.</summary>
+        public FusionDropDownButtonItem Item { get; set; } = new FusionDropDownButtonItem();
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionDropDownButtonSelectArgs() { }
+    }
+
+    /// <summary>
+    /// Narrowed action item payload proven from Syncfusion DropDownButton MenuEventArgs.
+    /// </summary>
+    public sealed class FusionDropDownButtonItem
+    {
+        /// <summary>Gets or sets the selected item's Syncfusion id.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the selected item's display text.</summary>
+        public string Text { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets whether the selected item is disabled.</summary>
+        public bool Disabled { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButton.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButton.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 DropDownButton. Static item and render configuration stays on the MVC builder;
+    /// this type scopes typed post-render behavior and event wiring.
+    /// </summary>
+    public sealed class FusionDropDownButton : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonBuilder.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps Syncfusion DropDownButtonBuilder output while carrying the component id.
+    /// </summary>
+    public sealed class FusionDropDownButtonBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionDropDownButtonBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonEvents.cs
@@ -1,0 +1,17 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionDropDownButton"/> component.
+    /// </summary>
+    public sealed class FusionDropDownButtonEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionDropDownButtonEvents Instance = new FusionDropDownButtonEvents();
+        private FusionDropDownButtonEvents() { }
+
+        /// <summary>Fires after an action item is selected (SF "select" event).</summary>
+        public TypedEvent<FusionDropDownButtonSelectArgs> Selected =>
+            new TypedEvent<FusionDropDownButtonSelectArgs>(
+                "select", new FusionDropDownButtonSelectArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonExtensions.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render mutations, reads, and methods for <see cref="FusionDropDownButton"/>.
+    /// </summary>
+    public static class FusionDropDownButtonExtensions
+    {
+        private static readonly ComponentProperty<string> ContentProperty =
+            ComponentProperty<string>.Named("content");
+
+        private static readonly ComponentProperty<bool> DisabledProperty =
+            ComponentProperty<bool>.Named("disabled");
+
+        private static readonly ComponentProperty<string> CssClassProperty =
+            ComponentProperty<string>.Named("cssClass");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod ToggleMethod =
+            ComponentMethod.Named("toggle");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        private static readonly ComponentMethod RemoveItemsMethod =
+            ComponentMethod.Named("removeItems").WithArgs<string[], bool>();
+
+        /// <summary>Sets the visible button content and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionDropDownButton, TModel> SetContent<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self,
+            string content)
+            where TModel : class
+            => self
+                .EmitSet(ContentProperty, ValueExpression.Literal(content))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether the dropdown button is disabled and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionDropDownButton, TModel> SetDisabled<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self,
+            bool disabled)
+            where TModel : class
+            => self
+                .EmitSet(DisabledProperty, ValueExpression.Literal(disabled))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets the rendered CSS classes on the dropdown button and popup, then flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionDropDownButton, TModel> SetCssClass<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self,
+            string cssClass)
+            where TModel : class
+            => self
+                .EmitSet(CssClassProperty, ValueExpression.Literal(cssClass))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Toggles the DropDownButton popup between open and closed states.</summary>
+        public static ComponentRef<FusionDropDownButton, TModel> Toggle<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(ToggleMethod);
+
+        /// <summary>Moves focus into the dropdown button through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionDropDownButton, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Removes action items by displayed text.</summary>
+        public static ComponentRef<FusionDropDownButton, TModel> RemoveItemsByText<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self,
+            params string[] itemTexts)
+            where TModel : class
+            => self.EmitCall(RemoveItemsMethod, RemoveItemsArgs(itemTexts, isUniqueId: false));
+
+        /// <summary>Removes action items by Syncfusion item id.</summary>
+        public static ComponentRef<FusionDropDownButton, TModel> RemoveItemsById<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self,
+            params string[] itemIds)
+            where TModel : class
+            => self.EmitCall(RemoveItemsMethod, RemoveItemsArgs(itemIds, isUniqueId: true));
+
+        /// <summary>Reads the current Syncfusion content property.</summary>
+        public static TypedComponentSource<string> Content<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self)
+            where TModel : class
+            => self.Read(ContentProperty);
+
+        /// <summary>Reads whether the dropdown button is currently disabled.</summary>
+        public static TypedComponentSource<bool> Disabled<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self)
+            where TModel : class
+            => self.Read(DisabledProperty);
+
+        /// <summary>Reads the current Syncfusion CSS class property.</summary>
+        public static TypedComponentSource<string> CssClass<TModel>(
+            this ComponentRef<FusionDropDownButton, TModel> self)
+            where TModel : class
+            => self.Read(CssClassProperty);
+
+        private static List<ValueExpression> RemoveItemsArgs(string[] items, bool isUniqueId)
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+
+            var itemValues = items
+                .Select(ValueExpression.Literal)
+                .ToList();
+
+            return new List<ValueExpression>
+            {
+                ValueExpression.Array(itemValues, Shape.ArrayOf(Shape.String)),
+                ValueExpression.Literal(isUniqueId)
+            };
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonHtmlExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.SplitButtons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionDropDownButton with Syncfusion MVC builder-owned initial render.
+    /// </summary>
+    public static class FusionDropDownButtonHtmlExtensions
+    {
+        /// <summary>
+        /// Renders one Syncfusion DropDownButton with a stable component id.
+        /// </summary>
+        public static FusionDropDownButtonBuilder<TModel> FusionDropDownButton<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<DropDownButtonBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().DropDownButton(elementId);
+            build(builder);
+
+            return new FusionDropDownButtonBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownButton/FusionDropDownButtonReactiveExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionDropDownButton"/> into the reactive plan.
+    /// </summary>
+    public static class FusionDropDownButtonReactiveExtensions
+    {
+        private static readonly FusionDropDownButton Component = new FusionDropDownButton();
+
+        /// <summary>
+        /// Wires a FusionDropDownButton event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        public static FusionDropDownButtonBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionDropDownButtonBuilder<TModel> builder,
+            Func<FusionDropDownButtonEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionDropDownButtonEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownTree/Events/FusionDropDownTreeOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownTree/Events/FusionDropDownTreeOnChanged.cs
@@ -1,0 +1,25 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionDropDownTree"/> selection changes.
+    /// </summary>
+    /// <remarks>
+    /// Access properties in conditions: <c>p.When(args, x =&gt; x.Value).NotEmpty()</c>.
+    /// </remarks>
+    public class FusionDropDownTreeChangeArgs
+    {
+        /// <summary>Gets or sets the selected value IDs.</summary>
+        public string[]? Value { get; set; }
+
+        /// <summary>Gets or sets the previous selected value IDs.</summary>
+        public string[]? OldValue { get; set; }
+
+        /// <summary>Gets or sets whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionDropDownTreeChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTree.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTree.cs
@@ -1,0 +1,18 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionDropDownTree for selecting values from hierarchical data.
+    /// </summary>
+    /// <remarks>
+    /// The Syncfusion runtime value is an array of selected string IDs, even in
+    /// single-selection mode.
+    /// </remarks>
+    public sealed class FusionDropDownTree : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionDropDownTree(), "dropdowntree");
+
+        /// <inheritdoc />
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeEvents.cs
@@ -1,0 +1,21 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionDropDownTree"/> component.
+    /// </summary>
+    /// <remarks>
+    /// Select an event via the <c>.Reactive()</c> lambda:
+    /// <c>.Reactive(plan, evt =&gt; evt.Changed, (args, p) =&gt; { ... })</c>.
+    /// </remarks>
+    public sealed class FusionDropDownTreeEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionDropDownTreeEvents Instance = new FusionDropDownTreeEvents();
+        private FusionDropDownTreeEvents() { }
+
+        /// <summary>Fires when the selected value changes (SF "change" event).</summary>
+        public TypedEvent<FusionDropDownTreeChangeArgs> Changed =>
+            new TypedEvent<FusionDropDownTreeChangeArgs>(
+                "change", new FusionDropDownTreeChangeArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeExtensions.cs
@@ -1,0 +1,95 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed mutations and value reading for <see cref="FusionDropDownTree"/> in a reactive pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Obtain a <see cref="ComponentRef{TComponent, TModel}"/> via the pipeline:
+    /// <c>p.Component&lt;FusionDropDownTree&gt;(m =&gt; m.ResidentIds).SetValue(new[] { "alice" })</c>.
+    /// </remarks>
+    public static class FusionDropDownTreeExtensions
+    {
+        private static readonly FusionDropDownTree Component = new FusionDropDownTree();
+
+        private static readonly ComponentProperty<string[]> ValueProperty =
+            ComponentProperty<string[]>.Named(Component.ValueMember);
+
+        private static readonly ComponentProperty<string?> TextProperty =
+            ComponentProperty<string?>.Named("text");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod ShowPopupMethod =
+            ComponentMethod.Named("showPopup");
+
+        private static readonly ComponentMethod HidePopupMethod =
+            ComponentMethod.Named("hidePopup");
+
+        private static readonly ComponentMethod ClearMethod =
+            ComponentMethod.Named("clear");
+
+        /// <summary>Sets the selected value IDs.</summary>
+        /// <param name="value">The selected IDs, or <see langword="null"/> to clear.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionDropDownTree, TModel> SetValue<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self, string[]? value)
+            where TModel : class
+            => self.EmitSet(ValueProperty, value == null
+                ? ValueExpression.Null()
+                : ValueExpression.LiteralRaw(value, Shape.ArrayOf(Shape.String)));
+
+        /// <summary>Sets the display text and lets Syncfusion map it back to the selected value ID.</summary>
+        /// <param name="text">The display text to select, or <see langword="null"/> to clear.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionDropDownTree, TModel> SetText<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self, string? text)
+            where TModel : class
+            => self.EmitSet(TextProperty, ValueExpression.LiteralRaw(text, Shape.String));
+
+        /// <summary>Flushes pending property changes to the DropDownTree in the browser.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionDropDownTree, TModel> DataBind<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self)
+            where TModel : class
+            => self.EmitCall(DataBindMethod);
+
+        /// <summary>Opens the DropDownTree popup.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionDropDownTree, TModel> ShowPopup<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self)
+            where TModel : class
+            => self.EmitCall(ShowPopupMethod);
+
+        /// <summary>Closes the DropDownTree popup.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionDropDownTree, TModel> HidePopup<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self)
+            where TModel : class
+            => self.EmitCall(HidePopupMethod);
+
+        /// <summary>Clears the selected values and display text.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionDropDownTree, TModel> Clear<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClearMethod);
+
+        /// <summary>Reads the selected value IDs for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the selected value IDs.</returns>
+        public static TypedComponentSource<string[]> Value<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+
+        /// <summary>Reads the display text for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the display text.</returns>
+        public static TypedComponentSource<string?> Text<TModel>(
+            this ComponentRef<FusionDropDownTree, TModel> self)
+            where TModel : class
+            => self.Read(TextProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeHtmlExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.DropDowns;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionDropDownTree inside a field wrapper, bound to a model property.
+    /// </summary>
+    /// <remarks>
+    /// Syncfusion's MVC builder owns initial render configuration such as fields,
+    /// tree settings, popup dimensions, templates, and selection mode.
+    /// </remarks>
+    public static class FusionDropDownTreeHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionDropDownTree bound to the field's model property.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TProp">The bound property type.</typeparam>
+        /// <param name="setup">The field wrapper created by <c>Html.InputField()</c>.</param>
+        /// <param name="build">Callback to build the Syncfusion DropDownTree.</param>
+        public static void FusionDropDownTree<TModel, TProp>(
+            this InputBoundField<TModel, TProp> setup,
+            Action<DropDownTreeBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionDropDownTree.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().DropDownTreeFor(setup.Expression)
+                .HtmlAttributes(new Dictionary<string, object> { ["id"] = setup.ElementId, ["name"] = setup.BindingPath });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownTree/FusionDropDownTreeReactiveExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.DropDowns;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionDropDownTree"/> into the reactive plan.
+    /// </summary>
+    /// <remarks>
+    /// <c>.Reactive()</c> is always the last call inside the build callback passed to
+    /// <see cref="FusionDropDownTreeHtmlExtensions.FusionDropDownTree{TModel,TProp}"/>.
+    /// </remarks>
+    public static class FusionDropDownTreeReactiveExtensions
+    {
+        private static readonly FusionDropDownTree Component = new FusionDropDownTree();
+
+        /// <summary>
+        /// Wires a FusionDropDownTree event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TArgs">The event args type, inferred from the event selector.</typeparam>
+        /// <param name="builder">The Syncfusion DropDownTree builder.</param>
+        /// <param name="plan">The plan to add the reactive behavior to.</param>
+        /// <param name="eventSelector">Selects which event to react to.</param>
+        /// <param name="pipeline">Configures the commands to run when the event fires.</param>
+        /// <returns>The builder for method chaining.</returns>
+        public static DropDownTreeBuilder Reactive<TModel, TArgs>(
+            this DropDownTreeBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionDropDownTreeEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionDropDownTreeEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnDataStateChange.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnDataStateChange.cs
@@ -22,6 +22,15 @@ namespace Alis.Reactive.Fusion.Components
         /// <summary>Active sort columns. Empty when unsorted. Supports multi-sort.</summary>
         public List<FusionGridSortColumn>? Sorted { get; set; }
 
+        /// <summary>Active group fields. Empty when ungrouped. Supports nested grouping.</summary>
+        public List<string>? Group { get; set; }
+
+        /// <summary>Active text filter criteria from Grid filter UI.</summary>
+        public List<FusionGridTextFilterCriterion>? Where { get; set; }
+
+        /// <summary>Active search descriptors from Grid toolbar or public search method.</summary>
+        public List<FusionGridSearchDescriptor>? Search { get; set; }
+
         /// <summary>Action details: requestType, columnName, direction, currentPage.</summary>
         public FusionGridAction Action { get; set; } = new FusionGridAction();
 
@@ -44,6 +53,64 @@ namespace Alis.Reactive.Fusion.Components
     }
 
     /// <summary>
+    /// Text filter criterion emitted by Grid dataStateChange for filter-bar/menu text filters.
+    /// </summary>
+    public class FusionGridTextFilterCriterion
+    {
+        /// <summary>Field being filtered.</summary>
+        public string? Field { get; set; }
+
+        /// <summary>Filter operator such as "contains", "equal", or "startswith".</summary>
+        public string? Operator { get; set; }
+
+        /// <summary>Text value being filtered.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Composite predicate condition such as "and" or "or".</summary>
+        public string? Condition { get; set; }
+
+        /// <summary>Nested predicates when Syncfusion emits a composite Predicate.</summary>
+        public List<FusionGridTextFilterCriterion>? Predicates { get; set; }
+
+        /// <summary>Predicate joining this criterion to the next criterion.</summary>
+        public string? Predicate { get; set; }
+
+        /// <summary>Whether the filter ignores case.</summary>
+        public bool IgnoreCase { get; set; }
+
+        /// <summary>Whether the filter is case-sensitive.</summary>
+        public bool MatchCase { get; set; }
+
+        /// <summary>Whether the filter ignores accents.</summary>
+        public bool IgnoreAccent { get; set; }
+
+        public FusionGridTextFilterCriterion() { }
+    }
+
+    /// <summary>
+    /// Search descriptor emitted by Grid dataStateChange for toolbar/search method operations.
+    /// </summary>
+    public class FusionGridSearchDescriptor
+    {
+        /// <summary>Fields included in the search.</summary>
+        public List<string>? Fields { get; set; }
+
+        /// <summary>Search text.</summary>
+        public string? Key { get; set; }
+
+        /// <summary>Search operator such as "contains".</summary>
+        public string? Operator { get; set; }
+
+        /// <summary>Whether search is case-insensitive.</summary>
+        public bool IgnoreCase { get; set; }
+
+        /// <summary>Whether search ignores accents.</summary>
+        public bool IgnoreAccent { get; set; }
+
+        public FusionGridSearchDescriptor() { }
+    }
+
+    /// <summary>
     /// Action details from the dataStateChange event.
     /// Contains requestType plus context-specific parameters.
     /// </summary>
@@ -55,6 +122,7 @@ namespace Alis.Reactive.Fusion.Components
         public const string Filtering = "filtering";
         public const string Searching = "searching";
         public const string Grouping = "grouping";
+        public const string Ungrouping = "ungrouping";
         public const string Refresh = "refresh";
 
         /// <summary>Gets or sets the request type (e.g. "sorting", "paging").</summary>

--- a/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnEditing.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnEditing.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public class FusionGridBatchChanges<TRow>
+        where TRow : class
+    {
+        public List<TRow> AddedRecords { get; set; } = new List<TRow>();
+        public List<TRow> ChangedRecords { get; set; } = new List<TRow>();
+        public List<TRow> DeletedRecords { get; set; } = new List<TRow>();
+    }
+
+    public class FusionGridBeginEditArgs<TRow>
+        where TRow : class
+    {
+        public TRow RowData { get; set; } = default!;
+        public int RowIndex { get; set; }
+        public string? Type { get; set; }
+        public bool Cancel { get; set; }
+    }
+
+    public class FusionGridEditActionArgs<TRow>
+        where TRow : class
+    {
+        public string? RequestType { get; set; }
+        public string? Action { get; set; }
+        public string? Type { get; set; }
+        public bool Cancel { get; set; }
+        public TRow Data { get; set; } = default!;
+        public TRow PreviousData { get; set; } = default!;
+        public int SelectedRow { get; set; }
+        public int Index { get; set; }
+    }
+
+    public class FusionGridCellSaveArgs<TRow, TValue>
+        where TRow : class
+    {
+        public TRow RowData { get; set; } = default!;
+        public string? ColumnName { get; set; }
+        public TValue? Value { get; set; }
+        public TValue? PreviousValue { get; set; }
+        public bool Cancel { get; set; }
+    }
+
+    public class FusionGridBeforeBatchSaveArgs<TRow>
+        where TRow : class
+    {
+        public FusionGridBatchChanges<TRow> BatchChanges { get; set; } = new FusionGridBatchChanges<TRow>();
+        public bool Cancel { get; set; }
+    }
+
+    public static class FusionGridEditEventArgsExtensions
+    {
+        public static void Cancel<TRow>(
+            this FusionGridBeginEditArgs<TRow> args,
+            IReactionEmitter pipeline)
+            where TRow : class
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void Cancel<TRow>(
+            this FusionGridEditActionArgs<TRow> args,
+            IReactionEmitter pipeline)
+            where TRow : class
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void Cancel<TRow, TValue>(
+            this FusionGridCellSaveArgs<TRow, TValue> args,
+            IReactionEmitter pipeline)
+            where TRow : class
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+
+        public static void Cancel<TRow>(
+            this FusionGridBeforeBatchSaveArgs<TRow> args,
+            IReactionEmitter pipeline)
+            where TRow : class
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnRecordClick.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnRecordClick.cs
@@ -1,0 +1,24 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event args for the SF Grid "recordClick" event.
+    /// </summary>
+    /// <typeparam name="TRow">The row DTO type bound to the grid.</typeparam>
+    public class FusionGridRecordClickArgs<TRow>
+        where TRow : class
+    {
+        /// <summary>Current row data.</summary>
+        public TRow RowData { get; set; } = default!;
+
+        /// <summary>Zero-based row index.</summary>
+        public int RowIndex { get; set; }
+
+        /// <summary>Zero-based cell index.</summary>
+        public int CellIndex { get; set; }
+
+        /// <summary>Syncfusion event name.</summary>
+        public string? Name { get; set; }
+
+        public FusionGridRecordClickArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnRowSelected.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnRowSelected.cs
@@ -1,0 +1,24 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event args for the SF Grid "rowSelected" event.
+    /// </summary>
+    /// <typeparam name="TRow">The row DTO type bound to the grid.</typeparam>
+    public class FusionGridRowSelectedArgs<TRow>
+        where TRow : class
+    {
+        /// <summary>Selected row data.</summary>
+        public TRow Data { get; set; } = default!;
+
+        /// <summary>Selected row index.</summary>
+        public int RowIndex { get; set; }
+
+        /// <summary>Previously selected row index.</summary>
+        public int PreviousRowIndex { get; set; }
+
+        /// <summary>Whether selection came from user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        public FusionGridRowSelectedArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnToolbarClick.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/Events/FusionGridOnToolbarClick.cs
@@ -1,0 +1,33 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event args for the SF Grid "toolbarClick" event.
+    /// Fires when any toolbar item is clicked, including custom items.
+    /// Read <see cref="Item"/> to branch on which button was pressed.
+    /// </summary>
+    public class FusionGridToolbarClickArgs
+    {
+        /// <summary>The clicked toolbar item.</summary>
+        public FusionGridToolbarItem Item { get; set; } = new FusionGridToolbarItem();
+
+        /// <summary>Set true to cancel the default toolbar action.</summary>
+        public bool Cancel { get; set; }
+
+        public FusionGridToolbarClickArgs() { }
+    }
+
+    /// <summary>
+    /// The toolbar item carried by a Grid "toolbarClick" event.
+    /// Custom items expose the id and text declared on the builder Toolbar.
+    /// </summary>
+    public class FusionGridToolbarItem
+    {
+        /// <summary>The toolbar item id (e.g. a custom command id, or "{gridId}_excelexport").</summary>
+        public string? Id { get; set; }
+
+        /// <summary>The toolbar item display text.</summary>
+        public string? Text { get; set; }
+
+        public FusionGridToolbarItem() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridColumnExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridColumnExtensions.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static partial class FusionGridExtensions
+    {
+        private static readonly ComponentMethod ShowColumnsByFieldMethod =
+            ComponentMethod.Named("showColumns").WithArgs<string, string>();
+
+        private static readonly ComponentMethod HideColumnsByFieldMethod =
+            ComponentMethod.Named("hideColumns").WithArgs<string, string>();
+
+        private static readonly ComponentMethod ReorderColumnsByFieldMethod =
+            ComponentMethod.Named("reorderColumns").WithArgs<string, string>();
+
+        /// <summary>
+        /// Shows a runtime-hidden Grid column by typed row field.
+        /// Initial column definitions remain owned by the Syncfusion MVC builder.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ShowColumn<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TField>> field)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(ShowColumnsByFieldMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(fieldName),
+                ValueExpression.Literal("field")
+            });
+        }
+
+        /// <summary>
+        /// Hides a Grid column by typed row field.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> HideColumn<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TField>> field)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(HideColumnsByFieldMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(fieldName),
+                ValueExpression.Literal("field")
+            });
+        }
+
+        /// <summary>
+        /// Moves one column before another using typed row fields.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ReorderColumnBefore<TModel, TRow, TFromField, TToField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TFromField>> fromField,
+            Expression<Func<TRow, TToField>> beforeField)
+            where TModel : class
+            where TRow : class
+        {
+            var fromFieldName = ExpressionPathHelper.ToEventPath(fromField);
+            var beforeFieldName = ExpressionPathHelper.ToEventPath(beforeField);
+            return self.EmitCall(ReorderColumnsByFieldMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(fromFieldName),
+                ValueExpression.Literal(beforeFieldName)
+            });
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridDataSourceExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridDataSourceExtensions.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static partial class FusionGridExtensions
+    {
+        private static readonly ComponentProperty<object> DataSourceProperty =
+            ComponentProperty<object>.Named("dataSource");
+
+        private static readonly ComponentMethod RefreshMethod =
+            ComponentMethod.Named("refresh");
+
+        /// <summary>
+        /// Replaces the grid data source with items from an HTTP response body.
+        /// Typically used in custom binding to push server-filtered/sorted data.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SetDataSource<TModel, TResponse, TValue>(
+            this ComponentRef<FusionGrid, TModel> self,
+            ResponseBody<TResponse> source, Expression<Func<TResponse, TValue>> path)
+            where TModel : class
+            where TResponse : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            return self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, sourcePath));
+        }
+
+        /// <summary>
+        /// Replaces the grid data source with the entire HTTP response body.
+        /// Use for SF Grid custom binding where the response shape is
+        /// <c>{ result: [...], count: N }</c>.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SetDataSource<TModel, TResponse>(
+            this ComponentRef<FusionGrid, TModel> self,
+            ResponseBody<TResponse> source)
+            where TModel : class
+            where TResponse : class
+            => self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, "responseBody"));
+
+        /// <summary>
+        /// Replaces the grid data source with items from an event payload.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SetDataSource<TModel, TSource, TValue>(
+            this ComponentRef<FusionGrid, TModel> self,
+            TSource source, Expression<Func<TSource, TValue>> path)
+            where TModel : class
+        {
+            var sourcePath = ExpressionPathHelper.ToEventPath(path);
+            return self.EmitSet(DataSourceProperty, ValueExpression.Read(PayloadSource.Event(), sourcePath));
+        }
+
+        /// <summary>
+        /// Triggers a grid refresh through Syncfusion's public refresh method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> Refresh<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(RefreshMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEditTemplates.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEditTemplates.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Text.Encodings.Web;
+using Alis.Reactive.Builders.Conditions;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed cell editors for <see cref="FusionGrid"/> columns, rendered as Syncfusion
+    /// <c>EditTemplate</c> markup. The template owns its own option data, so it works under
+    /// custom (server) binding where the built-in <c>dropdownedit</c> cannot read distinct
+    /// values from the remote data source.
+    /// </summary>
+    /// <remarks>
+    /// Field names come from a typed row expression (no stringly field names):
+    /// <code>
+    /// new GridColumn
+    /// {
+    ///     Field = "careLevel",
+    ///     EditTemplate = FusionGridEditTemplates.Select((ResidentCareItem r) =&gt; r.CareLevel,
+    ///         new[] { "Independent", "Assisted Living", "Memory Care", "Skilled Nursing" })
+    /// }
+    /// </code>
+    /// </remarks>
+    public static class FusionGridEditTemplates
+    {
+        /// <summary>
+        /// A typed single-select cell editor bound to a row field, populated from a string list.
+        /// </summary>
+        public static string Select<TRow, TField>(
+            Expression<Func<TRow, TField>> field,
+            IEnumerable<string> options)
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return BuildSelect(fieldName, options.Select(o => (o, o)));
+        }
+
+        /// <summary>
+        /// A typed single-select cell editor over a typed option list with text/value selectors.
+        /// </summary>
+        public static string Select<TRow, TField, TItem>(
+            Expression<Func<TRow, TField>> field,
+            IEnumerable<TItem> items,
+            Func<TItem, string> text,
+            Func<TItem, string> value)
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return BuildSelect(fieldName, items.Select(i => (text(i), value(i))));
+        }
+
+        /// <summary>
+        /// A typed native date cell editor bound to a row field. Saves an ISO yyyy-MM-dd value.
+        /// </summary>
+        public static string DateInput<TRow, TField>(Expression<Func<TRow, TField>> field)
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            var name = HtmlEncoder.Default.Encode(fieldName);
+            // value="${field}" binds the editing row's current value through the SF
+            // template engine — the built-in editor leaves native date inputs unset.
+            return "<input type=\"date\" name=\"" + name + "\" value=\"${" + fieldName
+                + "}\" class=\"e-field e-input\" style=\"width:100%\" />";
+        }
+
+        /// <summary>
+        /// A typed dialog-edit form template for <c>GridEditSettings.Template</c> in
+        /// <see cref="Syncfusion.EJ2.Grids.EditMode"/> Dialog mode. Each field is declared
+        /// from a typed row expression, so there is no stringly field name and no raw HTML
+        /// in the view.
+        /// </summary>
+        /// <remarks>
+        /// <code>
+        /// EditSettings = new GridEditSettings
+        /// {
+        ///     Mode = EditMode.Dialog,
+        ///     Template = FusionGridEditTemplates.DialogForm&lt;ResidentRow&gt;(d => d
+        ///         .Text(r =&gt; r.ResidentName, "Resident")
+        ///         .Select(r =&gt; r.RiskLevel, "Risk", riskOptions)
+        ///         .Number(r =&gt; r.OpenTasks, "Open tasks"))
+        /// }
+        /// </code>
+        /// </remarks>
+        public static string DialogForm<TRow>(Action<FusionGridDialogFormBuilder<TRow>> build)
+            where TRow : class
+        {
+            if (build == null) throw new ArgumentNullException(nameof(build));
+            var builder = new FusionGridDialogFormBuilder<TRow>();
+            build(builder);
+            return builder.Render();
+        }
+
+        private static string BuildSelect(string fieldName, IEnumerable<(string Text, string Value)> options)
+        {
+            var encoder = HtmlEncoder.Default;
+            var sb = new StringBuilder();
+            sb.Append("<select name=\"")
+              .Append(encoder.Encode(fieldName))
+              .Append("\" class=\"e-field e-input\" style=\"width:100%\">");
+
+            foreach (var (text, value) in options)
+            {
+                sb.Append("<option value=\"")
+                  .Append(encoder.Encode(value))
+                  .Append("\">")
+                  .Append(encoder.Encode(text))
+                  .Append("</option>");
+            }
+
+            sb.Append("</select>");
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Builds a typed dialog-edit form for a <see cref="FusionGrid"/> row. Each labeled
+    /// field is declared from a typed row expression; the editing row's current value
+    /// binds through the SF <c>${field}</c> template token.
+    /// </summary>
+    public sealed class FusionGridDialogFormBuilder<TRow>
+        where TRow : class
+    {
+        private readonly List<string> _fields = new List<string>();
+
+        internal FusionGridDialogFormBuilder() { }
+
+        /// <summary>Adds a labeled text field bound to a typed row field.</summary>
+        public FusionGridDialogFormBuilder<TRow> Text<TField>(Expression<Func<TRow, TField>> field, string label) =>
+            AddField(field, label, name => "<input name=\"" + name + "\" value=\"${" + name + "}\" class=\"e-field e-input\" />");
+
+        /// <summary>Adds a labeled numeric field bound to a typed row field.</summary>
+        public FusionGridDialogFormBuilder<TRow> Number<TField>(Expression<Func<TRow, TField>> field, string label) =>
+            AddField(field, label, name => "<input type=\"number\" name=\"" + name + "\" value=\"${" + name + "}\" class=\"e-field e-input\" />");
+
+        /// <summary>Adds a labeled date field bound to a typed row field.</summary>
+        public FusionGridDialogFormBuilder<TRow> Date<TField>(Expression<Func<TRow, TField>> field, string label) =>
+            AddField(field, label, name => "<input type=\"date\" name=\"" + name + "\" value=\"${" + name + "}\" class=\"e-field e-input\" />");
+
+        /// <summary>Adds a labeled single-select field bound to a typed row field.</summary>
+        public FusionGridDialogFormBuilder<TRow> Select<TField>(
+            Expression<Func<TRow, TField>> field, string label, IEnumerable<string> options) =>
+            AddField(field, label, name => BuildSelect(name, options));
+
+        private FusionGridDialogFormBuilder<TRow> AddField<TField>(
+            Expression<Func<TRow, TField>> field, string label, Func<string, string> editor)
+        {
+            var name = HtmlEncoder.Default.Encode(ExpressionPathHelper.ToEventPath(field));
+            _fields.Add(
+                "<label class=\"grid gap-1\"><span class=\"font-medium text-text\">"
+                + HtmlEncoder.Default.Encode(label) + "</span>" + editor(name) + "</label>");
+            return this;
+        }
+
+        private static string BuildSelect(string name, IEnumerable<string> options)
+        {
+            var encoder = HtmlEncoder.Default;
+            var sb = new StringBuilder();
+            sb.Append("<select name=\"").Append(name).Append("\" class=\"e-field e-input\">");
+            foreach (var option in options)
+            {
+                if (string.IsNullOrEmpty(option)) continue;
+                var encoded = encoder.Encode(option);
+                sb.Append("<option value=\"").Append(encoded).Append("\">").Append(encoded).Append("</option>");
+            }
+            sb.Append("</select>");
+            return sb.ToString();
+        }
+
+        internal string Render()
+        {
+            var sb = new StringBuilder();
+            sb.Append("<div class=\"grid grid-cols-1 gap-3 p-2 text-sm\">");
+            foreach (var field in _fields) sb.Append(field);
+            sb.Append("</div>");
+            return sb.ToString();
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEditingExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEditingExtensions.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static partial class FusionGridExtensions
+    {
+        private static readonly ComponentMethod StartEditMethod =
+            ComponentMethod.Named("startEdit");
+
+        private static readonly ComponentMethod EndEditMethod =
+            ComponentMethod.Named("endEdit");
+
+        private static readonly ComponentMethod CloseEditMethod =
+            ComponentMethod.Named("closeEdit");
+
+        private static readonly ComponentMethod AddRecordMethod =
+            ComponentMethod.Named("addRecord").WithArgs<object>();
+
+        private static readonly ComponentMethod AddRecordAtMethod =
+            ComponentMethod.Named("addRecord").WithArgs<object, int>();
+
+        private static readonly ComponentMethod DeleteRecordMethod =
+            ComponentMethod.Named("deleteRecord");
+
+        private static readonly ComponentMethod UpdateRowMethod =
+            ComponentMethod.Named("updateRow").WithArgs<int, object>();
+
+        private static readonly ComponentMethod EditCellMethod =
+            ComponentMethod.Named("editCell").WithArgs<int, string>();
+
+        private static readonly ComponentMethod SaveCellMethod =
+            ComponentMethod.Named("saveCell");
+
+        private static readonly ComponentMethod UpdateStringCellMethod =
+            ComponentMethod.Named("updateCell").WithArgs<int, string, string>();
+
+        private static readonly ComponentMethod UpdateIntCellMethod =
+            ComponentMethod.Named("updateCell").WithArgs<int, string, int>();
+
+        private static readonly ComponentMethod GetBatchChangesMethod =
+            ComponentMethod.Named("getBatchChanges");
+
+        /// <summary>
+        /// Starts editing the selected row through Syncfusion's public startEdit method.
+        /// The builder-owned editSettings determine whether this is inline or dialog editing.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> StartEdit<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(StartEditMethod);
+
+        /// <summary>
+        /// Saves the current edit. In batch mode this commits pending batch changes.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> EndEdit<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(EndEditMethod);
+
+        /// <summary>
+        /// Cancels the current edit state through Syncfusion's public closeEdit method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> CloseEdit<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(CloseEditMethod);
+
+        /// <summary>
+        /// Adds a typed row through Syncfusion's public addRecord method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> AddRecord<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            TRow row,
+            int? index = null)
+            where TModel : class
+            where TRow : class
+        {
+            var rowValue = ValueExpression.LiteralRaw(row, Shape.FromClrType(typeof(TRow)));
+            return index.HasValue
+                ? self.EmitCall(AddRecordAtMethod, new List<ValueExpression> { rowValue, ValueExpression.Literal(index.Value) })
+                : self.EmitCall(AddRecordMethod, new List<ValueExpression> { rowValue });
+        }
+
+        /// <summary>
+        /// Adds a typed row from an HTTP response through Syncfusion's public addRecord method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> AddRecord<TModel, TResponse, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            ResponseBody<TResponse> source,
+            Expression<Func<TResponse, TRow>> path,
+            int? index = null)
+            where TModel : class
+            where TResponse : class
+            where TRow : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            var rowValue = ValueExpression.Read(source.Scope, sourcePath, Shape.FromClrType(typeof(TRow)));
+            return index.HasValue
+                ? self.EmitCall(AddRecordAtMethod, new List<ValueExpression> { rowValue, ValueExpression.Literal(index.Value) })
+                : self.EmitCall(AddRecordMethod, new List<ValueExpression> { rowValue });
+        }
+
+        /// <summary>
+        /// Deletes the currently selected record through Syncfusion's public deleteRecord method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> DeleteSelectedRecord<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(DeleteRecordMethod);
+
+        /// <summary>
+        /// Updates one rendered row with a typed row through Syncfusion's public updateRow method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> UpdateRow<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int rowIndex,
+            TRow row)
+            where TModel : class
+            where TRow : class
+        {
+            var rowValue = ValueExpression.LiteralRaw(row, Shape.FromClrType(typeof(TRow)));
+            return self.EmitCall(UpdateRowMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(rowIndex),
+                rowValue
+            });
+        }
+
+        /// <summary>
+        /// Updates one rendered row from an HTTP response through Syncfusion's public updateRow method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> UpdateRow<TModel, TResponse, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int rowIndex,
+            ResponseBody<TResponse> source,
+            Expression<Func<TResponse, TRow>> path)
+            where TModel : class
+            where TResponse : class
+            where TRow : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            var rowValue = ValueExpression.Read(source.Scope, sourcePath, Shape.FromClrType(typeof(TRow)));
+            return self.EmitCall(UpdateRowMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(rowIndex),
+                rowValue
+            });
+        }
+
+        /// <summary>
+        /// Enters batch cell edit mode for a typed row field.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> EditCell<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int rowIndex,
+            Expression<Func<TRow, TField>> field)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(EditCellMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(rowIndex),
+                ValueExpression.Literal(fieldName)
+            });
+        }
+
+        /// <summary>
+        /// Saves the currently edited batch cell through Syncfusion's public saveCell method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SaveCell<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(SaveCellMethod);
+
+        public static ComponentRef<FusionGrid, TModel> UpdateCell<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int rowIndex,
+            Expression<Func<TRow, string>> field,
+            string value)
+            where TModel : class
+            where TRow : class
+            => self.UpdateCell(rowIndex, field, ValueExpression.Literal(value), UpdateStringCellMethod);
+
+        public static ComponentRef<FusionGrid, TModel> UpdateCell<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int rowIndex,
+            Expression<Func<TRow, int>> field,
+            int value)
+            where TModel : class
+            where TRow : class
+            => self.UpdateCell(rowIndex, field, ValueExpression.Literal(value), UpdateIntCellMethod);
+
+        /// <summary>
+        /// Reads typed batch edit changes through Syncfusion's public getBatchChanges method.
+        /// </summary>
+        public static TypedComponentSource<FusionGridBatchChanges<TRow>> BatchChanges<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            where TRow : class
+            => self.Read<FusionGridBatchChanges<TRow>>(GetBatchChangesMethod);
+
+        private static ComponentRef<FusionGrid, TModel> UpdateCell<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int rowIndex,
+            Expression<Func<TRow, TField>> field,
+            ValueExpression value,
+            ComponentMethod method)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(method, new List<ValueExpression>
+            {
+                ValueExpression.Literal(rowIndex),
+                ValueExpression.Literal(fieldName),
+                value
+            });
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEvents.cs
@@ -20,5 +20,71 @@ namespace Alis.Reactive.Fusion.Components
         public TypedEvent<FusionGridDataStateChangeArgs> DataStateChange =>
             new TypedEvent<FusionGridDataStateChangeArgs>(
                 "dataStateChange", new FusionGridDataStateChangeArgs());
+
+        /// <summary>
+        /// Fires when a data row is clicked.
+        /// </summary>
+        /// <typeparam name="TRow">The row DTO type bound to the grid.</typeparam>
+        public TypedEvent<FusionGridRecordClickArgs<TRow>> RecordClick<TRow>()
+            where TRow : class
+            => new TypedEvent<FusionGridRecordClickArgs<TRow>>(
+                "recordClick", new FusionGridRecordClickArgs<TRow>());
+
+        /// <summary>
+        /// Fires when a data row is selected.
+        /// </summary>
+        /// <typeparam name="TRow">The row DTO type bound to the grid.</typeparam>
+        public TypedEvent<FusionGridRowSelectedArgs<TRow>> RowSelected<TRow>()
+            where TRow : class
+            => new TypedEvent<FusionGridRowSelectedArgs<TRow>>(
+                "rowSelected", new FusionGridRowSelectedArgs<TRow>());
+
+        /// <summary>
+        /// Fires before grid actions such as edit, save, delete, sort, page, filter, and group.
+        /// </summary>
+        public TypedEvent<FusionGridEditActionArgs<TRow>> ActionBegin<TRow>()
+            where TRow : class
+            => new TypedEvent<FusionGridEditActionArgs<TRow>>(
+                "actionBegin", new FusionGridEditActionArgs<TRow>());
+
+        /// <summary>
+        /// Fires after grid actions such as edit, save, delete, sort, page, filter, and group.
+        /// </summary>
+        public TypedEvent<FusionGridEditActionArgs<TRow>> ActionComplete<TRow>()
+            where TRow : class
+            => new TypedEvent<FusionGridEditActionArgs<TRow>>(
+                "actionComplete", new FusionGridEditActionArgs<TRow>());
+
+        /// <summary>
+        /// Fires before a row enters edit mode.
+        /// </summary>
+        public TypedEvent<FusionGridBeginEditArgs<TRow>> BeginEdit<TRow>()
+            where TRow : class
+            => new TypedEvent<FusionGridBeginEditArgs<TRow>>(
+                "beginEdit", new FusionGridBeginEditArgs<TRow>());
+
+        /// <summary>
+        /// Fires when a batch-edit cell is being saved.
+        /// </summary>
+        public TypedEvent<FusionGridCellSaveArgs<TRow, TValue>> CellSave<TRow, TValue>()
+            where TRow : class
+            => new TypedEvent<FusionGridCellSaveArgs<TRow, TValue>>(
+                "cellSave", new FusionGridCellSaveArgs<TRow, TValue>());
+
+        /// <summary>
+        /// Fires after a batch-edit cell is saved.
+        /// </summary>
+        public TypedEvent<FusionGridCellSaveArgs<TRow, TValue>> CellSaved<TRow, TValue>()
+            where TRow : class
+            => new TypedEvent<FusionGridCellSaveArgs<TRow, TValue>>(
+                "cellSaved", new FusionGridCellSaveArgs<TRow, TValue>());
+
+        /// <summary>
+        /// Fires before pending batch changes are committed.
+        /// </summary>
+        public TypedEvent<FusionGridBeforeBatchSaveArgs<TRow>> BeforeBatchSave<TRow>()
+            where TRow : class
+            => new TypedEvent<FusionGridBeforeBatchSaveArgs<TRow>>(
+                "beforeBatchSave", new FusionGridBeforeBatchSaveArgs<TRow>());
     }
 }

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridEvents.cs
@@ -22,6 +22,14 @@ namespace Alis.Reactive.Fusion.Components
                 "dataStateChange", new FusionGridDataStateChangeArgs());
 
         /// <summary>
+        /// Fires when any toolbar item is clicked, including custom toolbar buttons.
+        /// SF "toolbarClick" event. Branch on <c>args.Item.Id</c> to handle a specific button.
+        /// </summary>
+        public TypedEvent<FusionGridToolbarClickArgs> ToolbarClick =>
+            new TypedEvent<FusionGridToolbarClickArgs>(
+                "toolbarClick", new FusionGridToolbarClickArgs());
+
+        /// <summary>
         /// Fires when a data row is clicked.
         /// </summary>
         /// <typeparam name="TRow">The row DTO type bound to the grid.</typeparam>

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridExtensions.cs
@@ -1,92 +1,13 @@
-using System;
-using System.Linq.Expressions;
-using Alis.Reactive.PlanModel;
-
 namespace Alis.Reactive.Fusion.Components
 {
     /// <summary>
-    /// Typed mutations for <see cref="FusionGrid"/> in a reactive pipeline.
+    /// Typed runtime extensions for <see cref="FusionGrid"/> in reactive pipelines.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Obtain a <see cref="ComponentRef{TComponent, TModel}"/> via the pipeline:
-    /// <c>p.Component&lt;FusionGrid&gt;("residents-grid").SetDataSource(json, j =&gt; j.Result)</c>.
-    /// </para>
-    /// <para>
-    /// Non-input component: no <c>Value()</c> read or <c>SetValue()</c>.
-    /// </para>
+    /// Keep Syncfusion MVC builder configuration on the builder. These partial
+    /// files expose only proven post-render Grid object behavior.
     /// </remarks>
-    public static class FusionGridExtensions
+    public static partial class FusionGridExtensions
     {
-        private static readonly ComponentProperty<object> DataSourceProperty =
-            ComponentProperty<object>.Named("dataSource");
-
-        private static readonly ComponentMethod RefreshMethod =
-            ComponentMethod.Named("refresh");
-
-        /// <summary>
-        /// Replaces the grid data source with items from an HTTP response body.
-        /// Typically used in custom binding to push server-filtered/sorted data.
-        /// </summary>
-        /// <typeparam name="TModel">The view model type.</typeparam>
-        /// <typeparam name="TResponse">The response body type containing the items.</typeparam>
-        /// <param name="self">The grid component reference.</param>
-        /// <param name="source">The response body instance.</param>
-        /// <param name="path">Expression selecting the items collection from the response.</param>
-        /// <returns>The component reference for method chaining.</returns>
-        public static ComponentRef<FusionGrid, TModel> SetDataSource<TModel, TResponse>(
-            this ComponentRef<FusionGrid, TModel> self,
-            ResponseBody<TResponse> source, Expression<Func<TResponse, object?>> path)
-            where TModel : class
-            where TResponse : class
-        {
-            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
-            return self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, sourcePath));
-        }
-
-        /// <summary>
-        /// Replaces the grid data source with the entire HTTP response body.
-        /// Use for SF Grid custom binding where the response shape is
-        /// <c>{ result: [...], count: N }</c>.
-        /// </summary>
-        /// <typeparam name="TModel">The view model type.</typeparam>
-        /// <typeparam name="TResponse">The response body type.</typeparam>
-        /// <param name="self">The grid component reference.</param>
-        /// <param name="source">The response body instance.</param>
-        /// <returns>The component reference for method chaining.</returns>
-        public static ComponentRef<FusionGrid, TModel> SetDataSource<TModel, TResponse>(
-            this ComponentRef<FusionGrid, TModel> self,
-            ResponseBody<TResponse> source)
-            where TModel : class
-            where TResponse : class
-            => self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, "responseBody"));
-
-        /// <summary>
-        /// Replaces the grid data source with items from an event payload.
-        /// </summary>
-        /// <typeparam name="TModel">The view model type.</typeparam>
-        /// <typeparam name="TSource">The event payload type containing the items.</typeparam>
-        /// <param name="self">The grid component reference.</param>
-        /// <param name="source">The event payload instance.</param>
-        /// <param name="path">Expression selecting the items collection from the payload.</param>
-        /// <returns>The component reference for method chaining.</returns>
-        public static ComponentRef<FusionGrid, TModel> SetDataSource<TModel, TSource>(
-            this ComponentRef<FusionGrid, TModel> self,
-            TSource source, Expression<Func<TSource, object?>> path)
-            where TModel : class
-        {
-            var sourcePath = ExpressionPathHelper.ToEventPath(path);
-            return self.EmitSet(DataSourceProperty, ValueExpression.Read(PayloadSource.Event(), sourcePath));
-        }
-
-        /// <summary>
-        /// Triggers a grid refresh. Call after <see cref="SetDataSource{TModel, TResponse}"/>
-        /// to re-render with the new data.
-        /// </summary>
-        /// <returns>The component reference for method chaining.</returns>
-        public static ComponentRef<FusionGrid, TModel> Refresh<TModel>(
-            this ComponentRef<FusionGrid, TModel> self)
-            where TModel : class
-            => self.EmitCall(RefreshMethod);
     }
 }

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridHtmlExtensions.cs
@@ -21,16 +21,17 @@ namespace Alis.Reactive.Fusion.Components
         /// <param name="elementId">The DOM element ID for the grid.</param>
         /// <param name="build">Callback to configure columns, paging, sorting, etc.</param>
         /// <returns>A builder for chaining <c>.Reactive()</c>.</returns>
-        public static FusionGridBuilder<TModel> FusionGrid<TModel>(
+        public static FusionGridBuilder<TModel> FusionGrid<TModel, TRow>(
             this IHtmlHelper<TModel> html,
             ReactivePlan<TModel> plan,
             string elementId,
-            Action<GridBuilder<object>> build)
+            Action<GridBuilder<TRow>> build)
             where TModel : class
+            where TRow : class
         {
             // NO input component registration — this is NOT an input component
 
-            var builder = html.EJS().Grid<object>(elementId);
+            var builder = html.EJS().Grid<TRow>(elementId);
             build(builder);
 
             return new FusionGridBuilder<TModel>(plan, elementId, builder.Render());

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridQueryExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridQueryExtensions.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static partial class FusionGridExtensions
+    {
+        private static readonly ComponentMethod GoToPageMethod =
+            ComponentMethod.Named("goToPage").WithArgs<int>();
+
+        private static readonly ComponentMethod SortColumnMethod =
+            ComponentMethod.Named("sortColumn").WithArgs<string, string, bool>();
+
+        private static readonly ComponentMethod ClearSortingMethod =
+            ComponentMethod.Named("clearSorting");
+
+        private static readonly ComponentMethod SearchMethod =
+            ComponentMethod.Named("search").WithArgs<string>();
+
+        private static readonly ComponentMethod FilterByColumnTextMethod =
+            ComponentMethod.Named("filterByColumn").WithArgs<string, string, string>();
+
+        private static readonly ComponentMethod ClearFilteringMethod =
+            ComponentMethod.Named("clearFiltering");
+
+        private static readonly ComponentMethod GroupColumnMethod =
+            ComponentMethod.Named("groupColumn").WithArgs<string>();
+
+        private static readonly ComponentMethod UngroupColumnMethod =
+            ComponentMethod.Named("ungroupColumn").WithArgs<string>();
+
+        private static readonly ComponentMethod ClearGroupingMethod =
+            ComponentMethod.Named("clearGrouping");
+
+        /// <summary>
+        /// Navigates the grid to a page through Syncfusion's public goToPage method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> GoToPage<TModel>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int pageNumber)
+            where TModel : class
+            => self.EmitCall(GoToPageMethod, new List<ValueExpression> { ValueExpression.Literal(pageNumber) });
+
+        /// <summary>
+        /// Sorts a typed row field through Syncfusion's public sortColumn method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SortBy<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TField>> field,
+            FusionGridSortDirection direction,
+            bool keepExistingSorts = false)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(SortColumnMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(fieldName),
+                ValueExpression.Literal(ToSyncfusion(direction)),
+                ValueExpression.Literal(keepExistingSorts)
+            });
+        }
+
+        /// <summary>
+        /// Clears all grid sorting through Syncfusion's public clearSorting method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ClearSorting<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClearSortingMethod);
+
+        /// <summary>
+        /// Searches grid records through Syncfusion's public search method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> Search<TModel>(
+            this ComponentRef<FusionGrid, TModel> self,
+            string searchText)
+            where TModel : class
+            => self.EmitCall(SearchMethod, new List<ValueExpression> { ValueExpression.Literal(searchText) });
+
+        /// <summary>
+        /// Clears grid search by invoking Syncfusion's public search method with an empty term.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ClearSearch<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.Search(string.Empty);
+
+        /// <summary>
+        /// Applies a text filter to a typed row field through Syncfusion's public filterByColumn method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> FilterTextBy<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TField>> field,
+            FusionGridTextFilterOperator filterOperator,
+            string value)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(FilterByColumnTextMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(fieldName),
+                ValueExpression.Literal(ToSyncfusion(filterOperator)),
+                ValueExpression.Literal(value)
+            });
+        }
+
+        /// <summary>
+        /// Clears all grid filtering through Syncfusion's public clearFiltering method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ClearFiltering<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClearFilteringMethod);
+
+        /// <summary>
+        /// Groups a typed row field through Syncfusion's public groupColumn method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> GroupBy<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TField>> field)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(GroupColumnMethod, new List<ValueExpression> { ValueExpression.Literal(fieldName) });
+        }
+
+        /// <summary>
+        /// Ungroups a typed row field through Syncfusion's public ungroupColumn method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> UngroupBy<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TField>> field)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(UngroupColumnMethod, new List<ValueExpression> { ValueExpression.Literal(fieldName) });
+        }
+
+        /// <summary>
+        /// Clears all grouping through Syncfusion's public clearGrouping method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ClearGrouping<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClearGroupingMethod);
+
+        private static string ToSyncfusion(FusionGridSortDirection direction) =>
+            direction == FusionGridSortDirection.Descending ? "Descending" : "Ascending";
+
+        private static string ToSyncfusion(FusionGridTextFilterOperator filterOperator) =>
+            filterOperator switch
+            {
+                FusionGridTextFilterOperator.Equal => "equal",
+                FusionGridTextFilterOperator.NotEqual => "notequal",
+                FusionGridTextFilterOperator.StartsWith => "startswith",
+                FusionGridTextFilterOperator.EndsWith => "endswith",
+                _ => "contains"
+            };
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridReactiveExtensions.cs
@@ -9,9 +9,9 @@ namespace Alis.Reactive.Fusion.Components
     /// </summary>
     /// <remarks>
     /// <c>.Reactive()</c> is called on the builder returned by
-    /// <see cref="FusionGridHtmlExtensions.FusionGrid{TModel}"/>:
+    /// <see cref="FusionGridHtmlExtensions.FusionGrid{TModel, TRow}"/>:
     /// <code>
-    /// @(Html.FusionGrid(plan, "residents-grid", b =&gt; { /* columns */ })
+    /// @(Html.FusionGrid&lt;GridModel, ResidentGridItem&gt;(plan, "residents-grid", b =&gt; { /* columns */ })
     ///     .Reactive(evt =&gt; evt.DataStateChange, (args, p) =&gt; { /* commands */ }))
     /// </code>
     /// </remarks>

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridRowDataExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridRowDataExtensions.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static partial class FusionGridExtensions
+    {
+        private static readonly ComponentMethod GetCurrentViewRecordsMethod =
+            ComponentMethod.Named("getCurrentViewRecords");
+
+        private static readonly ComponentMethod GetRowIndexByIntPrimaryKeyMethod =
+            ComponentMethod.Named("getRowIndexByPrimaryKey").WithArgs<int>();
+
+        private static readonly ComponentMethod SetIntCellValueMethod =
+            ComponentMethod.Mapped("setIntCellValue", "setCellValue").WithArgs<int, string, int>();
+
+        private static readonly ComponentMethod SetStringCellValueMethod =
+            ComponentMethod.Mapped("setStringCellValue", "setCellValue").WithArgs<int, string, string>();
+
+        private static readonly ComponentMethod SetRowDataByIntKeyMethod =
+            ComponentMethod.Named("setRowData").WithArgs<int, object>();
+
+        /// <summary>
+        /// Reads the Grid's current rendered view records through Syncfusion's public getCurrentViewRecords method.
+        /// </summary>
+        public static TypedComponentSource<TRow[]> CurrentViewRecords<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            where TRow : class
+            => self.Read<TRow[]>(GetCurrentViewRecordsMethod);
+
+        /// <summary>
+        /// Reads the visible row index for a numeric primary key through Syncfusion's public getRowIndexByPrimaryKey method.
+        /// </summary>
+        public static TypedComponentSource<int> RowIndexByPrimaryKey<TModel>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int primaryKey)
+            where TModel : class
+            => self.Read<int>(
+                GetRowIndexByIntPrimaryKeyMethod,
+                new List<ValueExpression> { ValueExpression.Literal(primaryKey) });
+
+        /// <summary>
+        /// Updates one visible cell by numeric primary key and typed string row field.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SetCellValue<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int primaryKey,
+            Expression<Func<TRow, string>> field,
+            string value)
+            where TModel : class
+            where TRow : class
+            => self.SetCellValue(primaryKey, field, ValueExpression.Literal(value), SetStringCellValueMethod);
+
+        /// <summary>
+        /// Updates one visible cell by numeric primary key and typed integer row field.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SetCellValue<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int primaryKey,
+            Expression<Func<TRow, int>> field,
+            int value)
+            where TModel : class
+            where TRow : class
+            => self.SetCellValue(primaryKey, field, ValueExpression.Literal(value), SetIntCellValueMethod);
+
+        /// <summary>
+        /// Updates one visible row by numeric primary key with a typed row payload.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SetRowData<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int primaryKey,
+            TRow row)
+            where TModel : class
+            where TRow : class
+        {
+            var rowValue = ValueExpression.LiteralRaw(row, Shape.FromClrType(typeof(TRow)));
+            return self.EmitCall(SetRowDataByIntKeyMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(primaryKey),
+                rowValue
+            });
+        }
+
+        /// <summary>
+        /// Updates one visible row by numeric primary key with a typed row from an HTTP response.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SetRowData<TModel, TResponse, TRow>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int primaryKey,
+            ResponseBody<TResponse> source,
+            Expression<Func<TResponse, TRow>> path)
+            where TModel : class
+            where TResponse : class
+            where TRow : class
+        {
+            var sourcePath = ExpressionPathHelper.ToResponsePath(path);
+            var rowValue = ValueExpression.Read(source.Scope, sourcePath, Shape.FromClrType(typeof(TRow)));
+            return self.EmitCall(SetRowDataByIntKeyMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(primaryKey),
+                rowValue
+            });
+        }
+
+        private static ComponentRef<FusionGrid, TModel> SetCellValue<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int primaryKey,
+            Expression<Func<TRow, TField>> field,
+            ValueExpression value,
+            ComponentMethod method)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(method, new List<ValueExpression>
+            {
+                ValueExpression.Literal(primaryKey),
+                ValueExpression.Literal(fieldName),
+                value
+            });
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridSelectionExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridSelectionExtensions.cs
@@ -9,6 +9,9 @@ namespace Alis.Reactive.Fusion.Components
         private static readonly ComponentMethod SelectRowMethod =
             ComponentMethod.Named("selectRow").WithArgs<int>();
 
+        private static readonly ComponentMethod SelectRowsByRangeMethod =
+            ComponentMethod.Named("selectRowsByRange").WithArgs<int, int>();
+
         private static readonly ComponentMethod ClearSelectionMethod =
             ComponentMethod.Named("clearSelection");
 
@@ -26,6 +29,20 @@ namespace Alis.Reactive.Fusion.Components
             int rowIndex)
             where TModel : class
             => self.EmitCall(SelectRowMethod, new List<ValueExpression> { ValueExpression.Literal(rowIndex) });
+
+        /// <summary>
+        /// Selects a contiguous range of rendered rows by zero-based row indexes.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SelectRowsByRange<TModel>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int startIndex,
+            int endIndex)
+            where TModel : class
+            => self.EmitCall(SelectRowsByRangeMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(startIndex),
+                ValueExpression.Literal(endIndex)
+            });
 
         /// <summary>
         /// Clears grid selection through Syncfusion's public clearSelection method.

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridSelectionExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridSelectionExtensions.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static partial class FusionGridExtensions
+    {
+        private static readonly ComponentMethod SelectRowMethod =
+            ComponentMethod.Named("selectRow").WithArgs<int>();
+
+        private static readonly ComponentMethod ClearSelectionMethod =
+            ComponentMethod.Named("clearSelection");
+
+        private static readonly ComponentMethod GetSelectedRowIndexesMethod =
+            ComponentMethod.Named("getSelectedRowIndexes");
+
+        private static readonly ComponentMethod GetSelectedRecordsMethod =
+            ComponentMethod.Named("getSelectedRecords");
+
+        /// <summary>
+        /// Selects one rendered row by zero-based row index.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> SelectRow<TModel>(
+            this ComponentRef<FusionGrid, TModel> self,
+            int rowIndex)
+            where TModel : class
+            => self.EmitCall(SelectRowMethod, new List<ValueExpression> { ValueExpression.Literal(rowIndex) });
+
+        /// <summary>
+        /// Clears grid selection through Syncfusion's public clearSelection method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ClearSelection<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClearSelectionMethod);
+
+        /// <summary>
+        /// Reads selected row indexes through Syncfusion's public getSelectedRowIndexes method.
+        /// </summary>
+        public static TypedComponentSource<int[]> SelectedRowIndexes<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.Read<int[]>(GetSelectedRowIndexesMethod);
+
+        /// <summary>
+        /// Reads selected row records through Syncfusion's public getSelectedRecords method.
+        /// </summary>
+        public static TypedComponentSource<TRow[]> SelectedRecords<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            where TRow : class
+            => self.Read<TRow[]>(GetSelectedRecordsMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridSortDirection.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridSortDirection.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Sort direction values accepted by Syncfusion EJ2 Grid sortColumn.
+    /// </summary>
+    public enum FusionGridSortDirection
+    {
+        /// <summary>Ascending sort order.</summary>
+        Ascending,
+
+        /// <summary>Descending sort order.</summary>
+        Descending
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridTextFilterOperator.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridTextFilterOperator.cs
@@ -1,0 +1,23 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Text filter operators accepted by Syncfusion EJ2 Grid filterByColumn.
+    /// </summary>
+    public enum FusionGridTextFilterOperator
+    {
+        /// <summary>Value contains the text.</summary>
+        Contains,
+
+        /// <summary>Value equals the text.</summary>
+        Equal,
+
+        /// <summary>Value does not equal the text.</summary>
+        NotEqual,
+
+        /// <summary>Value starts with the text.</summary>
+        StartsWith,
+
+        /// <summary>Value ends with the text.</summary>
+        EndsWith
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridToolingExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridToolingExtensions.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    public static partial class FusionGridExtensions
+    {
+        private static readonly ComponentMethod ExcelExportMethod =
+            ComponentMethod.Named("excelExport");
+
+        private static readonly ComponentMethod CsvExportMethod =
+            ComponentMethod.Named("csvExport");
+
+        private static readonly ComponentMethod PdfExportMethod =
+            ComponentMethod.Named("pdfExport");
+
+        private static readonly ComponentMethod PrintMethod =
+            ComponentMethod.Named("print");
+
+        private static readonly ComponentMethod OpenColumnChooserMethod =
+            ComponentMethod.Named("openColumnChooser");
+
+        private static readonly ComponentMethod AutoFitAllColumnsMethod =
+            ComponentMethod.Named("autoFitColumns");
+
+        private static readonly ComponentMethod AutoFitColumnMethod =
+            ComponentMethod.Named("autoFitColumns").WithArgs<string>();
+
+        /// <summary>
+        /// Exports the grid to Excel through Syncfusion's public excelExport method.
+        /// Requires <c>AllowExcelExport(true)</c> on the builder.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ExcelExport<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(ExcelExportMethod);
+
+        /// <summary>
+        /// Exports the grid to CSV through Syncfusion's public csvExport method.
+        /// Requires <c>AllowExcelExport(true)</c> on the builder.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> CsvExport<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(CsvExportMethod);
+
+        /// <summary>
+        /// Exports the grid to PDF through Syncfusion's public pdfExport method.
+        /// Requires <c>AllowPdfExport(true)</c> on the builder.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> PdfExport<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(PdfExportMethod);
+
+        /// <summary>
+        /// Opens the browser print dialog for the grid through Syncfusion's public print method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> Print<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(PrintMethod);
+
+        /// <summary>
+        /// Opens the column chooser through Syncfusion's public openColumnChooser method.
+        /// Requires <c>ShowColumnChooser(true)</c> on the builder.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> ShowColumnChooser<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(OpenColumnChooserMethod);
+
+        /// <summary>
+        /// Auto-fits every grid column to its content through Syncfusion's public autoFitColumns method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> AutoFitColumns<TModel>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            => self.EmitCall(AutoFitAllColumnsMethod);
+
+        /// <summary>
+        /// Auto-fits one grid column by typed row field through Syncfusion's public autoFitColumns method.
+        /// </summary>
+        public static ComponentRef<FusionGrid, TModel> AutoFitColumn<TModel, TRow, TField>(
+            this ComponentRef<FusionGrid, TModel> self,
+            Expression<Func<TRow, TField>> field)
+            where TModel : class
+            where TRow : class
+        {
+            var fieldName = ExpressionPathHelper.ToEventPath(field);
+            return self.EmitCall(AutoFitColumnMethod, new List<ValueExpression>
+            {
+                ValueExpression.Literal(fieldName)
+            });
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridValidation.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridValidation.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Alis.Reactive;
+using Alis.Reactive.Validation;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Emits Syncfusion-native column <c>validationRules</c> from the <em>same</em>
+    /// <c>ReactiveValidator</c> client metadata that powers form validation, so a Grid's
+    /// in-cell editor validates client-side without a second hand-written ruleset. The
+    /// validation source stays single (the validator), and EJ2's own <c>FormValidator</c>
+    /// runs the rule on cell save.
+    /// </summary>
+    /// <remarks>
+    /// Only the single-field rules that map directly to EJ2 FormValidator are emitted
+    /// (<c>required</c>, <c>minLength</c>, <c>maxLength</c>, <c>email</c>, <c>url</c>,
+    /// <c>regex</c>, <c>min</c>, <c>max</c>, numeric <c>range</c>). Conditional
+    /// (<c>WhenField</c>), cross-field, and exotic rules carry no EJ2 equivalent and stay
+    /// server-authoritative on save.
+    /// <code>
+    /// @inject Alis.Reactive.Validation.IClientValidationRuleSource ClientRules
+    /// @{ var care = FusionGridValidation.From&lt;ResidentCareItemValidator, ResidentCareItem&gt;(ClientRules); }
+    /// new GridColumn { Field = "openTasks", EditType = "numericedit",
+    ///     ValidationRules = care.Field(r =&gt; r.OpenTasks) }
+    /// </code>
+    /// </remarks>
+    public static class FusionGridValidation
+    {
+        /// <summary>
+        /// Reads the client validation metadata for <typeparamref name="TValidator"/> and
+        /// returns a per-field emitter for grid columns over <typeparamref name="TRow"/>.
+        /// </summary>
+        public static FusionGridFieldValidation<TRow> From<TValidator, TRow>(IClientValidationRuleSource source)
+            where TValidator : class
+            where TRow : class
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return new FusionGridFieldValidation<TRow>(source.GetClientRules(typeof(TValidator)));
+        }
+    }
+
+    /// <summary>
+    /// Per-field bridge from <c>ReactiveValidator</c> client metadata to an EJ2 column
+    /// <c>validationRules</c> object, keyed by typed row field.
+    /// </summary>
+    public sealed class FusionGridFieldValidation<TRow>
+        where TRow : class
+    {
+        private readonly IReadOnlyList<ClientValidationField> _fields;
+
+        internal FusionGridFieldValidation(IReadOnlyList<ClientValidationField> fields)
+        {
+            _fields = fields;
+        }
+
+        /// <summary>
+        /// The EJ2 <c>column.validationRules</c> object for a typed row field, or
+        /// <see langword="null"/> when no declared rule maps client-side (every rule on
+        /// the field is conditional, cross-field, or otherwise server-only).
+        /// </summary>
+        public object? Field<TField>(Expression<Func<TRow, TField>> field)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+
+            var path = ExpressionPathHelper.ToPropertyName(field);
+            var declared = _fields.FirstOrDefault(candidate => candidate.FieldName == path);
+            if (declared == null)
+                throw new InvalidOperationException(
+                    $"No client validation rules are declared for '{path}'. " +
+                    "Add a ClientRule for it on the validator, or remove the ValidationRules emit for this column.");
+
+            var rules = Ej2ColumnRules.From(declared);
+            return rules.Count == 0 ? null : rules;
+        }
+    }
+
+    /// <summary>
+    /// Translates a field's client rules into the EJ2 FormValidator object shape
+    /// <c>{ rule: [value, message] }</c>. The validator rule names are already EJ2-shaped
+    /// (<c>required</c>, <c>minLength</c>, <c>range</c>, ...), so each maps by name.
+    /// </summary>
+    internal static class Ej2ColumnRules
+    {
+        internal static Dictionary<string, object> From(ClientValidationField field)
+        {
+            var rules = new Dictionary<string, object>(StringComparer.Ordinal);
+            foreach (var rule in field.Rules)
+            {
+                if (!rule.IsUnconditional) continue; // EJ2 column rules are always-on
+                Add(rules, rule);
+            }
+            return rules;
+        }
+
+        private static void Add(Dictionary<string, object> rules, ValidationRule rule)
+        {
+            var key = rule.Name.Value;
+            switch (key)
+            {
+                case "required":
+                case "email":
+                case "url":
+                    rules[key] = new object[] { true, rule.Message };
+                    break;
+
+                case "minLength":
+                case "maxLength":
+                    if (rule.LiteralOperand is int length)
+                        rules[key] = new object[] { length, rule.Message };
+                    break;
+
+                case "regex":
+                    if (rule.LiteralOperand is string pattern)
+                        rules[key] = new object[] { pattern, rule.Message };
+                    break;
+
+                case "min":
+                case "max":
+                    if (IsNumeric(rule.LiteralOperand))
+                        rules[key] = new object[] { rule.LiteralOperand!, rule.Message };
+                    break;
+
+                case "range":
+                    var bounds = rule.RangeOperand;
+                    if (bounds is { Length: 2 } && IsNumeric(bounds[0]) && IsNumeric(bounds[1]))
+                        rules["range"] = new object[] { new[] { bounds[0], bounds[1] }, rule.Message };
+                    break;
+
+                // gt, lt, exclusiveRange, equalTo, notEqual, notEqualTo, creditCard,
+                // atLeastOne, empty: no EJ2 FormValidator equivalent — server-authoritative.
+            }
+        }
+
+        private static bool IsNumeric(object? value) =>
+            value is byte or sbyte or short or ushort or int or uint or long or ulong or decimal or double or float;
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListBox/Events/FusionListBoxOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListBox/Events/FusionListBoxOnChanged.cs
@@ -1,0 +1,13 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionListBox"/> selection changes.
+    /// </summary>
+    public sealed class FusionListBoxChangeArgs
+    {
+        /// <summary>Gets or sets the selected string values.</summary>
+        public string[]? Value { get; set; }
+
+        public FusionListBoxChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBox.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBox.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 ListBox. Static rendering and data binding stay on the MVC builder;
+    /// this type scopes proven post-render string-value behavior and event wiring.
+    /// </summary>
+    public sealed class FusionListBox : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxBuilder.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps Syncfusion ListBox render output while carrying reactive plan context.
+    /// </summary>
+    public sealed class FusionListBoxBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionListBoxBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxEvents.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionListBox"/> component.
+    /// </summary>
+    public sealed class FusionListBoxEvents
+    {
+        public static readonly FusionListBoxEvents Instance = new FusionListBoxEvents();
+        private FusionListBoxEvents() { }
+
+        /// <summary>Fires when selected values change (SF "change" event).</summary>
+        public TypedEvent<FusionListBoxChangeArgs> Changed =>
+            new TypedEvent<FusionListBoxChangeArgs>(
+                "change", new FusionListBoxChangeArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxExtensions.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionListBox"/>.
+    /// </summary>
+    public static class FusionListBoxExtensions
+    {
+        private static readonly ComponentProperty<string[]> ValueProperty =
+            ComponentProperty<string[]>.Named("value");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod SelectValuesMethod =
+            ComponentMethod.Mapped("selectValues", "selectItems").WithArgs<string[], bool, bool>();
+
+        private static readonly ComponentMethod UnselectValuesMethod =
+            ComponentMethod.Mapped("unselectValues", "selectItems").WithArgs<string[], bool, bool>();
+
+        private static readonly ComponentMethod SelectAllMethod =
+            ComponentMethod.Named("selectAll").WithArgs<bool>();
+
+        private static readonly ComponentMethod UnselectAllMethod =
+            ComponentMethod.Mapped("unselectAll", "selectAll").WithArgs<bool>();
+
+        private static readonly ComponentMethod EnableValuesMethod =
+            ComponentMethod.Mapped("enableValues", "enableItems").WithArgs<string[], bool, bool>();
+
+        private static readonly ComponentMethod DisableValuesMethod =
+            ComponentMethod.Mapped("disableValues", "enableItems").WithArgs<string[], bool, bool>();
+
+        /// <summary>Sets selected string values. Use an empty array to clear selection.</summary>
+        public static ComponentRef<FusionListBox, TModel> SetValue<TModel>(
+            this ComponentRef<FusionListBox, TModel> self,
+            string[] value)
+            where TModel : class
+            => self.EmitSet(ValueProperty, StringArray(value));
+
+        /// <summary>Flushes pending property changes to the ListBox in the browser.</summary>
+        public static ComponentRef<FusionListBox, TModel> DataBind<TModel>(
+            this ComponentRef<FusionListBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(DataBindMethod);
+
+        /// <summary>Selects items by string value.</summary>
+        public static ComponentRef<FusionListBox, TModel> SelectValues<TModel>(
+            this ComponentRef<FusionListBox, TModel> self,
+            params string[] values)
+            where TModel : class
+            => self.EmitCall(
+                SelectValuesMethod,
+                new List<ValueExpression>
+                {
+                    StringArray(values),
+                    ValueExpression.Literal(true),
+                    ValueExpression.Literal(true)
+                });
+
+        /// <summary>Clears selection for items by string value.</summary>
+        public static ComponentRef<FusionListBox, TModel> UnselectValues<TModel>(
+            this ComponentRef<FusionListBox, TModel> self,
+            params string[] values)
+            where TModel : class
+            => self.EmitCall(
+                UnselectValuesMethod,
+                new List<ValueExpression>
+                {
+                    StringArray(values),
+                    ValueExpression.Literal(false),
+                    ValueExpression.Literal(true)
+                });
+
+        /// <summary>Selects all enabled ListBox items.</summary>
+        public static ComponentRef<FusionListBox, TModel> SelectAll<TModel>(
+            this ComponentRef<FusionListBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(
+                SelectAllMethod,
+                new List<ValueExpression> { ValueExpression.Literal(true) });
+
+        /// <summary>Clears all ListBox selections.</summary>
+        public static ComponentRef<FusionListBox, TModel> UnselectAll<TModel>(
+            this ComponentRef<FusionListBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(
+                UnselectAllMethod,
+                new List<ValueExpression> { ValueExpression.Literal(false) });
+
+        /// <summary>Enables items by string value.</summary>
+        public static ComponentRef<FusionListBox, TModel> EnableValues<TModel>(
+            this ComponentRef<FusionListBox, TModel> self,
+            params string[] values)
+            where TModel : class
+            => self.EmitCall(
+                EnableValuesMethod,
+                new List<ValueExpression>
+                {
+                    StringArray(values),
+                    ValueExpression.Literal(true),
+                    ValueExpression.Literal(true)
+                });
+
+        /// <summary>Disables items by string value.</summary>
+        public static ComponentRef<FusionListBox, TModel> DisableValues<TModel>(
+            this ComponentRef<FusionListBox, TModel> self,
+            params string[] values)
+            where TModel : class
+            => self.EmitCall(
+                DisableValuesMethod,
+                new List<ValueExpression>
+                {
+                    StringArray(values),
+                    ValueExpression.Literal(false),
+                    ValueExpression.Literal(true)
+                });
+
+        /// <summary>Reads selected string values for use in conditions or gather.</summary>
+        public static TypedComponentSource<string[]> Value<TModel>(
+            this ComponentRef<FusionListBox, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+
+        private static ValueExpression StringArray(string[] values)
+        {
+            if (values is null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            return ValueExpression.LiteralRaw(values, Shape.ArrayOf(Shape.String));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxHtmlExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.DropDowns;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionListBox with Syncfusion MVC builder-owned static configuration.
+    /// </summary>
+    public static class FusionListBoxHtmlExtensions
+    {
+        /// <summary>Creates a FusionListBox with the given element ID.</summary>
+        public static FusionListBoxBuilder<TModel> FusionListBox<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<ListBoxBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().ListBox(elementId);
+            build(builder);
+
+            return new FusionListBoxBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListBox/FusionListBoxReactiveExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires ListBox browser events into a reactive plan.
+    /// </summary>
+    public static class FusionListBoxReactiveExtensions
+    {
+        private static readonly FusionListBox Component = new FusionListBox();
+
+        public static FusionListBoxBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionListBoxBuilder<TModel> builder,
+            Func<FusionListBoxEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionListBoxEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListView/Events/FusionListViewOnSelected.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListView/Events/FusionListViewOnSelected.cs
@@ -1,0 +1,42 @@
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionListView"/> item is selected.
+    /// </summary>
+    public sealed class FusionListViewSelectArgs
+    {
+        /// <summary>Gets or sets the selected item's visible text.</summary>
+        public string? Text { get; set; }
+
+        /// <summary>Gets or sets the selected item's zero-based index when the event came from user interaction.</summary>
+        public int? Index { get; set; }
+
+        /// <summary>Gets or sets whether the selection came from user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>Gets or sets the checkbox state for checkbox ListViews.</summary>
+        public bool? IsChecked { get; set; }
+
+        /// <summary>Gets or sets whether Syncfusion should cancel the selection.</summary>
+        public bool Cancel { get; set; }
+
+        public FusionListViewSelectArgs() { }
+    }
+
+    public static class FusionListViewSelectArgsExtensions
+    {
+        /// <summary>Cancels Syncfusion's selected item commit for the current select event.</summary>
+        public static void CancelSelection(
+            this FusionListViewSelectArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(
+                PayloadSource.Event(),
+                "cancel",
+                ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListView/FusionListView.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListView/FusionListView.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 ListView. Static rendering and data binding stay on the MVC builder;
+    /// this type scopes proven post-render behavior and event wiring.
+    /// </summary>
+    public sealed class FusionListView : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewBuilder.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps Syncfusion ListView render output while carrying reactive plan context.
+    /// </summary>
+    public sealed class FusionListViewBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionListViewBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewEvents.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionListView"/> component.
+    /// </summary>
+    public sealed class FusionListViewEvents
+    {
+        public static readonly FusionListViewEvents Instance = new FusionListViewEvents();
+        private FusionListViewEvents() { }
+
+        /// <summary>Fires when a ListView item is selected (SF "select" event).</summary>
+        public TypedEvent<FusionListViewSelectArgs> Selected =>
+            new TypedEvent<FusionListViewSelectArgs>(
+                "select", new FusionListViewSelectArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewExtensions.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionListView"/>.
+    /// </summary>
+    public static class FusionListViewExtensions
+    {
+        private static readonly ComponentMethod SelectTextMethod =
+            ComponentMethod.Mapped("selectText", "selectItem").WithArgs<string>();
+
+        private static readonly ComponentMethod UnselectTextMethod =
+            ComponentMethod.Mapped("unselectText", "unselectItem").WithArgs<string>();
+
+        private static readonly ComponentMethod CheckAllItemsMethod =
+            ComponentMethod.Named("checkAllItems");
+
+        private static readonly ComponentMethod UncheckAllItemsMethod =
+            ComponentMethod.Named("uncheckAllItems");
+
+        /// <summary>Selects an item by visible text for a primitive string ListView data source.</summary>
+        public static ComponentRef<FusionListView, TModel> SelectText<TModel>(
+            this ComponentRef<FusionListView, TModel> self,
+            string text)
+            where TModel : class
+            => self.EmitCall(
+                SelectTextMethod,
+                new List<ValueExpression> { ValueExpression.Literal(text) });
+
+        /// <summary>Clears selection for an item by visible text for a primitive string ListView data source.</summary>
+        public static ComponentRef<FusionListView, TModel> UnselectText<TModel>(
+            this ComponentRef<FusionListView, TModel> self,
+            string text)
+            where TModel : class
+            => self.EmitCall(
+                UnselectTextMethod,
+                new List<ValueExpression> { ValueExpression.Literal(text) });
+
+        /// <summary>Checks all ListView items when the MVC builder has enabled checkboxes.</summary>
+        public static ComponentRef<FusionListView, TModel> CheckAllItems<TModel>(
+            this ComponentRef<FusionListView, TModel> self)
+            where TModel : class
+            => self.EmitCall(CheckAllItemsMethod);
+
+        /// <summary>Unchecks all ListView items when the MVC builder has enabled checkboxes.</summary>
+        public static ComponentRef<FusionListView, TModel> UncheckAllItems<TModel>(
+            this ComponentRef<FusionListView, TModel> self)
+            where TModel : class
+            => self.EmitCall(UncheckAllItemsMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewHtmlExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Lists;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionListView with Syncfusion MVC builder-owned static configuration.
+    /// </summary>
+    public static class FusionListViewHtmlExtensions
+    {
+        /// <summary>Creates a non-input FusionListView with the given element ID.</summary>
+        public static FusionListViewBuilder<TModel> FusionListView<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<ListViewBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().ListView(elementId);
+            build(builder);
+
+            return new FusionListViewBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionListView/FusionListViewReactiveExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires ListView browser events into a reactive plan.
+    /// </summary>
+    public static class FusionListViewReactiveExtensions
+    {
+        private static readonly FusionListView Component = new FusionListView();
+
+        public static FusionListViewBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionListViewBuilder<TModel> builder,
+            Func<FusionListViewEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionListViewEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeCloseArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeCloseArgs.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered before the menu closes.
+    /// </summary>
+    public sealed class FusionMenuBeforeCloseArgs
+    {
+        public List<FusionMenuItem> Items { get; set; } = [];
+
+        public FusionMenuItem? ParentItem { get; set; }
+
+        public bool Cancel { get; set; }
+    }
+
+    /// <summary>
+    /// Typed mutations on the beforeClose event args for <see cref="FusionMenu"/>.
+    /// </summary>
+    public static class FusionMenuBeforeCloseArgsExtensions
+    {
+        public static void PreventClose(
+            this FusionMenuBeforeCloseArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(PayloadSource.Event(), "cancel", ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeItemRenderArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeItemRenderArgs.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered before a menu item renders.
+    /// </summary>
+    public sealed class FusionMenuBeforeItemRenderArgs
+    {
+        public FusionMenuItem Item { get; set; } = new FusionMenuItem();
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeOpenArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeOpenArgs.cs
@@ -17,7 +17,7 @@ namespace Alis.Reactive.Fusion.Components
 
         public double Left { get; set; }
 
-        public bool IsFocused { get; set; }
+        public bool? IsFocused { get; set; }
 
         public bool Cancel { get; set; }
     }

--- a/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeOpenArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuBeforeOpenArgs.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered before the menu opens.
+    /// </summary>
+    public sealed class FusionMenuBeforeOpenArgs
+    {
+        public List<FusionMenuItem> Items { get; set; } = [];
+
+        public FusionMenuItem? ParentItem { get; set; }
+
+        public double Top { get; set; }
+
+        public double Left { get; set; }
+
+        public bool IsFocused { get; set; }
+
+        public bool Cancel { get; set; }
+    }
+
+    /// <summary>
+    /// Typed mutations on the beforeOpen event args for <see cref="FusionMenu"/>.
+    /// </summary>
+    public static class FusionMenuBeforeOpenArgsExtensions
+    {
+        public static void PreventOpen(
+            this FusionMenuBeforeOpenArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(PayloadSource.Event(), "cancel", ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuItem.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuItem.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Narrow typed menu item payload projected from Syncfusion Menu item objects.
+    /// </summary>
+    public sealed class FusionMenuItem
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Text { get; set; } = string.Empty;
+
+        public string Url { get; set; } = string.Empty;
+
+        public string IconCss { get; set; } = string.Empty;
+
+        public bool Separator { get; set; }
+
+        public List<FusionMenuItem> Items { get; set; } = [];
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuOpenCloseArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuOpenCloseArgs.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered after the menu opens or closes.
+    /// </summary>
+    public sealed class FusionMenuOpenCloseArgs
+    {
+        public List<FusionMenuItem> Items { get; set; } = [];
+
+        public FusionMenuItem? ParentItem { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuSelectArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/Events/FusionMenuSelectArgs.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Payload delivered when a menu item is selected.
+    /// </summary>
+    public sealed class FusionMenuSelectArgs
+    {
+        public FusionMenuItem Item { get; set; } = new FusionMenuItem();
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenu.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenu.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionMenu - non-input navigation component wrapping Syncfusion EJ2 Menu.
+    /// Exposes typed open/close methods and lifecycle/item selection payloads.
+    /// </summary>
+    public sealed class FusionMenu : FusionComponent
+    {
+        // No ValueMember. This is a navigation component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps MenuBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionMenuBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionMenuBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuEvents.cs
@@ -1,0 +1,40 @@
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionMenu"/> component.
+    /// </summary>
+    public sealed class FusionMenuEvents
+    {
+        public static readonly FusionMenuEvents Instance = new FusionMenuEvents();
+
+        private FusionMenuEvents()
+        {
+        }
+
+        /// <summary>Fires before each menu item renders.</summary>
+        public TypedEvent<FusionMenuBeforeItemRenderArgs> BeforeItemRender =>
+            new TypedEvent<FusionMenuBeforeItemRenderArgs>("beforeItemRender", new FusionMenuBeforeItemRenderArgs());
+
+        /// <summary>Fires before the menu opens.</summary>
+        public TypedEvent<FusionMenuBeforeOpenArgs> BeforeOpen =>
+            new TypedEvent<FusionMenuBeforeOpenArgs>("beforeOpen", new FusionMenuBeforeOpenArgs());
+
+        /// <summary>Fires after the menu opens.</summary>
+        public TypedEvent<FusionMenuOpenCloseArgs> Opened =>
+            new TypedEvent<FusionMenuOpenCloseArgs>("onOpen", new FusionMenuOpenCloseArgs());
+
+        /// <summary>Fires before the menu closes.</summary>
+        public TypedEvent<FusionMenuBeforeCloseArgs> BeforeClose =>
+            new TypedEvent<FusionMenuBeforeCloseArgs>("beforeClose", new FusionMenuBeforeCloseArgs());
+
+        /// <summary>Fires after the menu closes.</summary>
+        public TypedEvent<FusionMenuOpenCloseArgs> Closed =>
+            new TypedEvent<FusionMenuOpenCloseArgs>("onClose", new FusionMenuOpenCloseArgs());
+
+        /// <summary>Fires when a menu item is selected.</summary>
+        public TypedEvent<FusionMenuSelectArgs> Select =>
+            new TypedEvent<FusionMenuSelectArgs>("select", new FusionMenuSelectArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuExtensions.cs
@@ -1,0 +1,33 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionMenu"/>.
+    /// </summary>
+    public static class FusionMenuExtensions
+    {
+        private static readonly ComponentMethod OpenMethod =
+            ComponentMethod.Named("open");
+
+        private static readonly ComponentMethod CloseMethod =
+            ComponentMethod.Named("close");
+
+        /// <summary>
+        /// Opens the menu in hamburger mode.
+        /// </summary>
+        public static ComponentRef<FusionMenu, TModel> Open<TModel>(
+            this ComponentRef<FusionMenu, TModel> self)
+            where TModel : class
+            => self.EmitCall(OpenMethod);
+
+        /// <summary>
+        /// Closes the menu in hamburger mode.
+        /// </summary>
+        public static ComponentRef<FusionMenu, TModel> Close<TModel>(
+            this ComponentRef<FusionMenu, TModel> self)
+            where TModel : class
+            => self.EmitCall(CloseMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuHtmlExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Navigations;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating FusionMenuBuilder.
+    /// </summary>
+    public static class FusionMenuHtmlExtensions
+    {
+        /// <summary>
+        /// Creates a FusionMenu with the given element ID.
+        /// </summary>
+        public static FusionMenuBuilder<TModel> FusionMenu<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<MenuBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Menu(elementId);
+            build(builder);
+
+            return new FusionMenuBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMenu/FusionMenuReactiveExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionMenu"/> into the reactive plan.
+    /// </summary>
+    public static class FusionMenuReactiveExtensions
+    {
+        private static readonly FusionMenu Component = new FusionMenu();
+
+        public static FusionMenuBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionMenuBuilder<TModel> builder,
+            Func<FusionMenuEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionMenuEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnBlur.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnBlur.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionOtpInput"/> field loses focus.
+    /// </summary>
+    public class FusionOtpInputBlurArgs
+    {
+        /// <summary>Gets or sets the current OTP value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the zero-based field index that lost focus.</summary>
+        public int Index { get; set; }
+
+        /// <summary>Gets or sets whether the blur came from user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionOtpInputBlurArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnFocus.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnFocus.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionOtpInput"/> field receives focus.
+    /// </summary>
+    public class FusionOtpInputFocusArgs
+    {
+        /// <summary>Gets or sets the current OTP value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the zero-based field index that received focus.</summary>
+        public int Index { get; set; }
+
+        /// <summary>Gets or sets whether the focus came from user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionOtpInputFocusArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnInput.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnInput.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionOtpInput"/> field changes.
+    /// </summary>
+    public class FusionOtpInputInputArgs
+    {
+        /// <summary>Gets or sets the current OTP value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the previous OTP value.</summary>
+        public string? PreviousValue { get; set; }
+
+        /// <summary>Gets or sets the zero-based field index that changed.</summary>
+        public int Index { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionOtpInputInputArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnValueChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/Events/FusionOtpInputOnValueChanged.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a complete <see cref="FusionOtpInput"/> value changes.
+    /// </summary>
+    public class FusionOtpInputValueChangedArgs
+    {
+        /// <summary>Gets or sets the new OTP value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the previous committed OTP value.</summary>
+        public string? PreviousValue { get; set; }
+
+        /// <summary>Gets or sets whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionOtpInputValueChangedArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInput.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInput.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionOtpInput for entering a one-time passcode value.
+    /// </summary>
+    public sealed class FusionOtpInput : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionOtpInput(), "otpinput");
+
+        /// <inheritdoc />
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputEvents.cs
@@ -1,0 +1,32 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionOtpInput"/> component.
+    /// </summary>
+    public sealed class FusionOtpInputEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionOtpInputEvents Instance = new FusionOtpInputEvents();
+        private FusionOtpInputEvents() { }
+
+        /// <summary>Fires each time an OTP field changes (SF "input" event).</summary>
+        public TypedEvent<FusionOtpInputInputArgs> Input =>
+            new TypedEvent<FusionOtpInputInputArgs>(
+                "input", new FusionOtpInputInputArgs());
+
+        /// <summary>Fires after the complete OTP value changes (SF "valueChanged" event).</summary>
+        public TypedEvent<FusionOtpInputValueChangedArgs> ValueChanged =>
+            new TypedEvent<FusionOtpInputValueChangedArgs>(
+                "valueChanged", new FusionOtpInputValueChangedArgs());
+
+        /// <summary>Fires when an OTP field receives focus.</summary>
+        public TypedEvent<FusionOtpInputFocusArgs> Focus =>
+            new TypedEvent<FusionOtpInputFocusArgs>(
+                "focus", new FusionOtpInputFocusArgs());
+
+        /// <summary>Fires when an OTP field loses focus.</summary>
+        public TypedEvent<FusionOtpInputBlurArgs> Blur =>
+            new TypedEvent<FusionOtpInputBlurArgs>(
+                "blur", new FusionOtpInputBlurArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputExtensions.cs
@@ -1,0 +1,57 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed mutations, methods, and value reading for <see cref="FusionOtpInput"/> in a reactive pipeline.
+    /// </summary>
+    public static class FusionOtpInputExtensions
+    {
+        private static readonly FusionOtpInput Component = new FusionOtpInput();
+
+        private static readonly ComponentProperty<string> ValueProperty =
+            ComponentProperty<string>.Named(Component.ValueMember);
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        private static readonly ComponentMethod FocusOutMethod =
+            ComponentMethod.Named("focusOut");
+
+        /// <summary>Sets the OTP value and flushes it into the visible fields.</summary>
+        /// <param name="value">The OTP value to set.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionOtpInput, TModel> SetValue<TModel>(
+            this ComponentRef<FusionOtpInput, TModel> self,
+            string value)
+            where TModel : class
+            => self
+                .EmitSet(ValueProperty, ValueExpression.Literal(value))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Moves focus into the OTP input.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionOtpInput, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionOtpInput, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Removes focus from the OTP input.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionOtpInput, TModel> FocusOut<TModel>(
+            this ComponentRef<FusionOtpInput, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusOutMethod);
+
+        /// <summary>Reads the current OTP value for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the OTP input's current value.</returns>
+        public static TypedComponentSource<string> Value<TModel>(
+            this ComponentRef<FusionOtpInput, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputHtmlExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionOtpInput inside a field wrapper, bound to a string model property.
+    /// </summary>
+    public static class FusionOtpInputHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionOtpInput bound to the field's model property.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <param name="setup">The field wrapper created by <c>Html.InputField()</c>.</param>
+        /// <param name="build">Callback to build the FusionOtpInput initial configuration.</param>
+        public static void FusionOtpInput<TModel>(
+            this InputBoundField<TModel, string?> setup,
+            Action<OtpInputBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionOtpInput.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().OtpInput(setup.ElementId)
+                .HtmlAttributes(new Dictionary<string, object> { ["id"] = setup.ElementId, ["name"] = setup.BindingPath });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionOtpInput/FusionOtpInputReactiveExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionOtpInput"/> into the reactive plan.
+    /// </summary>
+    public static class FusionOtpInputReactiveExtensions
+    {
+        private static readonly FusionOtpInput Component = new FusionOtpInput();
+
+        /// <summary>
+        /// Wires a FusionOtpInput event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TArgs">The event args type, inferred from the event selector.</typeparam>
+        /// <param name="builder">The Fusion builder.</param>
+        /// <param name="plan">The plan to add the reactive behavior to.</param>
+        /// <param name="eventSelector">Selects which event to react to.</param>
+        /// <param name="pipeline">Configures the commands to run when the event fires.</param>
+        /// <returns>The builder for method chaining.</returns>
+        public static OtpInputBuilder Reactive<TModel, TArgs>(
+            this OtpInputBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionOtpInputEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionOtpInputEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionProgressButton/Events/FusionProgressButtonOnProgress.cs
+++ b/Alis.Reactive.Fusion/Components/FusionProgressButton/Events/FusionProgressButtonOnProgress.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered by ProgressButton begin, progress, and end events.
+    /// </summary>
+    public class FusionProgressButtonProgressArgs
+    {
+        /// <summary>Gets or sets the current progress percentage.</summary>
+        public double Percent { get; set; }
+
+        /// <summary>Gets or sets the current progress duration in milliseconds.</summary>
+        public double CurrentDuration { get; set; }
+
+        /// <summary>Gets or sets the progress step interval.</summary>
+        public double Step { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionProgressButtonProgressArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButton.cs
+++ b/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButton.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 ProgressButton. Static render configuration stays on the MVC builder;
+    /// this type scopes typed post-render progress behavior and event wiring.
+    /// </summary>
+    public sealed class FusionProgressButton : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonBuilder.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps Syncfusion ProgressButtonBuilder output while carrying the component id.
+    /// </summary>
+    public sealed class FusionProgressButtonBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionProgressButtonBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonEvents.cs
@@ -1,0 +1,27 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionProgressButton"/> component.
+    /// </summary>
+    public sealed class FusionProgressButtonEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionProgressButtonEvents Instance = new FusionProgressButtonEvents();
+        private FusionProgressButtonEvents() { }
+
+        /// <summary>Fires when progress starts (SF "begin" event).</summary>
+        public TypedEvent<FusionProgressButtonProgressArgs> Began =>
+            new TypedEvent<FusionProgressButtonProgressArgs>(
+                "begin", new FusionProgressButtonProgressArgs());
+
+        /// <summary>Fires as progress advances (SF "progress" event).</summary>
+        public TypedEvent<FusionProgressButtonProgressArgs> Progressed =>
+            new TypedEvent<FusionProgressButtonProgressArgs>(
+                "progress", new FusionProgressButtonProgressArgs());
+
+        /// <summary>Fires when progress completes (SF "end" event).</summary>
+        public TypedEvent<FusionProgressButtonProgressArgs> Ended =>
+            new TypedEvent<FusionProgressButtonProgressArgs>(
+                "end", new FusionProgressButtonProgressArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonExtensions.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render mutations, reads, and methods for <see cref="FusionProgressButton"/>.
+    /// </summary>
+    public static class FusionProgressButtonExtensions
+    {
+        private static readonly ComponentProperty<string> ContentProperty =
+            ComponentProperty<string>.Named("content");
+
+        private static readonly ComponentProperty<bool> DisabledProperty =
+            ComponentProperty<bool>.Named("disabled");
+
+        private static readonly ComponentProperty<string> CssClassProperty =
+            ComponentProperty<string>.Named("cssClass");
+
+        private static readonly ComponentProperty<bool> EnableProgressProperty =
+            ComponentProperty<bool>.Named("enableProgress");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod StartMethod =
+            ComponentMethod.Named("start");
+
+        private static readonly ComponentMethod StartAtMethod =
+            ComponentMethod.Mapped("startAt", "start").WithArgs<double>();
+
+        private static readonly ComponentMethod ProgressCompleteMethod =
+            ComponentMethod.Named("progressComplete");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        /// <summary>Sets the visible button content and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> SetContent<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self,
+            string content)
+            where TModel : class
+            => self
+                .EmitSet(ContentProperty, ValueExpression.Literal(content))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether the progress button is disabled and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> SetDisabled<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self,
+            bool disabled)
+            where TModel : class
+            => self
+                .EmitSet(DisabledProperty, ValueExpression.Literal(disabled))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets rendered CSS classes on the progress button, then flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> SetCssClass<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self,
+            string cssClass)
+            where TModel : class
+            => self
+                .EmitSet(CssClassProperty, ValueExpression.Literal(cssClass))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Enables or disables the Syncfusion progress filler and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> SetProgressEnabled<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self,
+            bool enabled)
+            where TModel : class
+            => self
+                .EmitSet(EnableProgressProperty, ValueExpression.Literal(enabled))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Starts progress from the current ProgressButton percent.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> Start<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(StartMethod);
+
+        /// <summary>Starts progress from the supplied percent.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> StartAt<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self,
+            double percent)
+            where TModel : class
+            => self.EmitCall(
+                StartAtMethod,
+                new List<ValueExpression> { ValueExpression.Literal(percent) });
+
+        /// <summary>Completes the current progress operation.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> ProgressComplete<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(ProgressCompleteMethod);
+
+        /// <summary>Moves focus into the progress button through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionProgressButton, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Reads the current Syncfusion content property.</summary>
+        public static TypedComponentSource<string> Content<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self)
+            where TModel : class
+            => self.Read(ContentProperty);
+
+        /// <summary>Reads whether the progress button is currently disabled.</summary>
+        public static TypedComponentSource<bool> Disabled<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self)
+            where TModel : class
+            => self.Read(DisabledProperty);
+
+        /// <summary>Reads the current Syncfusion CSS class property.</summary>
+        public static TypedComponentSource<string> CssClass<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self)
+            where TModel : class
+            => self.Read(CssClassProperty);
+
+        /// <summary>Reads whether Syncfusion progress filler rendering is enabled.</summary>
+        public static TypedComponentSource<bool> ProgressEnabled<TModel>(
+            this ComponentRef<FusionProgressButton, TModel> self)
+            where TModel : class
+            => self.Read(EnableProgressProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonHtmlExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.SplitButtons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionProgressButton with Syncfusion MVC builder-owned initial render.
+    /// </summary>
+    public static class FusionProgressButtonHtmlExtensions
+    {
+        /// <summary>
+        /// Renders one Syncfusion ProgressButton with a stable component id.
+        /// </summary>
+        public static FusionProgressButtonBuilder<TModel> FusionProgressButton<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<ProgressButtonBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().ProgressButton(elementId);
+            build(builder);
+
+            return new FusionProgressButtonBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionProgressButton/FusionProgressButtonReactiveExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionProgressButton"/> into the reactive plan.
+    /// </summary>
+    public static class FusionProgressButtonReactiveExtensions
+    {
+        private static readonly FusionProgressButton Component = new FusionProgressButton();
+
+        /// <summary>
+        /// Wires a FusionProgressButton event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        public static FusionProgressButtonBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionProgressButtonBuilder<TModel> builder,
+            Func<FusionProgressButtonEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionProgressButtonEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRadioButton/Events/FusionRadioButtonOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRadioButton/Events/FusionRadioButtonOnChanged.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionRadioButton"/> is selected.
+    /// </summary>
+    public class FusionRadioButtonChangeArgs
+    {
+        /// <summary>Gets or sets the selected radio button value from the Syncfusion change event.</summary>
+        public string Value { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionRadioButtonChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButton.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButton.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 RadioButton. Static option rendering stays on the MVC builder;
+    /// this type scopes typed post-render behavior and event wiring.
+    /// </summary>
+    public sealed class FusionRadioButton : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonBuilder.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps Syncfusion RadioButtonBuilder output while carrying the component id.
+    /// </summary>
+    public sealed class FusionRadioButtonBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionRadioButtonBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonEvents.cs
@@ -1,0 +1,17 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionRadioButton"/> component.
+    /// </summary>
+    public sealed class FusionRadioButtonEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionRadioButtonEvents Instance = new FusionRadioButtonEvents();
+        private FusionRadioButtonEvents() { }
+
+        /// <summary>Fires when this radio button becomes selected (SF "change" event).</summary>
+        public TypedEvent<FusionRadioButtonChangeArgs> Changed =>
+            new TypedEvent<FusionRadioButtonChangeArgs>(
+                "change", new FusionRadioButtonChangeArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonExtensions.cs
@@ -1,0 +1,77 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render mutations, reads, and methods for <see cref="FusionRadioButton"/>.
+    /// </summary>
+    public static class FusionRadioButtonExtensions
+    {
+        private static readonly ComponentProperty<bool> CheckedProperty =
+            ComponentProperty<bool>.Named("checked");
+
+        private static readonly ComponentProperty<bool> DisabledProperty =
+            ComponentProperty<bool>.Named("disabled");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod SelectedValueMethod =
+            ComponentMethod.Named("getSelectedValue");
+
+        private static readonly ComponentMethod ClickMethod =
+            ComponentMethod.Named("click");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        /// <summary>Sets the selected state and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionRadioButton, TModel> SetChecked<TModel>(
+            this ComponentRef<FusionRadioButton, TModel> self,
+            bool isChecked)
+            where TModel : class
+            => self
+                .EmitSet(CheckedProperty, ValueExpression.Literal(isChecked))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether the radio button is disabled and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionRadioButton, TModel> SetDisabled<TModel>(
+            this ComponentRef<FusionRadioButton, TModel> self,
+            bool disabled)
+            where TModel : class
+            => self
+                .EmitSet(DisabledProperty, ValueExpression.Literal(disabled))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Invokes the radio button's native click through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionRadioButton, TModel> Click<TModel>(
+            this ComponentRef<FusionRadioButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(ClickMethod);
+
+        /// <summary>Moves focus into the radio button through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionRadioButton, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionRadioButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Reads whether this radio button is currently checked.</summary>
+        public static TypedComponentSource<bool> Checked<TModel>(
+            this ComponentRef<FusionRadioButton, TModel> self)
+            where TModel : class
+            => self.Read(CheckedProperty);
+
+        /// <summary>Reads whether this radio button is currently disabled.</summary>
+        public static TypedComponentSource<bool> Disabled<TModel>(
+            this ComponentRef<FusionRadioButton, TModel> self)
+            where TModel : class
+            => self.Read(DisabledProperty);
+
+        /// <summary>Reads the selected value from this radio button's named group.</summary>
+        public static TypedComponentSource<string> SelectedValue<TModel>(
+            this ComponentRef<FusionRadioButton, TModel> self)
+            where TModel : class
+            => self.Read<string>(SelectedValueMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonHtmlExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Buttons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionRadioButton with Syncfusion MVC builder-owned initial render.
+    /// </summary>
+    public static class FusionRadioButtonHtmlExtensions
+    {
+        /// <summary>
+        /// Renders one Syncfusion RadioButton with a stable component id.
+        /// </summary>
+        public static FusionRadioButtonBuilder<TModel> FusionRadioButton<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<RadioButtonBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().RadioButton(elementId);
+            build(builder);
+
+            return new FusionRadioButtonBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRadioButton/FusionRadioButtonReactiveExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionRadioButton"/> into the reactive plan.
+    /// </summary>
+    public static class FusionRadioButtonReactiveExtensions
+    {
+        private static readonly FusionRadioButton Component = new FusionRadioButton();
+
+        /// <summary>
+        /// Wires a FusionRadioButton event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        public static FusionRadioButtonBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionRadioButtonBuilder<TModel> builder,
+            Func<FusionRadioButtonEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionRadioButtonEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRating/Events/FusionRatingOnValueChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRating/Events/FusionRatingOnValueChanged.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionRating"/> value changes.
+    /// </summary>
+    public class FusionRatingValueChangedArgs
+    {
+        /// <summary>Gets or sets the new rating value.</summary>
+        public double Value { get; set; }
+
+        /// <summary>Gets or sets the previous rating value.</summary>
+        public double PreviousValue { get; set; }
+
+        /// <summary>Gets or sets whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionRatingValueChangedArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRating/FusionRating.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRating/FusionRating.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionRating for selecting a numeric rating value.
+    /// </summary>
+    public sealed class FusionRating : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionRating(), "rating");
+
+        /// <inheritdoc />
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingEvents.cs
@@ -1,0 +1,17 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionRating"/> component.
+    /// </summary>
+    public sealed class FusionRatingEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionRatingEvents Instance = new FusionRatingEvents();
+        private FusionRatingEvents() { }
+
+        /// <summary>Fires when the rating value changes (SF "valueChanged" event).</summary>
+        public TypedEvent<FusionRatingValueChangedArgs> ValueChanged =>
+            new TypedEvent<FusionRatingValueChangedArgs>(
+                "valueChanged", new FusionRatingValueChangedArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingExtensions.cs
@@ -1,0 +1,47 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed mutations, methods, and value reading for <see cref="FusionRating"/> in a reactive pipeline.
+    /// </summary>
+    public static class FusionRatingExtensions
+    {
+        private static readonly FusionRating Component = new FusionRating();
+
+        private static readonly ComponentProperty<double> ValueProperty =
+            ComponentProperty<double>.Named(Component.ValueMember);
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod ResetMethod =
+            ComponentMethod.Named("reset");
+
+        /// <summary>Sets the rating value and flushes it into the visible rating.</summary>
+        /// <param name="value">The rating value to set.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionRating, TModel> SetValue<TModel>(
+            this ComponentRef<FusionRating, TModel> self,
+            double value)
+            where TModel : class
+            => self
+                .EmitSet(ValueProperty, ValueExpression.Literal(value))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Resets the rating value to its minimum.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionRating, TModel> Reset<TModel>(
+            this ComponentRef<FusionRating, TModel> self)
+            where TModel : class
+            => self.EmitCall(ResetMethod);
+
+        /// <summary>Reads the current rating value for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the rating's current value.</returns>
+        public static TypedComponentSource<double> Value<TModel>(
+            this ComponentRef<FusionRating, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingHtmlExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionRating inside a field wrapper, bound to a numeric model property.
+    /// </summary>
+    public static class FusionRatingHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionRating bound to the field's model property.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <param name="setup">The field wrapper created by <c>Html.InputField()</c>.</param>
+        /// <param name="build">Callback to build the FusionRating initial configuration.</param>
+        public static void FusionRating<TModel>(
+            this InputBoundField<TModel, double> setup,
+            Action<RatingBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionRating.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().Rating(setup.ElementId)
+                .HtmlAttributes(new Dictionary<string, object> { ["id"] = setup.ElementId, ["name"] = setup.BindingPath });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionRating/FusionRatingReactiveExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionRating"/> into the reactive plan.
+    /// </summary>
+    public static class FusionRatingReactiveExtensions
+    {
+        private static readonly FusionRating Component = new FusionRating();
+
+        /// <summary>
+        /// Wires a FusionRating event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TArgs">The event args type, inferred from the event selector.</typeparam>
+        /// <param name="builder">The Fusion builder.</param>
+        /// <param name="plan">The plan to add the reactive behavior to.</param>
+        /// <param name="eventSelector">Selects which event to react to.</param>
+        /// <param name="pipeline">Configures the commands to run when the event fires.</param>
+        /// <returns>The builder for method chaining.</returns>
+        public static RatingBuilder Reactive<TModel, TArgs>(
+            this RatingBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionRatingEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionRatingEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSidebar/Events/FusionSidebarTransitionArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSidebar/Events/FusionSidebarTransitionArgs.cs
@@ -1,0 +1,18 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered before a Sidebar transition.
+    /// </summary>
+    public sealed class FusionSidebarTransitionArgs
+    {
+        /// <summary>Whether the transition was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionSidebarTransitionArgs()
+        {
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebar.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebar.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionSidebar - non-input navigation component wrapping Syncfusion EJ2 Sidebar.
+    /// Exposes typed open-state reads, navigation methods, and transition events.
+    /// </summary>
+    public sealed class FusionSidebar : FusionComponent
+    {
+        // No ValueMember. This is a navigation component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps SidebarBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionSidebarBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionSidebarBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarEvents.cs
@@ -1,0 +1,24 @@
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionSidebar"/> component.
+    /// </summary>
+    public sealed class FusionSidebarEvents
+    {
+        public static readonly FusionSidebarEvents Instance = new FusionSidebarEvents();
+
+        private FusionSidebarEvents()
+        {
+        }
+
+        /// <summary>Fires before the sidebar opens.</summary>
+        public TypedEvent<FusionSidebarTransitionArgs> Opened =>
+            new TypedEvent<FusionSidebarTransitionArgs>("open", new FusionSidebarTransitionArgs());
+
+        /// <summary>Fires before the sidebar closes.</summary>
+        public TypedEvent<FusionSidebarTransitionArgs> Closed =>
+            new TypedEvent<FusionSidebarTransitionArgs>("close", new FusionSidebarTransitionArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarExtensions.cs
@@ -1,0 +1,57 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionSidebar"/>.
+    /// </summary>
+    public static class FusionSidebarExtensions
+    {
+        private static readonly FusionSidebar Component = new FusionSidebar();
+
+        private static readonly ComponentProperty<bool> IsOpenProperty =
+            ComponentProperty<bool>.Named("isOpen");
+
+        private static readonly ComponentMethod ShowMethod =
+            ComponentMethod.Named("show");
+
+        private static readonly ComponentMethod HideMethod =
+            ComponentMethod.Named("hide");
+
+        private static readonly ComponentMethod ToggleMethod =
+            ComponentMethod.Named("toggle");
+
+        /// <summary>
+        /// Reads whether the sidebar is open.
+        /// </summary>
+        public static TypedComponentSource<bool> IsOpen<TModel>(
+            this ComponentRef<FusionSidebar, TModel> self)
+            where TModel : class
+            => self.Read(IsOpenProperty);
+
+        /// <summary>
+        /// Opens the sidebar.
+        /// </summary>
+        public static ComponentRef<FusionSidebar, TModel> Show<TModel>(
+            this ComponentRef<FusionSidebar, TModel> self)
+            where TModel : class
+            => self.EmitCall(ShowMethod);
+
+        /// <summary>
+        /// Closes the sidebar.
+        /// </summary>
+        public static ComponentRef<FusionSidebar, TModel> Hide<TModel>(
+            this ComponentRef<FusionSidebar, TModel> self)
+            where TModel : class
+            => self.EmitCall(HideMethod);
+
+        /// <summary>
+        /// Toggles the sidebar open state.
+        /// </summary>
+        public static ComponentRef<FusionSidebar, TModel> Toggle<TModel>(
+            this ComponentRef<FusionSidebar, TModel> self)
+            where TModel : class
+            => self.EmitCall(ToggleMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarHtmlExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Navigations;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating FusionSidebarBuilder.
+    /// Non-input component - NO InputField wrapper, NO input component registration.
+    /// </summary>
+    public static class FusionSidebarHtmlExtensions
+    {
+        /// <summary>
+        /// Creates a FusionSidebar with the given element ID.
+        /// </summary>
+        public static FusionSidebarBuilder<TModel> FusionSidebar<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<SidebarBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Sidebar(elementId);
+            build(builder);
+
+            return new FusionSidebarBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSidebar/FusionSidebarReactiveExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionSidebar"/> into the reactive plan.
+    /// </summary>
+    public static class FusionSidebarReactiveExtensions
+    {
+        private static readonly FusionSidebar Component = new FusionSidebar();
+
+        public static FusionSidebarBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionSidebarBuilder<TModel> builder,
+            Func<FusionSidebarEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionSidebarEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSlider/Events/FusionSliderOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSlider/Events/FusionSliderOnChanged.cs
@@ -1,0 +1,28 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a scalar <see cref="FusionSlider"/> value changes.
+    /// </summary>
+    public class FusionSliderChangeArgs
+    {
+        /// <summary>Gets or sets the new slider value.</summary>
+        public double Value { get; set; }
+
+        /// <summary>Gets or sets the previous slider value.</summary>
+        public double PreviousValue { get; set; }
+
+        /// <summary>Gets or sets the formatted slider value text.</summary>
+        public string? Text { get; set; }
+
+        /// <summary>Gets or sets the Syncfusion action name for the change.</summary>
+        public string? Action { get; set; }
+
+        /// <summary>Gets or sets whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionSliderChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSlider/FusionSlider.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSlider/FusionSlider.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionSlider for selecting a numeric value or numeric range.
+    /// </summary>
+    public sealed class FusionSlider : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionSlider(), "slider");
+
+        /// <inheritdoc />
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderEvents.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionSlider"/> component.
+    /// </summary>
+    public sealed class FusionSliderEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionSliderEvents Instance = new FusionSliderEvents();
+        private FusionSliderEvents() { }
+
+        /// <summary>Fires when the scalar slider value changes (SF "change" event).</summary>
+        public TypedEvent<FusionSliderChangeArgs> Change =>
+            new TypedEvent<FusionSliderChangeArgs>(
+                "change", new FusionSliderChangeArgs());
+
+        /// <summary>Fires after the scalar slider value changes (SF "changed" event).</summary>
+        public TypedEvent<FusionSliderChangeArgs> Changed =>
+            new TypedEvent<FusionSliderChangeArgs>(
+                "changed", new FusionSliderChangeArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderExtensions.cs
@@ -1,0 +1,62 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed mutations and value reading for <see cref="FusionSlider"/> in a reactive pipeline.
+    /// </summary>
+    public static class FusionSliderExtensions
+    {
+        private static readonly FusionSlider Component = new FusionSlider();
+
+        private static readonly ComponentProperty<double> ValueProperty =
+            ComponentProperty<double>.Named(Component.ValueMember);
+
+        private static readonly ComponentProperty<double[]> RangeValueProperty =
+            ComponentProperty<double[]>.Mapped("rangeValue", Component.ValueMember);
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        /// <summary>Sets the scalar slider value and flushes it into the visible slider.</summary>
+        /// <param name="value">The numeric value to set.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionSlider, TModel> SetValue<TModel>(
+            this ComponentRef<FusionSlider, TModel> self,
+            double value)
+            where TModel : class
+            => self
+                .EmitSet(ValueProperty, ValueExpression.Literal(value))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets the range slider value and flushes it into the visible slider.</summary>
+        /// <param name="start">The lower range value.</param>
+        /// <param name="end">The upper range value.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionSlider, TModel> SetRangeValue<TModel>(
+            this ComponentRef<FusionSlider, TModel> self,
+            double start,
+            double end)
+            where TModel : class
+            => self
+                .EmitSet(
+                    RangeValueProperty,
+                    ValueExpression.LiteralRaw(new[] { start, end }, Shape.ArrayOf(Shape.Number)))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Reads the current scalar value for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the slider's current scalar value.</returns>
+        public static TypedComponentSource<double> Value<TModel>(
+            this ComponentRef<FusionSlider, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+
+        /// <summary>Reads the current range value for use in gather or display pipelines.</summary>
+        /// <returns>A typed source representing the slider's current range value.</returns>
+        public static TypedComponentSource<double[]> RangeValue<TModel>(
+            this ComponentRef<FusionSlider, TModel> self)
+            where TModel : class
+            => self.Read(RangeValueProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderHtmlExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionSlider inside a field wrapper, bound to a model property.
+    /// </summary>
+    public static class FusionSliderHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionSlider bound to the field's model property.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TProp">The bound property type.</typeparam>
+        /// <param name="setup">The field wrapper created by <c>Html.InputField()</c>.</param>
+        /// <param name="build">Callback to build the FusionSlider initial configuration.</param>
+        public static void FusionSlider<TModel, TProp>(
+            this InputBoundField<TModel, TProp> setup,
+            Action<SliderBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionSlider.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().Slider(setup.ElementId)
+                .HtmlAttributes(new Dictionary<string, object> { ["id"] = setup.ElementId, ["name"] = setup.BindingPath });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSlider/FusionSliderReactiveExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionSlider"/> into the reactive plan.
+    /// </summary>
+    public static class FusionSliderReactiveExtensions
+    {
+        private static readonly FusionSlider Component = new FusionSlider();
+
+        /// <summary>
+        /// Wires a FusionSlider event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TArgs">The event args type, inferred from the event selector.</typeparam>
+        /// <param name="builder">The Fusion builder.</param>
+        /// <param name="plan">The plan to add the reactive behavior to.</param>
+        /// <param name="eventSelector">Selects which event to react to.</param>
+        /// <param name="pipeline">Configures the commands to run when the event fires.</param>
+        /// <returns>The builder for method chaining.</returns>
+        public static SliderBuilder Reactive<TModel, TArgs>(
+            this SliderBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionSliderEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionSliderEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/Events/FusionSplitButtonOnClicked.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/Events/FusionSplitButtonOnClicked.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionSplitButton"/> primary action is clicked.
+    /// Syncfusion exposes the clicked HTMLElement, which is intentionally not surfaced in the public API.
+    /// </summary>
+    public class FusionSplitButtonClickArgs
+    {
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionSplitButtonClickArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/Events/FusionSplitButtonOnSelected.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/Events/FusionSplitButtonOnSelected.cs
@@ -1,0 +1,31 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionSplitButton"/> secondary action item is selected.
+    /// </summary>
+    public class FusionSplitButtonSelectArgs
+    {
+        /// <summary>Gets or sets the selected item metadata from the Syncfusion select event.</summary>
+        public FusionSplitButtonItem Item { get; set; } = new FusionSplitButtonItem();
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionSplitButtonSelectArgs() { }
+    }
+
+    /// <summary>
+    /// Narrowed action item payload proven from Syncfusion SplitButton MenuEventArgs.
+    /// </summary>
+    public sealed class FusionSplitButtonItem
+    {
+        /// <summary>Gets or sets the selected item's Syncfusion id.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the selected item's display text.</summary>
+        public string Text { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets whether the selected item is disabled.</summary>
+        public bool Disabled { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButton.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButton.cs
@@ -1,0 +1,10 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Syncfusion EJ2 SplitButton. Static render configuration stays on the MVC builder;
+    /// this type scopes typed post-render behavior and event wiring.
+    /// </summary>
+    public sealed class FusionSplitButton : FusionComponent
+    {
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonBuilder.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps Syncfusion SplitButtonBuilder output while carrying the component id.
+    /// </summary>
+    public sealed class FusionSplitButtonBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionSplitButtonBuilder(
+            ReactivePlan<TModel> plan,
+            string elementId,
+            IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonEvents.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionSplitButton"/> component.
+    /// </summary>
+    public sealed class FusionSplitButtonEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionSplitButtonEvents Instance = new FusionSplitButtonEvents();
+        private FusionSplitButtonEvents() { }
+
+        /// <summary>Fires after the primary SplitButton action is clicked (SF "click" event).</summary>
+        public TypedEvent<FusionSplitButtonClickArgs> Clicked =>
+            new TypedEvent<FusionSplitButtonClickArgs>(
+                "click", new FusionSplitButtonClickArgs());
+
+        /// <summary>Fires after a secondary action item is selected (SF "select" event).</summary>
+        public TypedEvent<FusionSplitButtonSelectArgs> Selected =>
+            new TypedEvent<FusionSplitButtonSelectArgs>(
+                "select", new FusionSplitButtonSelectArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonExtensions.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render mutations, reads, and methods for <see cref="FusionSplitButton"/>.
+    /// </summary>
+    public static class FusionSplitButtonExtensions
+    {
+        private static readonly ComponentProperty<string> ContentProperty =
+            ComponentProperty<string>.Named("content");
+
+        private static readonly ComponentProperty<bool> DisabledProperty =
+            ComponentProperty<bool>.Named("disabled");
+
+        private static readonly ComponentProperty<string> CssClassProperty =
+            ComponentProperty<string>.Named("cssClass");
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod ToggleMethod =
+            ComponentMethod.Named("toggle");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        private static readonly ComponentMethod RemoveItemsMethod =
+            ComponentMethod.Named("removeItems").WithArgs<string[], bool>();
+
+        /// <summary>Sets the visible primary button content and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionSplitButton, TModel> SetContent<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self,
+            string content)
+            where TModel : class
+            => self
+                .EmitSet(ContentProperty, ValueExpression.Literal(content))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets whether both SplitButton buttons are disabled and flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionSplitButton, TModel> SetDisabled<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self,
+            bool disabled)
+            where TModel : class
+            => self
+                .EmitSet(DisabledProperty, ValueExpression.Literal(disabled))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Sets rendered CSS classes on the SplitButton wrapper and buttons, then flushes the Syncfusion view.</summary>
+        public static ComponentRef<FusionSplitButton, TModel> SetCssClass<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self,
+            string cssClass)
+            where TModel : class
+            => self
+                .EmitSet(CssClassProperty, ValueExpression.Literal(cssClass))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Toggles the SplitButton secondary popup between open and closed states.</summary>
+        public static ComponentRef<FusionSplitButton, TModel> Toggle<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(ToggleMethod);
+
+        /// <summary>Moves focus into the SplitButton primary button through Syncfusion's public method.</summary>
+        public static ComponentRef<FusionSplitButton, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Removes secondary action items by displayed text.</summary>
+        public static ComponentRef<FusionSplitButton, TModel> RemoveItemsByText<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self,
+            params string[] itemTexts)
+            where TModel : class
+            => self.EmitCall(RemoveItemsMethod, RemoveItemsArgs(itemTexts, isUniqueId: false));
+
+        /// <summary>Removes secondary action items by Syncfusion item id.</summary>
+        public static ComponentRef<FusionSplitButton, TModel> RemoveItemsById<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self,
+            params string[] itemIds)
+            where TModel : class
+            => self.EmitCall(RemoveItemsMethod, RemoveItemsArgs(itemIds, isUniqueId: true));
+
+        /// <summary>Reads the current Syncfusion content property.</summary>
+        public static TypedComponentSource<string> Content<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self)
+            where TModel : class
+            => self.Read(ContentProperty);
+
+        /// <summary>Reads whether the SplitButton is currently disabled.</summary>
+        public static TypedComponentSource<bool> Disabled<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self)
+            where TModel : class
+            => self.Read(DisabledProperty);
+
+        /// <summary>Reads the current Syncfusion CSS class property.</summary>
+        public static TypedComponentSource<string> CssClass<TModel>(
+            this ComponentRef<FusionSplitButton, TModel> self)
+            where TModel : class
+            => self.Read(CssClassProperty);
+
+        private static List<ValueExpression> RemoveItemsArgs(string[] items, bool isUniqueId)
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+
+            var itemValues = items
+                .Select(ValueExpression.Literal)
+                .ToList();
+
+            return new List<ValueExpression>
+            {
+                ValueExpression.Array(itemValues, Shape.ArrayOf(Shape.String)),
+                ValueExpression.Literal(isUniqueId)
+            };
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonHtmlExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.SplitButtons;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionSplitButton with Syncfusion MVC builder-owned initial render.
+    /// </summary>
+    public static class FusionSplitButtonHtmlExtensions
+    {
+        /// <summary>
+        /// Renders one Syncfusion SplitButton with a stable component id.
+        /// </summary>
+        public static FusionSplitButtonBuilder<TModel> FusionSplitButton<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<SplitButtonBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().SplitButton(elementId);
+            build(builder);
+
+            return new FusionSplitButtonBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionSplitButton/FusionSplitButtonReactiveExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionSplitButton"/> into the reactive plan.
+    /// </summary>
+    public static class FusionSplitButtonReactiveExtensions
+    {
+        private static readonly FusionSplitButton Component = new FusionSplitButton();
+
+        /// <summary>
+        /// Wires a FusionSplitButton event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        public static FusionSplitButtonBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionSplitButtonBuilder<TModel> builder,
+            Func<FusionSplitButtonEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionSplitButtonEvents.Instance);
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/Events/FusionStepperChangedArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/Events/FusionStepperChangedArgs.cs
@@ -1,0 +1,17 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered after a Stepper step changes.
+    /// </summary>
+    public sealed class FusionStepperChangedArgs
+    {
+        /// <summary>The index of the previous step.</summary>
+        public int PreviousStep { get; set; }
+
+        /// <summary>The index of the current step.</summary>
+        public int ActiveStep { get; set; }
+
+        /// <summary>Whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/Events/FusionStepperChangingArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/Events/FusionStepperChangingArgs.cs
@@ -1,0 +1,37 @@
+using Alis.Reactive.Builders;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered before a Stepper step changes.
+    /// </summary>
+    public sealed class FusionStepperChangingArgs
+    {
+        /// <summary>The index of the previous step.</summary>
+        public int PreviousStep { get; set; }
+
+        /// <summary>The index of the target step.</summary>
+        public int ActiveStep { get; set; }
+
+        /// <summary>Whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>Whether Syncfusion should cancel the step transition.</summary>
+        public bool Cancel { get; set; }
+    }
+
+    /// <summary>
+    /// Typed mutations on the stepChanging event args for <see cref="FusionStepper"/>.
+    /// </summary>
+    public static class FusionStepperChangingArgsExtensions
+    {
+        /// <summary>Cancels the pending step transition.</summary>
+        public static void PreventDefault(
+            this FusionStepperChangingArgs args,
+            IReactionEmitter pipeline)
+        {
+            pipeline.AddStep(ReactionGraph.Set(PayloadSource.Event(), "cancel", ValueExpression.Literal(true)));
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/Events/FusionStepperClickArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/Events/FusionStepperClickArgs.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a Stepper step is clicked.
+    /// </summary>
+    public sealed class FusionStepperClickArgs
+    {
+        /// <summary>The index of the previous step.</summary>
+        public int PreviousStep { get; set; }
+
+        /// <summary>The index of the current step.</summary>
+        public int ActiveStep { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepper.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepper.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionStepper - non-input progress/navigation component wrapping Syncfusion EJ2 Stepper.
+    /// Exposes typed runtime navigation methods and step change events.
+    /// </summary>
+    public sealed class FusionStepper : FusionComponent
+    {
+        // No ValueMember. This is a progress/navigation component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps StepperBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionStepperBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionStepperBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperEvents.cs
@@ -1,0 +1,26 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionStepper"/> component.
+    /// </summary>
+    public sealed class FusionStepperEvents
+    {
+        public static readonly FusionStepperEvents Instance = new FusionStepperEvents();
+
+        private FusionStepperEvents()
+        {
+        }
+
+        /// <summary>Fires after the active step changes.</summary>
+        public TypedEvent<FusionStepperChangedArgs> StepChanged =>
+            new TypedEvent<FusionStepperChangedArgs>("stepChanged", new FusionStepperChangedArgs());
+
+        /// <summary>Fires before the active step changes.</summary>
+        public TypedEvent<FusionStepperChangingArgs> StepChanging =>
+            new TypedEvent<FusionStepperChangingArgs>("stepChanging", new FusionStepperChangingArgs());
+
+        /// <summary>Fires when a step is clicked.</summary>
+        public TypedEvent<FusionStepperClickArgs> StepClick =>
+            new TypedEvent<FusionStepperClickArgs>("stepClick", new FusionStepperClickArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperExtensions.cs
@@ -1,0 +1,75 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render navigation methods for <see cref="FusionStepper"/>.
+    /// </summary>
+    public static class FusionStepperExtensions
+    {
+        private static readonly ComponentMethod NextStepMethod =
+            ComponentMethod.Named("nextStep");
+
+        private static readonly ComponentMethod PreviousStepMethod =
+            ComponentMethod.Named("previousStep");
+
+        private static readonly ComponentMethod ResetMethod =
+            ComponentMethod.Named("reset");
+
+        private static readonly ComponentMethod RefreshProgressbarMethod =
+            ComponentMethod.Named("refreshProgressbar");
+
+        private static readonly ComponentProperty<int> ActiveStepProperty =
+            ComponentProperty<int>.Named("activeStep");
+
+        /// <summary>
+        /// Reads the current active step.
+        /// </summary>
+        public static TypedComponentSource<int> ActiveStep<TModel>(
+            this ComponentRef<FusionStepper, TModel> self)
+            where TModel : class
+            => self.Read(ActiveStepProperty);
+
+        /// <summary>
+        /// Updates the active step.
+        /// </summary>
+        public static ComponentRef<FusionStepper, TModel> SetActiveStep<TModel>(
+            this ComponentRef<FusionStepper, TModel> self,
+            int activeStep)
+            where TModel : class
+            => self.EmitSet(ActiveStepProperty, ValueExpression.Literal(activeStep));
+
+        /// <summary>
+        /// Advances to the next step.
+        /// </summary>
+        public static ComponentRef<FusionStepper, TModel> NextStep<TModel>(
+            this ComponentRef<FusionStepper, TModel> self)
+            where TModel : class
+            => self.EmitCall(NextStepMethod);
+
+        /// <summary>
+        /// Moves to the previous step.
+        /// </summary>
+        public static ComponentRef<FusionStepper, TModel> PreviousStep<TModel>(
+            this ComponentRef<FusionStepper, TModel> self)
+            where TModel : class
+            => self.EmitCall(PreviousStepMethod);
+
+        /// <summary>
+        /// Resets the stepper to the first step.
+        /// </summary>
+        public static ComponentRef<FusionStepper, TModel> Reset<TModel>(
+            this ComponentRef<FusionStepper, TModel> self)
+            where TModel : class
+            => self.EmitCall(ResetMethod);
+
+        /// <summary>
+        /// Recomputes the progress bar after dynamic state changes.
+        /// </summary>
+        public static ComponentRef<FusionStepper, TModel> RefreshProgressbar<TModel>(
+            this ComponentRef<FusionStepper, TModel> self)
+            where TModel : class
+            => self.EmitCall(RefreshProgressbarMethod);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperHtmlExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Navigations;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating FusionStepperBuilder.
+    /// Non-input component - NO InputField wrapper, NO input component registration.
+    /// </summary>
+    public static class FusionStepperHtmlExtensions
+    {
+        /// <summary>
+        /// Creates a FusionStepper with the given element ID.
+        /// </summary>
+        public static FusionStepperBuilder<TModel> FusionStepper<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<StepperBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Stepper(elementId);
+            build(builder);
+
+            return new FusionStepperBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionStepper/FusionStepperReactiveExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionStepper"/> into the reactive plan.
+    /// </summary>
+    public static class FusionStepperReactiveExtensions
+    {
+        private static readonly FusionStepper Component = new FusionStepper();
+
+        public static FusionStepperBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionStepperBuilder<TModel> builder,
+            Func<FusionStepperEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionStepperEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnBlur.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnBlur.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextArea"/> loses focus.
+    /// </summary>
+    public class FusionTextAreaBlurArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextAreaBlurArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnChanged.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextArea"/> value changes and focus leaves the input.
+    /// </summary>
+    public class FusionTextAreaChangeArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the previous committed text value.</summary>
+        public string? PreviousValue { get; set; }
+
+        /// <summary>Gets or sets whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextAreaChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnFocus.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnFocus.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextArea"/> receives focus.
+    /// </summary>
+    public class FusionTextAreaFocusArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextAreaFocusArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnInput.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/Events/FusionTextAreaOnInput.cs
@@ -1,0 +1,19 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextArea"/> value changes during input.
+    /// </summary>
+    public class FusionTextAreaInputArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the previously input text value.</summary>
+        public string? PreviousValue { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextAreaInputArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextArea.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextArea.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionTextArea for long-form text entry backed by Syncfusion EJ2 TextArea.
+    /// </summary>
+    public sealed class FusionTextArea : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionTextArea(), "textarea");
+
+        /// <inheritdoc />
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaEvents.cs
@@ -1,0 +1,32 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionTextArea"/> component.
+    /// </summary>
+    public sealed class FusionTextAreaEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionTextAreaEvents Instance = new FusionTextAreaEvents();
+        private FusionTextAreaEvents() { }
+
+        /// <summary>Fires each time the textarea value changes (SF "input" event).</summary>
+        public TypedEvent<FusionTextAreaInputArgs> Input =>
+            new TypedEvent<FusionTextAreaInputArgs>(
+                "input", new FusionTextAreaInputArgs());
+
+        /// <summary>Fires when the textarea value changes and focus leaves the input (SF "change" event).</summary>
+        public TypedEvent<FusionTextAreaChangeArgs> Changed =>
+            new TypedEvent<FusionTextAreaChangeArgs>(
+                "change", new FusionTextAreaChangeArgs());
+
+        /// <summary>Fires when the component receives focus (SF "focus" event).</summary>
+        public TypedEvent<FusionTextAreaFocusArgs> Focus =>
+            new TypedEvent<FusionTextAreaFocusArgs>(
+                "focus", new FusionTextAreaFocusArgs());
+
+        /// <summary>Fires when the component loses focus (SF "blur" event).</summary>
+        public TypedEvent<FusionTextAreaBlurArgs> Blur =>
+            new TypedEvent<FusionTextAreaBlurArgs>(
+                "blur", new FusionTextAreaBlurArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaExtensions.cs
@@ -1,0 +1,56 @@
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed mutations and value reading for <see cref="FusionTextArea"/> in a reactive pipeline.
+    /// </summary>
+    public static class FusionTextAreaExtensions
+    {
+        private static readonly FusionTextArea Component = new FusionTextArea();
+
+        private static readonly ComponentProperty<string> ValueProperty =
+            ComponentProperty<string>.Named(Component.ValueMember);
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        private static readonly ComponentMethod FocusOutMethod =
+            ComponentMethod.Named("focusOut");
+
+        /// <summary>Sets the text value and flushes it into the visible textarea.</summary>
+        /// <param name="value">The text to set, or <see langword="null"/> to clear.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionTextArea, TModel> SetValue<TModel>(
+            this ComponentRef<FusionTextArea, TModel> self, string? value)
+            where TModel : class
+            => self
+                .EmitSet(ValueProperty, ValueExpression.LiteralRaw(value, Shape.String))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Moves focus into the textarea.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionTextArea, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionTextArea, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Removes focus from the textarea.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionTextArea, TModel> FocusOut<TModel>(
+            this ComponentRef<FusionTextArea, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusOutMethod);
+
+        /// <summary>Reads the current text value for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the textarea's current value.</returns>
+        public static TypedComponentSource<string> Value<TModel>(
+            this ComponentRef<FusionTextArea, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaHtmlExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionTextArea inside a field wrapper, bound to a model property.
+    /// </summary>
+    public static class FusionTextAreaHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionTextArea bound to the field's model property.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TProp">The bound property type.</typeparam>
+        /// <param name="setup">The field wrapper created by <c>Html.InputField()</c>.</param>
+        /// <param name="build">Callback to build the TextArea using Syncfusion's MVC builder.</param>
+        public static void FusionTextArea<TModel, TProp>(
+            this InputBoundField<TModel, TProp> setup,
+            Action<TextAreaBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionTextArea.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().TextAreaFor(setup.Expression)
+                .HtmlAttributes(new Dictionary<string, object>
+                {
+                    ["id"] = setup.ElementId,
+                    ["name"] = setup.BindingPath
+                });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextArea/FusionTextAreaReactiveExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionTextArea"/> into the reactive plan.
+    /// </summary>
+    public static class FusionTextAreaReactiveExtensions
+    {
+        private static readonly FusionTextArea Component = new FusionTextArea();
+
+        /// <summary>
+        /// Wires a FusionTextArea event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TArgs">The event args type, inferred from the event selector.</typeparam>
+        /// <param name="builder">The Syncfusion TextArea builder.</param>
+        /// <param name="plan">The plan to add the reactive behavior to.</param>
+        /// <param name="eventSelector">Selects which event to react to.</param>
+        /// <param name="pipeline">Configures the commands to run when the event fires.</param>
+        /// <returns>The builder for method chaining.</returns>
+        public static TextAreaBuilder Reactive<TModel, TArgs>(
+            this TextAreaBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionTextAreaEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionTextAreaEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnBlur.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnBlur.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextBox"/> loses focus.
+    /// </summary>
+    public class FusionTextBoxBlurArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextBoxBlurArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnChanged.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnChanged.cs
@@ -1,0 +1,22 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextBox"/> value changes and focus leaves the input.
+    /// </summary>
+    public class FusionTextBoxChangeArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the previous committed text value.</summary>
+        public string? PreviousValue { get; set; }
+
+        /// <summary>Gets or sets whether the change was triggered by user interaction.</summary>
+        public bool IsInteracted { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextBoxChangeArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnFocus.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnFocus.cs
@@ -1,0 +1,16 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextBox"/> receives focus.
+    /// </summary>
+    public class FusionTextBoxFocusArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextBoxFocusArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnInput.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/Events/FusionTextBoxOnInput.cs
@@ -1,0 +1,19 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a <see cref="FusionTextBox"/> value changes during input.
+    /// </summary>
+    public class FusionTextBoxInputArgs
+    {
+        /// <summary>Gets or sets the current text value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the previously input text value.</summary>
+        public string? PreviousValue { get; set; }
+
+        /// <summary>
+        /// Creates a new instance. Framework-internal: instances are created by the event descriptor.
+        /// </summary>
+        public FusionTextBoxInputArgs() { }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBox.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBox.cs
@@ -1,0 +1,18 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A FusionTextBox for short text entry backed by Syncfusion EJ2 TextBox.
+    /// </summary>
+    /// <remarks>
+    /// Use as a type parameter in <c>p.Component&lt;FusionTextBox&gt;(m =&gt; m.ResidentName)</c>
+    /// to access FusionTextBox-specific mutations and value reading.
+    /// </remarks>
+    public sealed class FusionTextBox : FusionComponent, IInputComponent
+    {
+        internal static InputComponentRegistrationProfile Registration { get; } =
+            InputComponentRegistrationProfile.For(new FusionTextBox(), "textbox");
+
+        /// <inheritdoc />
+        public string ValueMember => "value";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxEvents.cs
@@ -1,0 +1,32 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionTextBox"/> component.
+    /// </summary>
+    public sealed class FusionTextBoxEvents
+    {
+        /// <summary>Shared instance used by the <c>.Reactive()</c> event selector.</summary>
+        public static readonly FusionTextBoxEvents Instance = new FusionTextBoxEvents();
+        private FusionTextBoxEvents() { }
+
+        /// <summary>Fires each time the textbox value changes (SF "input" event).</summary>
+        public TypedEvent<FusionTextBoxInputArgs> Input =>
+            new TypedEvent<FusionTextBoxInputArgs>(
+                "input", new FusionTextBoxInputArgs());
+
+        /// <summary>Fires when the textbox value changes and focus leaves the input (SF "change" event).</summary>
+        public TypedEvent<FusionTextBoxChangeArgs> Changed =>
+            new TypedEvent<FusionTextBoxChangeArgs>(
+                "change", new FusionTextBoxChangeArgs());
+
+        /// <summary>Fires when the component receives focus (SF "focus" event).</summary>
+        public TypedEvent<FusionTextBoxFocusArgs> Focus =>
+            new TypedEvent<FusionTextBoxFocusArgs>(
+                "focus", new FusionTextBoxFocusArgs());
+
+        /// <summary>Fires when the component loses focus (SF "blur" event).</summary>
+        public TypedEvent<FusionTextBoxBlurArgs> Blur =>
+            new TypedEvent<FusionTextBoxBlurArgs>(
+                "blur", new FusionTextBoxBlurArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxExtensions.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed mutations and value reading for <see cref="FusionTextBox"/> in a reactive pipeline.
+    /// </summary>
+    public static class FusionTextBoxExtensions
+    {
+        private static readonly FusionTextBox Component = new FusionTextBox();
+
+        private static readonly ComponentProperty<string> ValueProperty =
+            ComponentProperty<string>.Named(Component.ValueMember);
+
+        private static readonly ComponentMethod DataBindMethod =
+            ComponentMethod.Named("dataBind");
+
+        private static readonly ComponentMethod FocusInMethod =
+            ComponentMethod.Named("focusIn");
+
+        private static readonly ComponentMethod FocusOutMethod =
+            ComponentMethod.Named("focusOut");
+
+        private static readonly ComponentMethod AddAppendIconMethod =
+            ComponentMethod.Mapped("addAppendIcon", "addIcon").WithArgs<string, string>();
+
+        /// <summary>Sets the text value and flushes it into the visible input.</summary>
+        /// <param name="value">The text to set, or <see langword="null"/> to clear.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionTextBox, TModel> SetValue<TModel>(
+            this ComponentRef<FusionTextBox, TModel> self, string? value)
+            where TModel : class
+            => self
+                .EmitSet(ValueProperty, ValueExpression.LiteralRaw(value, Shape.String))
+                .EmitCall(DataBindMethod);
+
+        /// <summary>Moves focus into the textbox.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionTextBox, TModel> FocusIn<TModel>(
+            this ComponentRef<FusionTextBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusInMethod);
+
+        /// <summary>Removes focus from the textbox.</summary>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionTextBox, TModel> FocusOut<TModel>(
+            this ComponentRef<FusionTextBox, TModel> self)
+            where TModel : class
+            => self.EmitCall(FocusOutMethod);
+
+        /// <summary>Adds an append icon span using Syncfusion's public addIcon API.</summary>
+        /// <param name="iconCssClass">The icon CSS classes to add.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionTextBox, TModel> AddAppendIcon<TModel>(
+            this ComponentRef<FusionTextBox, TModel> self,
+            string iconCssClass)
+            where TModel : class
+            => self.EmitCall(
+                AddAppendIconMethod,
+                new List<ValueExpression>
+                {
+                    ValueExpression.Literal("append"),
+                    ValueExpression.Literal(iconCssClass)
+                });
+
+        /// <summary>Reads the current text value for use in conditions or gather.</summary>
+        /// <returns>A typed source representing the textbox's current value.</returns>
+        public static TypedComponentSource<string> Value<TModel>(
+            this ComponentRef<FusionTextBox, TModel> self)
+            where TModel : class
+            => self.Read(ValueProperty);
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxHtmlExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Native;
+using Alis.Reactive.Native.Extensions;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Creates a FusionTextBox inside a field wrapper, bound to a model property.
+    /// </summary>
+    public static class FusionTextBoxHtmlExtensions
+    {
+        /// <summary>
+        /// Renders a FusionTextBox bound to the field's model property.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TProp">The bound property type.</typeparam>
+        /// <param name="setup">The field wrapper created by <c>Html.InputField()</c>.</param>
+        /// <param name="build">Callback to build the TextBox using Syncfusion's MVC builder.</param>
+        public static void FusionTextBox<TModel, TProp>(
+            this InputBoundField<TModel, TProp> setup,
+            Action<TextBoxBuilder> build)
+            where TModel : class
+        {
+            var registration = global::Alis.Reactive.Fusion.Components.FusionTextBox.Registration;
+            setup.RegisterInputComponent(registration);
+
+            var builder = setup.Helper.EJS().TextBoxFor(setup.Expression)
+                .HtmlAttributes(new Dictionary<string, object>
+                {
+                    ["id"] = setup.ElementId,
+                    ["name"] = setup.BindingPath
+                });
+            build(builder);
+            setup.Render(builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionTextBox/FusionTextBoxReactiveExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Alis.Reactive.Builders;
+using Syncfusion.EJ2.Inputs;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionTextBox"/> into the reactive plan.
+    /// </summary>
+    public static class FusionTextBoxReactiveExtensions
+    {
+        private static readonly FusionTextBox Component = new FusionTextBox();
+
+        /// <summary>
+        /// Wires a FusionTextBox event to a reactive pipeline that executes in the browser.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TArgs">The event args type, inferred from the event selector.</typeparam>
+        /// <param name="builder">The Syncfusion TextBox builder.</param>
+        /// <param name="plan">The plan to add the reactive behavior to.</param>
+        /// <param name="eventSelector">Selects which event to react to.</param>
+        /// <param name="pipeline">Configures the commands to run when the event fires.</param>
+        /// <returns>The builder for method chaining.</returns>
+        public static TextBoxBuilder Reactive<TModel, TArgs>(
+            this TextBoxBuilder builder,
+            ReactivePlan<TModel> plan,
+            Func<FusionTextBoxEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionTextBoxEvents.Instance);
+
+            var attrs = (IDictionary<string, object>)builder.model.HtmlAttributes;
+            var componentId = (string)attrs["id"];
+
+            ComponentEventOnboarding.Wire(plan, componentId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionToolbar/Events/FusionToolbarClickedArgs.cs
+++ b/Alis.Reactive.Fusion/Components/FusionToolbar/Events/FusionToolbarClickedArgs.cs
@@ -1,0 +1,26 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Event payload delivered when a Toolbar item is clicked.
+    /// </summary>
+    public sealed class FusionToolbarClickedArgs
+    {
+        /// <summary>Toolbar item metadata from the Syncfusion click event.</summary>
+        public FusionToolbarItem Item { get; set; } = new FusionToolbarItem();
+    }
+
+    /// <summary>
+    /// Narrowed toolbar item payload proven from Syncfusion toolbar click behavior.
+    /// </summary>
+    public sealed class FusionToolbarItem
+    {
+        /// <summary>Toolbar item id.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Toolbar item text.</summary>
+        public string Text { get; set; } = string.Empty;
+
+        /// <summary>Whether the clicked item is disabled.</summary>
+        public bool Disabled { get; set; }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbar.cs
+++ b/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbar.cs
@@ -1,0 +1,11 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// FusionToolbar - non-input navigation component wrapping Syncfusion EJ2 Toolbar.
+    /// Exposes typed disable/enable behavior and item click events.
+    /// </summary>
+    public sealed class FusionToolbar : FusionComponent
+    {
+        // No ValueMember. This is a navigation/command component, not a form input.
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarBuilder.cs
+++ b/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarBuilder.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wraps ToolbarBuilder.Render() output and carries plan metadata for reactive chaining.
+    /// </summary>
+    public sealed class FusionToolbarBuilder<TModel> : IHtmlContent
+        where TModel : class
+    {
+        private readonly IHtmlContent _inner;
+
+        internal ReactivePlan<TModel> Plan { get; }
+        internal string ElementId { get; }
+
+        internal FusionToolbarBuilder(ReactivePlan<TModel> plan, string elementId, IHtmlContent inner)
+        {
+            Plan = plan;
+            ElementId = elementId;
+            _inner = inner;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            _inner.WriteTo(writer, encoder);
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarEvents.cs
+++ b/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarEvents.cs
@@ -1,0 +1,18 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed event descriptors for the <see cref="FusionToolbar"/> component.
+    /// </summary>
+    public sealed class FusionToolbarEvents
+    {
+        public static readonly FusionToolbarEvents Instance = new FusionToolbarEvents();
+
+        private FusionToolbarEvents()
+        {
+        }
+
+        /// <summary>Fires when a toolbar item is clicked.</summary>
+        public TypedEvent<FusionToolbarClickedArgs> Clicked =>
+            new TypedEvent<FusionToolbarClickedArgs>("clicked", new FusionToolbarClickedArgs());
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarExtensions.cs
@@ -1,0 +1,27 @@
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Typed post-render runtime behavior for <see cref="FusionToolbar"/>.
+    /// </summary>
+    public static class FusionToolbarExtensions
+    {
+        private static readonly FusionToolbar Component = new FusionToolbar();
+
+        private static readonly ComponentMethod DisableMethod =
+            ComponentMethod.Named("disable").WithArgs<bool>();
+
+        /// <summary>
+        /// Disables or enables the toolbar.
+        /// </summary>
+        public static ComponentRef<FusionToolbar, TModel> Disable<TModel>(
+            this ComponentRef<FusionToolbar, TModel> self,
+            bool value)
+            where TModel : class
+            => self.EmitCall(DisableMethod, new System.Collections.Generic.List<ValueExpression>
+            {
+                ValueExpression.Literal(value)
+            });
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarHtmlExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarHtmlExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Syncfusion.EJ2;
+using Syncfusion.EJ2.Navigations;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Factory extension for creating FusionToolbarBuilder.
+    /// Non-input component - NO InputField wrapper, NO input component registration.
+    /// </summary>
+    public static class FusionToolbarHtmlExtensions
+    {
+        /// <summary>
+        /// Creates a FusionToolbar with the given element ID.
+        /// </summary>
+        public static FusionToolbarBuilder<TModel> FusionToolbar<TModel>(
+            this IHtmlHelper<TModel> html,
+            ReactivePlan<TModel> plan,
+            string elementId,
+            Action<ToolbarBuilder> build)
+            where TModel : class
+        {
+            var builder = html.EJS().Toolbar(elementId);
+            build(builder);
+
+            return new FusionToolbarBuilder<TModel>(plan, elementId, builder.Render());
+        }
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarReactiveExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionToolbar/FusionToolbarReactiveExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Alis.Reactive.Builders;
+
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// Wires browser events from a <see cref="FusionToolbar"/> into the reactive plan.
+    /// </summary>
+    public static class FusionToolbarReactiveExtensions
+    {
+        private static readonly FusionToolbar Component = new FusionToolbar();
+
+        public static FusionToolbarBuilder<TModel> Reactive<TModel, TArgs>(
+            this FusionToolbarBuilder<TModel> builder,
+            Func<FusionToolbarEvents, TypedEvent<TArgs>> eventSelector,
+            Action<TArgs, PipelineBuilder<TModel>> pipeline)
+            where TModel : class
+        {
+            var descriptor = eventSelector(FusionToolbarEvents.Instance);
+
+            ComponentEventOnboarding.Wire(builder.Plan, builder.ElementId, Component.Vendor, descriptor, pipeline);
+
+            return builder;
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BreadcrumbController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BreadcrumbController.cs
@@ -15,5 +15,22 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
                 "~/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml",
                 new FusionBreadcrumbModel());
         }
+
+        [HttpPost("Route")]
+        public IActionResult Route([FromBody] FusionBreadcrumbRouteRequest request)
+        {
+            var category = request.Url.StartsWith("/docs", StringComparison.OrdinalIgnoreCase)
+                ? "documentation"
+                : "workspace";
+
+            return Ok(new FusionBreadcrumbRouteResponse
+            {
+                RouteCategory = category,
+                Trail = $"{request.Id}:{request.Url}",
+                Message = request.Disabled
+                    ? $"{request.Text} is disabled"
+                    : $"Opening {request.Text} in {category}"
+            });
+        }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BreadcrumbController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BreadcrumbController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionBreadcrumb")]
+    public class BreadcrumbController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml",
+                new FusionBreadcrumbModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BulletChartController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BulletChartController.cs
@@ -15,5 +15,20 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
                 "~/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml",
                 new FusionBulletChartModel());
         }
+
+        [HttpPost("ClickAudit")]
+        public IActionResult ClickAudit([FromBody] FusionBulletChartClickAuditRequest request)
+        {
+            var wing = request.Target.Contains("FeatureMeasure_0", StringComparison.Ordinal)
+                ? "North Wing"
+                : "Unknown wing";
+
+            return Ok(new FusionBulletChartClickAuditResponse
+            {
+                Wing = wing,
+                Coordinates = $"{Math.Round(request.X)},{Math.Round(request.Y)}",
+                Message = $"Opened readiness drilldown for {wing}"
+            });
+        }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BulletChartController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/BulletChartController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionBulletChart")]
+    public class BulletChartController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml",
+                new FusionBulletChartModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ButtonController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ButtonController.cs
@@ -1,0 +1,30 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/Button")]
+    public sealed class ButtonController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/Button/Index.cshtml", new ButtonModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] ButtonEchoRequest request)
+        {
+            return Ok(new ButtonEchoResponse
+            {
+                Content = request.Content,
+                Disabled = request.Disabled,
+                CssClass = request.CssClass,
+                IsPrimary = request.IsPrimary,
+                IsToggle = request.IsToggle,
+                Summary = request.Content + ":" + request.Disabled + ":" + request.IsPrimary + ":" + request.IsToggle
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/CarouselController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/CarouselController.cs
@@ -15,5 +15,24 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
                 "~/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml",
                 new FusionCarouselModel());
         }
+
+        [HttpPost("Audit")]
+        public IActionResult Audit([FromBody] FusionCarouselAuditRequest request)
+        {
+            var section = request.CurrentIndex switch
+            {
+                0 => "vitals snapshot",
+                1 => "care plan review",
+                2 => "discharge readiness",
+                _ => "unknown section"
+            };
+
+            return Ok(new FusionCarouselAuditResponse
+            {
+                Section = section,
+                Direction = request.SlideDirection,
+                Message = $"Saved review slide {request.CurrentIndex}: {section}"
+            });
+        }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/CarouselController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/CarouselController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionCarousel")]
+    public class CarouselController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml",
+                new FusionCarouselModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ComboBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ComboBoxController.cs
@@ -1,0 +1,36 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionComboBox")]
+    public sealed class ComboBoxController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            ViewBag.Residents = new List<ComboBoxResidentItem>
+            {
+                new() { Value = "alice", Text = "Alice", Unit = "A" },
+                new() { Value = "bennett", Text = "Bennett", Unit = "A" },
+                new() { Value = "carey", Text = "Carey", Unit = "B" },
+                new() { Value = "dawson", Text = "Dawson", Unit = "B" }
+            };
+
+            return View("~/Areas/Sandbox/Views/Components/Fusion/ComboBox/Index.cshtml", new FusionComboBoxModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionComboBoxEchoRequest request)
+        {
+            return Ok(new FusionComboBoxEchoResponse
+            {
+                Value = request.Value,
+                Text = request.Text,
+                Index = request.Index,
+                Summary = request.Value + ":" + request.Text + ":" + request.Index
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ContextMenuController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ContextMenuController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.ContextMenu;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/ContextMenu")]
+    public class ContextMenuController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/ContextMenu/Index.cshtml",
+                new FusionContextMenuModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DropDownButtonController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DropDownButtonController.cs
@@ -1,0 +1,28 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionDropDownButton")]
+    public sealed class DropDownButtonController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/DropDownButton/Index.cshtml", new FusionDropDownButtonModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionDropDownButtonEchoRequest request)
+        {
+            return Ok(new FusionDropDownButtonEchoResponse
+            {
+                Content = request.Content,
+                Disabled = request.Disabled,
+                CssClass = request.CssClass,
+                Summary = request.Content + ":" + request.Disabled + ":" + request.CssClass
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DropDownTreeController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/DropDownTreeController.cs
@@ -1,0 +1,38 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionDropDownTree")]
+    public sealed class DropDownTreeController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            ViewBag.Residents = new List<DropDownTreeResidentNode>
+            {
+                new() { Value = "floor-a", Text = "Floor A", HasChildren = true, Expanded = true },
+                new() { Value = "alice", Text = "Alice", ParentValue = "floor-a" },
+                new() { Value = "bennett", Text = "Bennett", ParentValue = "floor-a" },
+                new() { Value = "floor-b", Text = "Floor B", HasChildren = true, Expanded = true },
+                new() { Value = "carey", Text = "Carey", ParentValue = "floor-b" },
+                new() { Value = "dawson", Text = "Dawson", ParentValue = "floor-b" }
+            };
+
+            return View("~/Areas/Sandbox/Views/Components/Fusion/DropDownTree/Index.cshtml", new FusionDropDownTreeModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionDropDownTreeEchoRequest request)
+        {
+            var valueSummary = string.Join(",", request.Value ?? []);
+            return Ok(new FusionDropDownTreeEchoResponse
+            {
+                ValueSummary = valueSummary,
+                Text = request.Text,
+                Summary = valueSummary + ":" + request.Text
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/FusionCheckBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/FusionCheckBoxController.cs
@@ -1,0 +1,32 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionCheckBox")]
+    public sealed class FusionCheckBoxController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/CheckBox/Index.cshtml", new FusionCheckBoxModel
+            {
+                ConsentAccepted = false,
+                ReviewNeeded = false
+            });
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionCheckBoxEchoRequest request)
+        {
+            return Ok(new FusionCheckBoxEchoResponse
+            {
+                Checked = request.Checked,
+                Indeterminate = request.Indeterminate,
+                Disabled = request.Disabled,
+                Summary = request.Checked + ":" + request.Indeterminate + ":" + request.Disabled
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.Billing.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.Billing.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    /// <summary>
+    /// Month-end resident billing board: server-side filter/sort/page, bulk batch save,
+    /// bulk rate increase, mark-billed, and templated-dialog add. State is per browser
+    /// session (seeded on first access), so edits persist across saves and page refreshes
+    /// while each browser/test context stays isolated.
+    /// </summary>
+    public partial class GridController
+    {
+        private const string BillingSessionKey = "billingCensus";
+
+        private static readonly List<string> BillingCareLevels = new()
+        {
+            "", "Independent", "Assisted Living", "Memory Care", "Skilled Nursing"
+        };
+
+        private static readonly List<string> BillingWings = new() { "", "North", "East", "West", "South" };
+        private static readonly List<string> BillingStatuses = new() { "", "Pending", "Billed", "Paid" };
+
+        private List<ResidentBillingItem> GetBillingCensus()
+        {
+            var json = HttpContext.Session.GetString(BillingSessionKey);
+            if (string.IsNullOrEmpty(json))
+            {
+                var seed = GenerateBilling();
+                HttpContext.Session.SetString(BillingSessionKey, JsonSerializer.Serialize(seed));
+                return seed;
+            }
+            return JsonSerializer.Deserialize<List<ResidentBillingItem>>(json)!;
+        }
+
+        private void SaveBillingCensus(List<ResidentBillingItem> census) =>
+            HttpContext.Session.SetString(BillingSessionKey, JsonSerializer.Serialize(census));
+
+        [HttpGet("Billing")]
+        public IActionResult Billing()
+        {
+            GetBillingCensus(); // seed the session on first visit
+            ViewBag.CareLevels = BillingCareLevels;
+            ViewBag.Wings = BillingWings;
+            ViewBag.Statuses = BillingStatuses;
+
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Grid/Billing.cshtml",
+                new ResidentBillingViewModel());
+        }
+
+        [HttpPost("BillingData")]
+        public IActionResult BillingData([FromBody] BillingDataRequest? request)
+        {
+            request ??= new BillingDataRequest();
+            var rows = FilterBilling(GetBillingCensus(), request).ToList();
+            rows = SortBilling(rows, request.Sorted).ToList();
+
+            var total = rows.Count;
+            var skip = Math.Max(request.Skip, 0);
+            var take = request.Take > 0 ? request.Take : 12;
+
+            return Ok(new ResidentBillingResponse
+            {
+                Result = rows.Skip(skip).Take(take).ToList(),
+                Count = total,
+                Summary = BuildFilterSummary(rows, total, request)
+            });
+        }
+
+        [HttpPost("BillingSave")]
+        public IActionResult BillingSave([FromBody] BillingSaveRequest? request)
+        {
+            var changed = request?.BatchChanges?.ChangedRecords ?? new List<ResidentBillingItem>();
+            var overrides = changed
+                .GroupBy(r => r.ResidentId)
+                .ToDictionary(g => g.Key, g => g.Last());
+
+            var census = GetBillingCensus();
+            decimal adjusted = 0m;
+            foreach (var row in census)
+            {
+                if (!overrides.TryGetValue(row.ResidentId, out var edit)) continue;
+                adjusted += (edit.MonthlyRate + edit.AddOnCharges) - (row.MonthlyRate + row.AddOnCharges);
+                row.MonthlyRate = edit.MonthlyRate;
+                row.AddOnCharges = edit.AddOnCharges;
+                row.BalanceDue = Recompute(row);
+                row.BillingStatus = "Pending";
+            }
+            SaveBillingCensus(census);
+
+            return Ok(new ResidentBillingResponse
+            {
+                Result = SortBilling(census, null).Take(12).ToList(),
+                Count = census.Count,
+                Summary = overrides.Count == 0
+                    ? "no pending charge edits to save"
+                    : $"saved {overrides.Count} resident charge(s); net adjustment {adjusted:C0}"
+            });
+        }
+
+        [HttpPost("BillingBulkIncrease")]
+        public IActionResult BillingBulkIncrease([FromBody] BillingBulkRequest? request)
+        {
+            var percent = request?.Percent ?? 5m;
+            var ids = (request?.SelectedRecords ?? new()).Select(r => r.ResidentId).ToHashSet();
+
+            var census = GetBillingCensus();
+            foreach (var row in census.Where(r => ids.Contains(r.ResidentId)))
+            {
+                row.MonthlyRate = Math.Round(row.MonthlyRate * (1 + percent / 100m), 2);
+                row.BalanceDue = Recompute(row);
+                row.BillingStatus = "Pending";
+            }
+            SaveBillingCensus(census);
+
+            return Ok(new ResidentBillingResponse
+            {
+                Result = SortBilling(census, null).Take(12).ToList(),
+                Count = census.Count,
+                Summary = ids.Count == 0
+                    ? "select residents first, then apply the increase"
+                    : $"applied {percent:0.#}% increase to {ids.Count} resident(s)"
+            });
+        }
+
+        [HttpPost("BillingMarkBilled")]
+        public IActionResult BillingMarkBilled([FromBody] BillingBulkRequest? request)
+        {
+            var ids = (request?.SelectedRecords ?? new()).Select(r => r.ResidentId).ToHashSet();
+
+            var census = GetBillingCensus();
+            foreach (var row in census.Where(r => ids.Contains(r.ResidentId)))
+                row.BillingStatus = "Billed";
+            SaveBillingCensus(census);
+
+            return Ok(new ResidentBillingResponse
+            {
+                Result = SortBilling(census, null).Take(12).ToList(),
+                Count = census.Count,
+                Summary = ids.Count == 0
+                    ? "select residents first, then mark billed"
+                    : $"marked {ids.Count} resident(s) as billed"
+            });
+        }
+
+        [HttpPost("BillingAddCharge")]
+        public IActionResult BillingAddCharge([FromBody] ResidentBillingViewModel? request)
+        {
+            if (request == null)
+                return ValidationError(new Dictionary<string, string[]> { ["NewResidentName"] = ["Request body is required."] });
+
+            if (!TryValidate(new ResidentBillingAddValidator(), request, out var error))
+                return error;
+
+            var census = GetBillingCensus();
+            var row = new ResidentBillingItem
+            {
+                ResidentId = census.Count == 0 ? 9000 : census.Max(r => r.ResidentId) + 1,
+                ResidentName = request.NewResidentName!,
+                CareLevel = request.NewCareLevel!,
+                Wing = "North",
+                MonthlyRate = request.NewMonthlyRate!.Value,
+                AddOnCharges = request.NewAddOnCharges!.Value,
+                BillingStatus = "Pending"
+            };
+            row.BalanceDue = Recompute(row);
+            census.Insert(0, row);
+            SaveBillingCensus(census);
+
+            return Ok(new ResidentBillingResponse
+            {
+                Result = SortBilling(census, null).Take(12).ToList(),
+                Count = census.Count,
+                Summary = $"added {row.ResidentName} at {row.MonthlyRate:C0}/mo ({row.BalanceDue:C0} due)"
+            });
+        }
+
+        private static IEnumerable<ResidentBillingItem> FilterBilling(
+            IEnumerable<ResidentBillingItem> source, BillingDataRequest request)
+        {
+            var query = source;
+            if (!string.IsNullOrWhiteSpace(request.FilterCareLevel))
+                query = query.Where(r => r.CareLevel.Equals(request.FilterCareLevel, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(request.FilterWing))
+                query = query.Where(r => r.Wing.Equals(request.FilterWing, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(request.FilterStatus))
+                query = query.Where(r => r.BillingStatus.Equals(request.FilterStatus, StringComparison.OrdinalIgnoreCase));
+            return query;
+        }
+
+        private static IEnumerable<ResidentBillingItem> SortBilling(
+            IEnumerable<ResidentBillingItem> source, List<GridSortRequest>? sorted)
+        {
+            if (sorted == null || sorted.Count == 0)
+                return source.OrderBy(r => r.ResidentName);
+
+            IOrderedEnumerable<ResidentBillingItem>? ordered = null;
+            foreach (var sort in sorted.Where(s => !string.IsNullOrWhiteSpace(s.Name)))
+            {
+                var desc = sort.Direction.Equals("descending", StringComparison.OrdinalIgnoreCase);
+                ordered = ordered == null
+                    ? desc ? source.OrderByDescending(r => ReadBillingSort(r, sort.Name))
+                           : source.OrderBy(r => ReadBillingSort(r, sort.Name))
+                    : desc ? ordered.ThenByDescending(r => ReadBillingSort(r, sort.Name))
+                           : ordered.ThenBy(r => ReadBillingSort(r, sort.Name));
+            }
+            return ordered ?? source.OrderBy(r => r.ResidentName);
+        }
+
+        private static object ReadBillingSort(ResidentBillingItem r, string field) => field switch
+        {
+            "residentId" => r.ResidentId,
+            "residentName" => r.ResidentName,
+            "careLevel" => r.CareLevel,
+            "wing" => r.Wing,
+            "monthlyRate" => r.MonthlyRate,
+            "addOnCharges" => r.AddOnCharges,
+            "balanceDue" => r.BalanceDue,
+            "billingStatus" => r.BillingStatus,
+            _ => r.ResidentName
+        };
+
+        private static string BuildFilterSummary(
+            List<ResidentBillingItem> filteredRows, int total, BillingDataRequest request)
+        {
+            var parts = new List<string>();
+            if (!string.IsNullOrWhiteSpace(request.FilterCareLevel)) parts.Add(request.FilterCareLevel!);
+            if (!string.IsNullOrWhiteSpace(request.FilterWing)) parts.Add($"{request.FilterWing} wing");
+            if (!string.IsNullOrWhiteSpace(request.FilterStatus)) parts.Add(request.FilterStatus!);
+            var outstanding = filteredRows.Sum(r => r.BillingStatus == "Paid" ? 0 : r.BalanceDue);
+            var scope = parts.Count == 0 ? "all residents" : string.Join(", ", parts);
+            return $"{total} resident(s) — {scope}; {outstanding:C0} outstanding";
+        }
+
+        private static decimal Recompute(ResidentBillingItem r) =>
+            r.BillingStatus == "Paid" ? 0m : r.MonthlyRate + r.AddOnCharges;
+
+        private static List<ResidentBillingItem> GenerateBilling()
+        {
+            var names = new[]
+            {
+                "Amina Patel", "Grace Bennett", "Henry Liu", "Irene Morgan",
+                "Jonah Reed", "Katherine Ortiz", "Leo Simmons", "Mara Thompson",
+                "Noah Walsh", "Priya Shah", "Ruth Carter", "Samuel Diaz",
+                "Tara Novak", "Victor Chen", "Wendy Price", "Yara Ahmed"
+            };
+            var careLevels = new[] { "Independent", "Assisted Living", "Memory Care", "Skilled Nursing" };
+            var baseRates = new Dictionary<string, decimal>
+            {
+                ["Independent"] = 3200m,
+                ["Assisted Living"] = 4800m,
+                ["Memory Care"] = 6500m,
+                ["Skilled Nursing"] = 8200m
+            };
+            var wings = new[] { "North", "East", "West", "South" };
+            var statuses = new[] { "Pending", "Billed", "Paid" };
+
+            var rows = new List<ResidentBillingItem>();
+            for (var i = 0; i < 36; i++)
+            {
+                var careLevel = careLevels[i % careLevels.Length];
+                var status = statuses[i % statuses.Length];
+                var rate = baseRates[careLevel] + (i % 5) * 75m;
+                var addOns = 120m + (i % 7) * 60m;
+                var item = new ResidentBillingItem
+                {
+                    ResidentId = 6000 + i,
+                    ResidentName = names[i % names.Length],
+                    CareLevel = careLevel,
+                    Wing = wings[(i / 2) % wings.Length],
+                    MonthlyRate = rate,
+                    AddOnCharges = addOns,
+                    BillingStatus = status
+                };
+                item.BalanceDue = Recompute(item);
+                rows.Add(item);
+            }
+            return rows;
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.CareOps.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.CareOps.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    /// <summary>
+    /// Care Operations board: chip fast-filters, checkbox bulk selection, complex
+    /// cell editors, frozen columns, sticky header, per-row discharge action link,
+    /// bulk reassign/flag, and a templated admit dialog. State is per browser session
+    /// (seeded on first access), so edits persist across saves and page refreshes
+    /// while each browser/test context stays isolated.
+    /// </summary>
+    public partial class GridController
+    {
+        private const string CareSessionKey = "careOpsCensus";
+
+        private static readonly List<string> CareWings = new() { "", "North", "East", "West", "South" };
+        private static readonly List<string> CareLevelOptions = new()
+        {
+            "", "Independent", "Assisted Living", "Memory Care", "Skilled Nursing"
+        };
+        private static readonly List<string> CareRiskOptions = new() { "", "Low", "Moderate", "High", "Critical" };
+        private static readonly List<string> CareNurseOptions = new()
+        {
+            "Nora Ellis", "Malik Stone", "Elena Ruiz", "Owen Park", "Night Float Team"
+        };
+
+        private List<ResidentCareItem> GetCareCensus()
+        {
+            var json = HttpContext.Session.GetString(CareSessionKey);
+            if (string.IsNullOrEmpty(json))
+            {
+                var seed = GenerateCare();
+                HttpContext.Session.SetString(CareSessionKey, JsonSerializer.Serialize(seed));
+                return seed;
+            }
+            return JsonSerializer.Deserialize<List<ResidentCareItem>>(json)!;
+        }
+
+        private void SaveCareCensus(List<ResidentCareItem> census) =>
+            HttpContext.Session.SetString(CareSessionKey, JsonSerializer.Serialize(census));
+
+        [HttpGet("CareOps")]
+        public IActionResult CareOps()
+        {
+            GetCareCensus(); // seed the session on first visit
+            ViewBag.Wings = CareWings;
+            ViewBag.CareLevels = CareLevelOptions;
+            ViewBag.RiskLevels = CareRiskOptions;
+            ViewBag.Nurses = CareNurseOptions;
+
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Grid/CareOps.cshtml",
+                new CareOpsViewModel());
+        }
+
+        [HttpPost("CareOpsData")]
+        public IActionResult CareOpsData([FromBody] CareOpsDataRequest? request)
+        {
+            request ??= new CareOpsDataRequest();
+            var rows = FilterCare(GetCareCensus(), request.FilterRisk, request.FilterCareLevel).ToList();
+            rows = SortCare(rows, request.Sorted).ToList();
+
+            var total = rows.Count;
+            var skip = Math.Max(request.Skip, 0);
+            var take = request.Take > 0 ? request.Take : 10;
+
+            return Ok(new CareOpsResponse
+            {
+                Result = rows.Skip(skip).Take(take).ToList(),
+                Count = total,
+                Summary = CareSummary(rows, request.FilterRisk, request.FilterCareLevel)
+            });
+        }
+
+        [HttpPost("CareOpsSave")]
+        public IActionResult CareOpsSave([FromBody] CareOpsSaveRequest? request)
+        {
+            var changed = request?.BatchChanges?.ChangedRecords ?? new List<ResidentCareItem>();
+            var overrides = changed.GroupBy(r => r.ResidentId).ToDictionary(g => g.Key, g => g.Last());
+
+            var census = GetCareCensus();
+            foreach (var row in census.Where(r => overrides.ContainsKey(r.ResidentId)))
+            {
+                var edit = overrides[row.ResidentId];
+                row.CareLevel = string.IsNullOrWhiteSpace(edit.CareLevel) ? row.CareLevel : edit.CareLevel;
+                row.RiskLevel = string.IsNullOrWhiteSpace(edit.RiskLevel) ? row.RiskLevel : edit.RiskLevel;
+                row.PrimaryNurse = string.IsNullOrWhiteSpace(edit.PrimaryNurse) ? row.PrimaryNurse : edit.PrimaryNurse;
+                row.OpenTasks = edit.OpenTasks;
+                row.NextReview = string.IsNullOrWhiteSpace(edit.NextReview) ? row.NextReview : edit.NextReview;
+            }
+            SaveCareCensus(census);
+
+            return Ok(new CareOpsResponse
+            {
+                Result = SortCare(census, null).Take(10).ToList(),
+                Count = census.Count,
+                Summary = overrides.Count == 0
+                    ? "no pending care-plan edits to save"
+                    : $"saved care-plan updates for {overrides.Count} resident(s)"
+            });
+        }
+
+        [HttpPost("CareOpsBulkNurse")]
+        public IActionResult CareOpsBulkNurse([FromBody] CareOpsBulkRequest? request)
+        {
+            var nurse = string.IsNullOrWhiteSpace(request?.Nurse) ? "Night Float Team" : request!.Nurse!;
+            var ids = (request?.SelectedRecords ?? new()).Select(r => r.ResidentId).ToHashSet();
+
+            var census = GetCareCensus();
+            foreach (var row in census.Where(r => ids.Contains(r.ResidentId)))
+                row.PrimaryNurse = nurse;
+            SaveCareCensus(census);
+
+            return Ok(new CareOpsResponse
+            {
+                Result = SortCare(census, null).Take(10).ToList(),
+                Count = census.Count,
+                Summary = ids.Count == 0
+                    ? "select residents first, then reassign"
+                    : $"reassigned {ids.Count} resident(s) to {nurse}"
+            });
+        }
+
+        [HttpPost("CareOpsBulkRisk")]
+        public IActionResult CareOpsBulkRisk([FromBody] CareOpsBulkRequest? request)
+        {
+            var risk = string.IsNullOrWhiteSpace(request?.Risk) ? "High" : request!.Risk!;
+            var ids = (request?.SelectedRecords ?? new()).Select(r => r.ResidentId).ToHashSet();
+
+            var census = GetCareCensus();
+            foreach (var row in census.Where(r => ids.Contains(r.ResidentId)))
+                row.RiskLevel = risk;
+            SaveCareCensus(census);
+
+            return Ok(new CareOpsResponse
+            {
+                Result = SortCare(census, null).Take(10).ToList(),
+                Count = census.Count,
+                Summary = ids.Count == 0
+                    ? "select residents first, then flag risk"
+                    : $"flagged {ids.Count} resident(s) as {risk} risk"
+            });
+        }
+
+        [HttpPost("CareOpsDischargeSelected")]
+        public IActionResult CareOpsDischargeSelected([FromBody] CareOpsBulkRequest? request)
+        {
+            var ids = (request?.SelectedRecords ?? new()).Select(r => r.ResidentId).ToHashSet();
+
+            var census = GetCareCensus();
+            var discharged = census.Where(r => ids.Contains(r.ResidentId)).Select(r => r.ResidentName).ToList();
+            census.RemoveAll(r => ids.Contains(r.ResidentId));
+            SaveCareCensus(census);
+
+            return Ok(new CareOpsResponse
+            {
+                Result = SortCare(census, null).Take(10).ToList(),
+                Count = census.Count,
+                Summary = ids.Count == 0
+                    ? "select a resident first, then discharge"
+                    : $"discharged {string.Join(", ", discharged)}"
+            });
+        }
+
+        [HttpPost("CareOpsAdmit")]
+        public IActionResult CareOpsAdmit([FromBody] CareOpsViewModel? request)
+        {
+            if (request == null)
+                return ValidationError(new Dictionary<string, string[]> { ["NewResidentName"] = ["Request body is required."] });
+
+            if (!TryValidate(new CareOpsAdmitValidator(), request, out var error))
+                return error;
+
+            var census = GetCareCensus();
+            var row = new ResidentCareItem
+            {
+                ResidentId = census.Count == 0 ? 8000 : census.Max(r => r.ResidentId) + 1,
+                ResidentName = request.NewResidentName!,
+                Wing = request.NewWing!,
+                CareLevel = request.NewCareLevel!,
+                RiskLevel = request.NewRiskLevel!,
+                PrimaryNurse = "Admissions Desk",
+                OpenTasks = (int)request.NewOpenTasks!.Value,
+                NextReview = "2026-06-15"
+            };
+            census.Insert(0, row);
+            SaveCareCensus(census);
+
+            return Ok(new CareOpsResponse
+            {
+                Result = SortCare(census, null).Take(10).ToList(),
+                Count = census.Count,
+                Summary = $"admitted {row.ResidentName} to {row.Wing} wing at {row.RiskLevel} risk"
+            });
+        }
+
+        [HttpGet("CareOpsActionRows")]
+        public IActionResult CareOpsActionRows()
+        {
+            var rows = GetCareCensus().Take(8).ToList();
+            return PartialView(
+                "~/Areas/Sandbox/Views/Components/Fusion/Grid/_CareOpsActionRows.cshtml", rows);
+        }
+
+        [HttpPost("CareOpsDischargeOne/{id:int}")]
+        public IActionResult CareOpsDischargeOne(int id)
+        {
+            var census = GetCareCensus();
+            census.RemoveAll(r => r.ResidentId == id);
+            SaveCareCensus(census);
+            return Ok(new { discharged = id });
+        }
+
+        [HttpPost("CareOpsFlagOne/{id:int}")]
+        public IActionResult CareOpsFlagOne(int id)
+        {
+            var census = GetCareCensus();
+            foreach (var row in census.Where(r => r.ResidentId == id))
+                row.RiskLevel = "Critical";
+            SaveCareCensus(census);
+            return Ok(new { flagged = id });
+        }
+
+        private static IEnumerable<ResidentCareItem> FilterCare(
+            IEnumerable<ResidentCareItem> source, string? risk, string? careLevel)
+        {
+            var query = source;
+            if (!string.IsNullOrWhiteSpace(risk) && !risk.Equals("All", StringComparison.OrdinalIgnoreCase))
+                query = query.Where(r => r.RiskLevel.Equals(risk, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(careLevel) && !careLevel.Equals("All", StringComparison.OrdinalIgnoreCase))
+                query = query.Where(r => r.CareLevel.Equals(careLevel, StringComparison.OrdinalIgnoreCase));
+            return query;
+        }
+
+        private static IEnumerable<ResidentCareItem> SortCare(
+            IEnumerable<ResidentCareItem> source, List<GridSortRequest>? sorted)
+        {
+            if (sorted == null || sorted.Count == 0)
+                return source.OrderBy(r => r.ResidentName);
+
+            IOrderedEnumerable<ResidentCareItem>? ordered = null;
+            foreach (var sort in sorted.Where(s => !string.IsNullOrWhiteSpace(s.Name)))
+            {
+                var desc = sort.Direction.Equals("descending", StringComparison.OrdinalIgnoreCase);
+                ordered = ordered == null
+                    ? desc ? source.OrderByDescending(r => ReadCareSort(r, sort.Name))
+                           : source.OrderBy(r => ReadCareSort(r, sort.Name))
+                    : desc ? ordered.ThenByDescending(r => ReadCareSort(r, sort.Name))
+                           : ordered.ThenBy(r => ReadCareSort(r, sort.Name));
+            }
+            return ordered ?? source.OrderBy(r => r.ResidentName);
+        }
+
+        private static object ReadCareSort(ResidentCareItem r, string field) => field switch
+        {
+            "residentId" => r.ResidentId,
+            "residentName" => r.ResidentName,
+            "wing" => r.Wing,
+            "careLevel" => r.CareLevel,
+            "riskLevel" => r.RiskLevel,
+            "primaryNurse" => r.PrimaryNurse,
+            "openTasks" => r.OpenTasks,
+            "nextReview" => r.NextReview,
+            _ => r.ResidentName
+        };
+
+        private static string CareSummary(List<ResidentCareItem> rows, string? risk, string? careLevel)
+        {
+            var parts = new List<string>();
+            if (!string.IsNullOrWhiteSpace(risk) && !risk.Equals("All", StringComparison.OrdinalIgnoreCase)) parts.Add($"{risk} risk");
+            if (!string.IsNullOrWhiteSpace(careLevel) && !careLevel.Equals("All", StringComparison.OrdinalIgnoreCase)) parts.Add(careLevel!);
+            var openTasks = rows.Sum(r => r.OpenTasks);
+            var scope = parts.Count == 0 ? "whole census" : string.Join(", ", parts);
+            return $"{rows.Count} resident(s) — {scope}; {openTasks} open care tasks";
+        }
+
+        private static List<ResidentCareItem> GenerateCare()
+        {
+            var names = new[]
+            {
+                "Amina Patel", "Grace Bennett", "Henry Liu", "Irene Morgan",
+                "Jonah Reed", "Katherine Ortiz", "Leo Simmons", "Mara Thompson",
+                "Noah Walsh", "Priya Shah", "Ruth Carter", "Samuel Diaz",
+                "Tara Novak", "Victor Chen", "Wendy Price", "Yara Ahmed",
+                "Bilal Khan", "Clara Hoffman", "Diego Reyes", "Esther Cole"
+            };
+            var careLevels = new[] { "Independent", "Assisted Living", "Memory Care", "Skilled Nursing" };
+            var wings = new[] { "North", "East", "West", "South" };
+            var risks = new[] { "Low", "Moderate", "High", "Critical" };
+            var nurses = new[] { "Nora Ellis", "Malik Stone", "Elena Ruiz", "Owen Park" };
+
+            var rows = new List<ResidentCareItem>();
+            for (var i = 0; i < 30; i++)
+            {
+                rows.Add(new ResidentCareItem
+                {
+                    ResidentId = 7000 + i,
+                    ResidentName = names[i % names.Length],
+                    Wing = wings[(i / 2) % wings.Length],
+                    CareLevel = careLevels[i % careLevels.Length],
+                    RiskLevel = risks[(i + (i % 3)) % risks.Length],
+                    PrimaryNurse = nurses[i % nurses.Length],
+                    OpenTasks = i * 3 % 9,
+                    NextReview = new DateOnly(2026, 6, 1).AddDays(i % 21).ToString("yyyy-MM-dd")
+                });
+            }
+            return rows;
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.cs
@@ -10,7 +10,7 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
 {
     [Area("Sandbox")]
     [Route("Sandbox/Components/Grid")]
-    public class GridController : Controller
+    public partial class GridController : Controller
     {
         private static readonly List<ResidentGridItem> AllResidents = GenerateResidents();
         private static readonly List<ResidentDirectoryRecord> ResidentDirectory = GenerateResidentDirectory();

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.cs
@@ -49,10 +49,30 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
                 new ResidentGridEditingModel());
         }
 
+        [HttpGet("Operations")]
+        public IActionResult Operations()
+        {
+            ViewBag.RiskLevels = new List<string> { "", "Low", "Moderate", "High" };
+
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Grid/Operations.cshtml",
+                new GridOperationsModel
+                {
+                    PatchRiskLevel = "High",
+                    PatchOpenTasks = 6
+                });
+        }
+
         [HttpGet("EditingRows")]
         public IActionResult EditingRows()
         {
             return Ok(ResidentDirectory.Take(16).Select(ToGridItem).ToList());
+        }
+
+        [HttpGet("OperationRows")]
+        public IActionResult OperationRows()
+        {
+            return Ok(ResidentDirectory.Take(12).Select(ToGridItem).ToList());
         }
 
         /// <summary>
@@ -176,6 +196,71 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
                 Summary = records.Count == 0
                     ? "no selected records"
                     : $"selected records: {string.Join(", ", records.Select(r => r.ResidentName))}"
+            });
+        }
+
+        [HttpPost("CurrentViewSummary")]
+        public IActionResult CurrentViewSummary([FromBody] ResidentCurrentViewRequest request)
+        {
+            var records = request.Records ?? new List<ResidentDirectoryGridItem>();
+            var highRisk = records.Count(r => r.RiskLevel.Equals("High", StringComparison.OrdinalIgnoreCase));
+            var lead = records.FirstOrDefault()?.ResidentName ?? "no residents";
+
+            return Ok(new ResidentDirectorySelectionResponse
+            {
+                Summary = records.Count == 0
+                    ? "current view has no residents"
+                    : $"current view has {records.Count} residents, {highRisk} high risk; first is {lead}"
+            });
+        }
+
+        [HttpPost("RowIndexSummary")]
+        public IActionResult RowIndexSummary([FromBody] ResidentRowIndexRequest request)
+        {
+            return Ok(new ResidentDirectorySelectionResponse
+            {
+                Summary = request.RowIndex < 0
+                    ? "resident 6005 is not visible"
+                    : $"resident 6005 is visible at row index {request.RowIndex}"
+            });
+        }
+
+        [HttpPost("ReviewResident")]
+        public IActionResult ReviewResident([FromBody] GridTemplateActionPayload request)
+        {
+            var resident = ResidentDirectory.FirstOrDefault(r => r.ResidentId == request.Id);
+            return Ok(new ResidentDirectorySelectionResponse
+            {
+                ResidentName = resident?.ResidentName ?? "",
+                Summary = resident == null
+                    ? $"resident {request.Id} was not found"
+                    : $"review started for {resident.ResidentName} in suite {resident.Suite}"
+            });
+        }
+
+        [HttpPost("PatchResidentRow")]
+        public IActionResult PatchResidentRow([FromBody] GridOperationsModel? request)
+        {
+            request ??= new GridOperationsModel();
+            var source = ResidentDirectory[5];
+            var risk = string.IsNullOrWhiteSpace(request.PatchRiskLevel)
+                ? "High"
+                : request.PatchRiskLevel;
+            var tasks = request.PatchOpenTasks.HasValue
+                ? (int)request.PatchOpenTasks.Value
+                : 6;
+
+            var row = ToGridItem(source);
+            row.ResidentName = "Lena Server Patch";
+            row.RiskLevel = risk!;
+            row.OpenTasks = tasks;
+            row.PrimaryNurse = "Clinical Review Team";
+            row.NextReviewDate = "2026-06-30";
+
+            return Ok(new ResidentGridOperationsResponse
+            {
+                Row = row,
+                Summary = $"{row.ResidentName} changed to {row.RiskLevel} risk with {row.OpenTasks} tasks"
             });
         }
 
@@ -593,6 +678,16 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class ResidentSelectionRecordsRequest
     {
         public List<ResidentDirectoryGridItem>? SelectedRecords { get; set; }
+    }
+
+    public class ResidentCurrentViewRequest
+    {
+        public List<ResidentDirectoryGridItem>? Records { get; set; }
+    }
+
+    public class ResidentRowIndexRequest
+    {
+        public int RowIndex { get; set; }
     }
 
     public class ResidentGridBatchSummaryRequest

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/GridController.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using Alis.Reactive.Fusion.Components;
 using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
 
 namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
@@ -11,11 +13,46 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     public class GridController : Controller
     {
         private static readonly List<ResidentGridItem> AllResidents = GenerateResidents();
+        private static readonly List<ResidentDirectoryRecord> ResidentDirectory = GenerateResidentDirectory();
 
         [HttpGet("")]
         public IActionResult Index()
         {
             return View("~/Areas/Sandbox/Views/Components/Fusion/Grid/Index.cshtml", new GridModel());
+        }
+
+        [HttpGet("Directory")]
+        public IActionResult Directory()
+        {
+            ViewBag.CareLevels = new List<string>
+            {
+                "", "Independent", "Assisted Living", "Memory Care", "Skilled Nursing"
+            };
+            ViewBag.RiskLevels = new List<string>
+            {
+                "", "Low", "Moderate", "High"
+            };
+
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Grid/Directory.cshtml",
+                new ResidentDirectoryModel());
+        }
+
+        [HttpGet("Editing")]
+        public IActionResult Editing()
+        {
+            ViewBag.EditRows = ResidentDirectory.Take(16).Select(ToGridItem).ToList();
+            ViewBag.RiskLevels = new List<string> { "", "Low", "Moderate", "High" };
+
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Grid/Editing.cshtml",
+                new ResidentGridEditingModel());
+        }
+
+        [HttpGet("EditingRows")]
+        public IActionResult EditingRows()
+        {
+            return Ok(ResidentDirectory.Take(16).Select(ToGridItem).ToList());
         }
 
         /// <summary>
@@ -68,6 +105,145 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
             return Ok(new ResidentGridResponse { Result = paged, Count = total });
         }
 
+        [HttpPost("DirectoryData")]
+        public IActionResult DirectoryData([FromBody] ResidentDirectoryRequest? request)
+        {
+            request ??= new ResidentDirectoryRequest();
+            var rows = ApplyDirectoryRequest(ResidentDirectory, request).ToList();
+            var total = rows.Count;
+
+            if (request.Group is { Count: > 0 })
+            {
+                var groupedRows = GroupDirectoryRows(rows, request.Group, 0);
+                return Ok(new ResidentDirectoryResponse
+                {
+                    Result = groupedRows,
+                    Count = total,
+                    Summary = $"{total} residents grouped by {ToDisplayName(request.Group[0])}"
+                });
+            }
+
+            var skip = Math.Max(request.Skip, 0);
+            var take = request.Take > 0 ? request.Take : 8;
+            var page = rows.Skip(skip).Take(take).Select(ToGridItem).ToList();
+
+            return Ok(new ResidentDirectoryResponse
+            {
+                Result = page,
+                Count = total,
+                Summary = $"{total} residents matched"
+            });
+        }
+
+        [HttpPost("SelectResident")]
+        public IActionResult SelectResident([FromBody] ResidentSelectionRequest request)
+        {
+            var resident = ResidentDirectory.FirstOrDefault(r => r.ResidentId == request.ResidentId);
+            if (resident == null)
+            {
+                return Ok(new ResidentDirectorySelectionResponse
+                {
+                    Summary = $"No resident selected at row {request.RowIndex}"
+                });
+            }
+
+            return Ok(new ResidentDirectorySelectionResponse
+            {
+                ResidentName = resident.ResidentName,
+                Summary =
+                    $"{resident.ResidentName}: {resident.CareLevel}, {resident.Wing} wing, {resident.OpenTasks} open tasks"
+            });
+        }
+
+        [HttpPost("SelectionIndexes")]
+        public IActionResult SelectionIndexes([FromBody] ResidentSelectionIndexesRequest request)
+        {
+            var indexes = request.SelectedRowIndexes ?? new List<int>();
+            return Ok(new ResidentDirectorySelectionResponse
+            {
+                Summary = indexes.Count == 0
+                    ? "no selected row indexes"
+                    : $"selected row indexes: {string.Join(", ", indexes)}"
+            });
+        }
+
+        [HttpPost("SelectionRecords")]
+        public IActionResult SelectionRecords([FromBody] ResidentSelectionRecordsRequest request)
+        {
+            var records = request.SelectedRecords ?? new List<ResidentDirectoryGridItem>();
+            return Ok(new ResidentDirectorySelectionResponse
+            {
+                Summary = records.Count == 0
+                    ? "no selected records"
+                    : $"selected records: {string.Join(", ", records.Select(r => r.ResidentName))}"
+            });
+        }
+
+        [HttpPost("BatchSummary")]
+        public IActionResult BatchSummary([FromBody] ResidentGridBatchSummaryRequest request)
+        {
+            var changes = request.BatchChanges ?? new FusionGridBatchChanges<ResidentDirectoryGridItem>();
+            return Ok(new ResidentGridBatchSummaryResponse
+            {
+                Summary =
+                    $"batch added {changes.AddedRecords.Count}, changed {changes.ChangedRecords.Count}, deleted {changes.DeletedRecords.Count}"
+            });
+        }
+
+        [HttpPost("CreateEditResident")]
+        public IActionResult CreateEditResident()
+        {
+            var row = new ResidentDirectoryGridItem
+            {
+                ResidentId = 7200,
+                ResidentName = "Sofia Server",
+                Age = 79,
+                CareLevel = "Assisted Living",
+                Wing = "East",
+                Suite = "E-512",
+                RiskLevel = "Moderate",
+                PrimaryNurse = "Elena Ruiz",
+                OpenTasks = 2,
+                NextReviewDate = "2026-06-24"
+            };
+
+            return Ok(new ResidentGridEditResponse
+            {
+                Row = row,
+                Summary = $"{row.ResidentName} loaded from the server"
+            });
+        }
+
+        [HttpPost("ValidateEditDraft")]
+        public IActionResult ValidateEditDraft([FromBody] ResidentGridEditingModel? request)
+        {
+            if (request == null)
+                return ValidationError(new Dictionary<string, string[]> { ["ResidentName"] = ["Request body is required."] });
+
+            if (!TryValidate(new ResidentGridEditingValidator(), request, out var error))
+                return error;
+
+            var row = new ResidentDirectoryGridItem
+            {
+                ResidentId = 6000,
+                ResidentName = request.ResidentName!,
+                Age = 83,
+                CareLevel = "Memory Care",
+                Wing = "North",
+                Suite = "N-401",
+                RiskLevel = request.RiskLevel!,
+                PrimaryNurse = "Nora Ellis",
+                OpenTasks = (int)request.OpenTasks!.Value,
+                NextReviewDate = "2026-06-18"
+            };
+
+            return Ok(new ResidentGridEditResponse
+            {
+                Row = row,
+                Summary = $"{row.ResidentName} passed validation and updated row 1"
+            });
+        }
+
         private static List<ResidentGridItem> GenerateResidents()
         {
             var firstNames = new[]
@@ -103,6 +279,268 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
 
             return residents;
         }
+
+        private static IEnumerable<ResidentDirectoryRecord> ApplyDirectoryRequest(
+            IEnumerable<ResidentDirectoryRecord> source,
+            ResidentDirectoryRequest request)
+        {
+            var query = source;
+
+            if (!string.IsNullOrWhiteSpace(request.ResidentSearch))
+                query = query.Where(r => r.ResidentName.Contains(
+                    request.ResidentSearch,
+                    StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(request.CareLevel))
+                query = query.Where(r => r.CareLevel.Equals(
+                    request.CareLevel,
+                    StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(request.RiskLevel))
+                query = query.Where(r => r.RiskLevel.Equals(
+                    request.RiskLevel,
+                    StringComparison.OrdinalIgnoreCase));
+
+            if (request.MinimumAge.HasValue)
+                query = query.Where(r => r.Age >= (int)request.MinimumAge.Value);
+
+            query = ApplyGridFilters(query, request.Where);
+            query = ApplyGridSearch(query, request.Search);
+            query = ApplyGridSorting(query, request.Sorted);
+
+            return query;
+        }
+
+        private static IEnumerable<ResidentDirectoryRecord> ApplyGridSearch(
+            IEnumerable<ResidentDirectoryRecord> source,
+            List<ResidentDirectorySearchRequest>? search)
+        {
+            var active = search?.FirstOrDefault(s => !string.IsNullOrWhiteSpace(s.Key));
+            if (active == null)
+                return source;
+
+            var fields = active.Fields is { Count: > 0 }
+                ? active.Fields
+                : new List<string>
+                {
+                    "residentName", "careLevel", "wing", "suite", "riskLevel", "primaryNurse"
+                };
+
+            return source.Where(row => fields.Any(field =>
+                ReadDirectoryText(row, field).Contains(active.Key!, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        private static IEnumerable<ResidentDirectoryRecord> ApplyGridFilters(
+            IEnumerable<ResidentDirectoryRecord> source,
+            List<FusionGridTextFilterCriterion>? filters)
+        {
+            var flattened = FlattenGridFilters(filters).ToList();
+            if (flattened.Count == 0)
+                return source;
+
+            return source.Where(row => flattened.All(filter =>
+            {
+                if (string.IsNullOrWhiteSpace(filter.Field) || string.IsNullOrWhiteSpace(filter.Value))
+                    return true;
+
+                var actual = ReadDirectoryText(row, filter.Field);
+                var comparison = filter.MatchCase
+                    ? StringComparison.Ordinal
+                    : StringComparison.OrdinalIgnoreCase;
+
+                return filter.Operator switch
+                {
+                    "equal" => actual.Equals(filter.Value, comparison),
+                    "notequal" => !actual.Equals(filter.Value, comparison),
+                    "startswith" => actual.StartsWith(filter.Value, comparison),
+                    "endswith" => actual.EndsWith(filter.Value, comparison),
+                    _ => actual.Contains(filter.Value, comparison)
+                };
+            }));
+        }
+
+        private static IEnumerable<FusionGridTextFilterCriterion> FlattenGridFilters(
+            IEnumerable<FusionGridTextFilterCriterion>? filters)
+        {
+            if (filters == null)
+                yield break;
+
+            foreach (var filter in filters)
+            {
+                if (filter.Predicates is { Count: > 0 })
+                {
+                    foreach (var child in FlattenGridFilters(filter.Predicates))
+                        yield return child;
+                }
+                else
+                {
+                    yield return filter;
+                }
+            }
+        }
+
+        private static IEnumerable<ResidentDirectoryRecord> ApplyGridSorting(
+            IEnumerable<ResidentDirectoryRecord> source,
+            List<GridSortRequest>? sorted)
+        {
+            if (sorted == null || sorted.Count == 0)
+                return source.OrderBy(r => r.ResidentName);
+
+            IOrderedEnumerable<ResidentDirectoryRecord>? ordered = null;
+            foreach (var sort in sorted.Where(s => !string.IsNullOrWhiteSpace(s.Name)))
+            {
+                var descending = sort.Direction.Equals("descending", StringComparison.OrdinalIgnoreCase);
+                ordered = ordered == null
+                    ? descending
+                        ? source.OrderByDescending(row => ReadDirectorySortValue(row, sort.Name))
+                        : source.OrderBy(row => ReadDirectorySortValue(row, sort.Name))
+                    : descending
+                        ? ordered.ThenByDescending(row => ReadDirectorySortValue(row, sort.Name))
+                        : ordered.ThenBy(row => ReadDirectorySortValue(row, sort.Name));
+            }
+
+            return ordered ?? source.OrderBy(r => r.ResidentName);
+        }
+
+        private static List<ResidentDirectoryGridItem> GroupDirectoryRows(
+            List<ResidentDirectoryRecord> rows,
+            List<string> groupFields,
+            int level)
+        {
+            if (level >= groupFields.Count)
+                return rows.Select(ToGridItem).ToList();
+
+            var field = groupFields[level];
+            return rows
+                .GroupBy(row => ReadDirectoryText(row, field))
+                .OrderBy(group => group.Key)
+                .Select(group => new ResidentDirectoryGridItem
+                {
+                    Key = group.Key,
+                    Count = group.Count(),
+                    Field = field,
+                    Items = GroupDirectoryRows(group.ToList(), groupFields, level + 1)
+                })
+                .ToList();
+        }
+
+        private static object ReadDirectorySortValue(ResidentDirectoryRecord row, string field) =>
+            field switch
+            {
+                "residentId" => row.ResidentId,
+                "residentName" => row.ResidentName,
+                "age" => row.Age,
+                "careLevel" => row.CareLevel,
+                "wing" => row.Wing,
+                "suite" => row.Suite,
+                "riskLevel" => row.RiskLevel,
+                "primaryNurse" => row.PrimaryNurse,
+                "openTasks" => row.OpenTasks,
+                "nextReviewDate" => row.NextReviewDate,
+                _ => row.ResidentName
+            };
+
+        private static string ReadDirectoryText(ResidentDirectoryRecord row, string field) =>
+            field switch
+            {
+                "residentId" => row.ResidentId.ToString(),
+                "residentName" => row.ResidentName,
+                "age" => row.Age.ToString(),
+                "careLevel" => row.CareLevel,
+                "wing" => row.Wing,
+                "suite" => row.Suite,
+                "riskLevel" => row.RiskLevel,
+                "primaryNurse" => row.PrimaryNurse,
+                "openTasks" => row.OpenTasks.ToString(),
+                "nextReviewDate" => row.NextReviewDate.ToString("yyyy-MM-dd"),
+                _ => ""
+            };
+
+        private static string ToDisplayName(string field) =>
+            field switch
+            {
+                "careLevel" => "care level",
+                "riskLevel" => "risk level",
+                "wing" => "wing",
+                _ => field
+            };
+
+        private static ResidentDirectoryGridItem ToGridItem(ResidentDirectoryRecord row) =>
+            new ResidentDirectoryGridItem
+            {
+                ResidentId = row.ResidentId,
+                ResidentName = row.ResidentName,
+                Age = row.Age,
+                CareLevel = row.CareLevel,
+                Wing = row.Wing,
+                Suite = row.Suite,
+                RiskLevel = row.RiskLevel,
+                PrimaryNurse = row.PrimaryNurse,
+                OpenTasks = row.OpenTasks,
+                NextReviewDate = row.NextReviewDate.ToString("yyyy-MM-dd")
+            };
+
+        private static List<ResidentDirectoryRecord> GenerateResidentDirectory()
+        {
+            var names = new[]
+            {
+                "Amina Patel", "Grace Bennett", "Henry Liu", "Irene Morgan",
+                "Jonah Reed", "Katherine Ortiz", "Leo Simmons", "Mara Thompson",
+                "Noah Walsh", "Priya Shah", "Ruth Carter", "Samuel Diaz",
+                "Tara Novak", "Victor Chen", "Wendy Price", "Yara Ahmed"
+            };
+            var careLevels = new[] { "Independent", "Assisted Living", "Memory Care", "Skilled Nursing" };
+            var wings = new[] { "North", "East", "West", "South" };
+            var suites = new[] { "101", "112", "118", "205", "211", "301", "312", "401" };
+            var risks = new[] { "Low", "Moderate", "High" };
+            var nurses = new[] { "Nora Ellis", "Malik Stone", "Elena Ruiz", "Owen Park" };
+
+            var rows = new List<ResidentDirectoryRecord>();
+            for (var i = 0; i < 240; i++)
+            {
+                var careLevel = careLevels[i % careLevels.Length];
+                var wing = wings[(i / 2) % wings.Length];
+                var risk = risks[(i + (careLevel == "Memory Care" ? 1 : 0)) % risks.Length];
+                rows.Add(new ResidentDirectoryRecord(
+                    6000 + i,
+                    names[i % names.Length],
+                    67 + (i * 7 % 29),
+                    careLevel,
+                    wing,
+                    $"{wing[0]}-{suites[i % suites.Length]}",
+                    risk,
+                    nurses[i % nurses.Length],
+                    i * 3 % 8,
+                    new DateOnly(2026, 6, 1).AddDays(i % 21)));
+            }
+
+            return rows;
+        }
+
+        private static IActionResult ValidationError(Dictionary<string, string[]> errors) =>
+            new BadRequestObjectResult(new { errors });
+
+        private static bool TryValidate<T>(IValidator<T> validator, T model, out IActionResult error)
+        {
+            var result = validator.Validate(model);
+            if (result.IsValid)
+            {
+                error = null!;
+                return true;
+            }
+
+            var errors = new Dictionary<string, string[]>();
+            foreach (var failure in result.Errors)
+            {
+                if (!errors.TryGetValue(failure.PropertyName, out var existing))
+                    errors[failure.PropertyName] = [failure.ErrorMessage];
+                else
+                    errors[failure.PropertyName] = [.. existing, failure.ErrorMessage];
+            }
+
+            error = ValidationError(errors);
+            return false;
+        }
     }
 
     public class GridDataRequest
@@ -118,4 +556,59 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
         public string Name { get; set; } = "";
         public string Direction { get; set; } = "";
     }
+
+    public class ResidentDirectoryRequest
+    {
+        public int Skip { get; set; }
+        public int Take { get; set; }
+        public List<GridSortRequest>? Sorted { get; set; }
+        public List<string>? Group { get; set; }
+        public List<FusionGridTextFilterCriterion>? Where { get; set; }
+        public List<ResidentDirectorySearchRequest>? Search { get; set; }
+        public string? ResidentSearch { get; set; }
+        public string? CareLevel { get; set; }
+        public string? RiskLevel { get; set; }
+        public decimal? MinimumAge { get; set; }
+    }
+
+    public class ResidentDirectorySearchRequest
+    {
+        public List<string>? Fields { get; set; }
+        public string? Key { get; set; }
+        public string? Operator { get; set; }
+        public bool IgnoreCase { get; set; }
+    }
+
+    public class ResidentSelectionRequest
+    {
+        public int ResidentId { get; set; }
+        public int RowIndex { get; set; }
+    }
+
+    public class ResidentSelectionIndexesRequest
+    {
+        public List<int>? SelectedRowIndexes { get; set; }
+    }
+
+    public class ResidentSelectionRecordsRequest
+    {
+        public List<ResidentDirectoryGridItem>? SelectedRecords { get; set; }
+    }
+
+    public class ResidentGridBatchSummaryRequest
+    {
+        public FusionGridBatchChanges<ResidentDirectoryGridItem>? BatchChanges { get; set; }
+    }
+
+    public sealed record ResidentDirectoryRecord(
+        int ResidentId,
+        string ResidentName,
+        int Age,
+        string CareLevel,
+        string Wing,
+        string Suite,
+        string RiskLevel,
+        string PrimaryNurse,
+        int OpenTasks,
+        DateOnly NextReviewDate);
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ListBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ListBoxController.cs
@@ -1,0 +1,35 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionListBox")]
+    public sealed class ListBoxController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            ViewBag.Residents = new List<ListBoxResidentItem>
+            {
+                new() { Value = "alice", Text = "Alice", Unit = "A Wing" },
+                new() { Value = "bennett", Text = "Bennett", Unit = "A Wing" },
+                new() { Value = "carey", Text = "Carey", Unit = "B Wing" },
+                new() { Value = "dawson", Text = "Dawson", Unit = "B Wing" }
+            };
+
+            return View("~/Areas/Sandbox/Views/Components/Fusion/ListBox/Index.cshtml", new FusionListBoxModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionListBoxEchoRequest request)
+        {
+            var values = request.Value ?? [];
+            return Ok(new FusionListBoxEchoResponse
+            {
+                ValueSummary = string.Join(",", values),
+                CountSummary = values.Length.ToString()
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ListViewController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ListViewController.cs
@@ -1,0 +1,18 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionListView")]
+    public sealed class ListViewController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            ViewBag.Residents = new[] { "Alice", "Bennett", "Carey", "Dawson" };
+            ViewBag.Tasks = new[] { "Hydration", "Mobility", "Dining" };
+            return View("~/Areas/Sandbox/Views/Components/Fusion/ListView/Index.cshtml", new FusionListViewModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MenuController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/MenuController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Menu;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionMenu")]
+    public class MenuController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Menu/Index.cshtml",
+                new FusionMenuModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/OtpInputController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/OtpInputController.cs
@@ -1,0 +1,30 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/OtpInput")]
+    public class OtpInputController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/OtpInput/Index.cshtml", new OtpInputModel
+            {
+                Passcode = "1234",
+                AutoBlurCode = string.Empty
+            });
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] OtpInputEchoRequest request)
+        {
+            return Ok(new OtpInputEchoResponse
+            {
+                Passcode = request.Passcode,
+                Summary = "code:" + request.Passcode
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ProgressButtonController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ProgressButtonController.cs
@@ -1,0 +1,29 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionProgressButton")]
+    public sealed class ProgressButtonController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/ProgressButton/Index.cshtml", new FusionProgressButtonModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionProgressButtonEchoRequest request)
+        {
+            return Ok(new FusionProgressButtonEchoResponse
+            {
+                Content = request.Content,
+                Disabled = request.Disabled,
+                CssClass = request.CssClass,
+                ProgressEnabled = request.ProgressEnabled,
+                Summary = request.Content + ":" + request.Disabled + ":" + request.CssClass + ":" + request.ProgressEnabled
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/RadioButtonController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/RadioButtonController.cs
@@ -1,0 +1,29 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionRadioButton")]
+    public sealed class RadioButtonController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/RadioButton/Index.cshtml", new FusionRadioButtonModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionRadioButtonEchoRequest request)
+        {
+            return Ok(new FusionRadioButtonEchoResponse
+            {
+                SelectedValue = request.SelectedValue,
+                PrivateChecked = request.PrivateChecked,
+                SharedChecked = request.SharedChecked,
+                SharedDisabled = request.SharedDisabled,
+                Summary = request.SelectedValue + ":" + request.PrivateChecked + ":" + request.SharedChecked + ":" + request.SharedDisabled
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/RatingController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/RatingController.cs
@@ -1,0 +1,29 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/Rating")]
+    public class RatingController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/Rating/Index.cshtml", new RatingModel
+            {
+                SatisfactionScore = 2
+            });
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] RatingEchoRequest request)
+        {
+            return Ok(new RatingEchoResponse
+            {
+                SatisfactionScore = request.SatisfactionScore,
+                Summary = "score:" + request.SatisfactionScore
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SidebarController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SidebarController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Sidebar;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionSidebar")]
+    public class SidebarController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Sidebar/Index.cshtml",
+                new FusionSidebarModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SidebarController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SidebarController.cs
@@ -15,5 +15,18 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
                 "~/Areas/Sandbox/Views/Components/Fusion/Sidebar/Index.cshtml",
                 new FusionSidebarModel());
         }
+
+        [HttpPost("OpenPanel")]
+        public IActionResult OpenPanel([FromBody] FusionSidebarOpenRequest request)
+        {
+            var openMode = request.IsInteracted ? "user opened" : "workflow opened";
+
+            return Ok(new FusionSidebarOpenResponse
+            {
+                OpenMode = openMode,
+                PanelTitle = "Resident navigation",
+                Message = $"{openMode} resident navigation panel"
+            });
+        }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SliderController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SliderController.cs
@@ -1,0 +1,31 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/Slider")]
+    public class SliderController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/Slider/Index.cshtml", new SliderModel
+            {
+                PainScore = 25,
+                PreferredRange = [20, 60]
+            });
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] SliderEchoRequest request)
+        {
+            return Ok(new SliderEchoResponse
+            {
+                PainScore = request.PainScore,
+                PreferredRange = request.PreferredRange,
+                Summary = request.PainScore + ":" + string.Join(",", request.PreferredRange)
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SplitButtonController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/SplitButtonController.cs
@@ -1,0 +1,28 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionSplitButton")]
+    public sealed class SplitButtonController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/SplitButton/Index.cshtml", new FusionSplitButtonModel());
+        }
+
+        [HttpPost("Echo")]
+        public IActionResult Echo([FromBody] FusionSplitButtonEchoRequest request)
+        {
+            return Ok(new FusionSplitButtonEchoResponse
+            {
+                Content = request.Content,
+                Disabled = request.Disabled,
+                CssClass = request.CssClass,
+                Summary = request.Content + ":" + request.Disabled + ":" + request.CssClass
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/StepperController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/StepperController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionStepper")]
+    public class StepperController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml",
+                new FusionStepperModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/StepperController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/StepperController.cs
@@ -1,5 +1,7 @@
 using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Concurrent;
 
 namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
 {
@@ -7,13 +9,181 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
     [Route("Sandbox/Components/FusionStepper")]
     public class StepperController : Controller
     {
+        private const string ViewBase = "~/Areas/Sandbox/Views/Components/Fusion/Stepper/";
+
+        private static readonly ConcurrentDictionary<string, FusionStepperWizardIntakeModel> IntakeDrafts = new();
+        private static readonly ConcurrentDictionary<string, FusionStepperWizardCareModel> CareDrafts = new();
+        private static readonly ConcurrentDictionary<string, FusionStepperWizardContactModel> ContactDrafts = new();
+        private static readonly ConcurrentDictionary<string, FusionStepperWizardReviewModel> ReviewDrafts = new();
+
         [HttpGet("")]
         [HttpGet("Index")]
         public IActionResult Index()
         {
             return View(
-                "~/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml",
+                ViewBase + "Index.cshtml",
                 new FusionStepperModel());
+        }
+
+        [HttpGet("Wizard")]
+        public IActionResult Wizard()
+        {
+            return View(
+                ViewBase + "Wizard.cshtml",
+                new FusionStepperWizardShellModel { WizardId = NewWizardId() });
+        }
+
+        [HttpPost("Wizard/LoadStep")]
+        public IActionResult LoadWizardStep([FromBody] FusionStepperWizardLoadStepRequest request)
+        {
+            var wizardId = request.WizardId ?? NewWizardId();
+
+            return request.Step switch
+            {
+                1 => StepPartial("_WizardIntakeStep.cshtml", GetDraft(IntakeDrafts, wizardId) with { WizardId = wizardId }),
+                2 => StepPartial("_WizardCareStep.cshtml", BuildCareStep(wizardId)),
+                3 => StepPartial("_WizardContactStep.cshtml", GetDraft(ContactDrafts, wizardId) with { WizardId = wizardId }),
+                4 => StepPartial("_WizardReviewStep.cshtml", BuildReviewStep(wizardId)),
+                _ => BadRequest("Invalid wizard step")
+            };
+        }
+
+        [HttpPost("Wizard/SaveIntake")]
+        public IActionResult SaveIntake([FromBody] FusionStepperWizardIntakeModel model)
+        {
+            model = model with { WizardId = EnsureWizardId(model.WizardId) };
+            if (!TryValidate(new FusionStepperWizardIntakeValidator(), model, out var error)) return error;
+
+            IntakeDrafts[model.WizardId] = model;
+            return Ok(new FusionStepperWizardSaveResponse
+            {
+                WizardId = model.WizardId,
+                Message = $"Intake saved for {model.ResidentName}"
+            });
+        }
+
+        [HttpPost("Wizard/SaveCare")]
+        public IActionResult SaveCare([FromBody] FusionStepperWizardCareModel model)
+        {
+            model = model with { WizardId = EnsureWizardId(model.WizardId) };
+            if (!TryValidate(new FusionStepperWizardCareValidator(), model, out var error)) return error;
+
+            CareDrafts[model.WizardId] = model;
+            return Ok(new FusionStepperWizardSaveResponse
+            {
+                WizardId = model.WizardId,
+                Message = $"Care plan saved for {model.CareLevel}"
+            });
+        }
+
+        [HttpPost("Wizard/SaveContact")]
+        public IActionResult SaveContact([FromBody] FusionStepperWizardContactModel model)
+        {
+            model = model with { WizardId = EnsureWizardId(model.WizardId) };
+            if (!TryValidate(new FusionStepperWizardContactValidator(), model, out var error)) return error;
+
+            ContactDrafts[model.WizardId] = model;
+            return Ok(new FusionStepperWizardSaveResponse
+            {
+                WizardId = model.WizardId,
+                Message = $"Contact saved for {model.ResponsibleParty}"
+            });
+        }
+
+        [HttpPost("Wizard/Submit")]
+        public IActionResult SubmitWizard([FromBody] FusionStepperWizardReviewModel model)
+        {
+            model = model with { WizardId = EnsureWizardId(model.WizardId) };
+
+            var errors = new Dictionary<string, string[]>();
+            CollectErrors(new FusionStepperWizardReviewValidator().Validate(model), errors);
+
+            if (!IntakeDrafts.TryGetValue(model.WizardId, out var intake))
+                errors["ResidentName"] = ["Complete intake before submitting."];
+
+            if (!CareDrafts.TryGetValue(model.WizardId, out var care))
+                errors["CareLevel"] = ["Complete care planning before submitting."];
+
+            if (!ContactDrafts.TryGetValue(model.WizardId, out var contact))
+                errors["ResponsibleParty"] = ["Complete contacts before submitting."];
+
+            if (errors.Count > 0) return BadRequest(new { errors });
+
+            ReviewDrafts[model.WizardId] = model;
+            return Ok(new FusionStepperWizardSubmitResponse
+            {
+                WizardId = model.WizardId,
+                Message = $"Admission packet submitted for {intake!.ResidentName}",
+                CareSummary = $"{care!.CareLevel} / {care.PrimaryDiagnosis}",
+                ContactSummary = $"{contact!.ResponsibleParty} ({contact.Phone})"
+            });
+        }
+
+        private static string NewWizardId() => $"WIZ-{DateTime.UtcNow:yyyyMMddHHmmssffff}";
+
+        private static string EnsureWizardId(string? wizardId) =>
+            string.IsNullOrWhiteSpace(wizardId) ? NewWizardId() : wizardId;
+
+        private static T GetDraft<T>(ConcurrentDictionary<string, T> store, string wizardId) where T : new() =>
+            !string.IsNullOrEmpty(wizardId) && store.TryGetValue(wizardId, out var draft) ? draft : new T();
+
+        private static IActionResult ValidationError(Dictionary<string, string[]> errors) =>
+            new BadRequestObjectResult(new { errors });
+
+        private IActionResult StepPartial<T>(string view, T model) =>
+            PartialView(ViewBase + view, model);
+
+        private FusionStepperWizardCareModel BuildCareStep(string wizardId)
+        {
+            var model = GetDraft(CareDrafts, wizardId) with { WizardId = wizardId };
+            if (IntakeDrafts.TryGetValue(wizardId, out var intake) && string.IsNullOrWhiteSpace(model.ResidentName))
+                model = model with { ResidentName = intake.ResidentName };
+            return model;
+        }
+
+        private FusionStepperWizardReviewModel BuildReviewStep(string wizardId)
+        {
+            var intake = GetDraft(IntakeDrafts, wizardId);
+            var care = GetDraft(CareDrafts, wizardId);
+            var contact = GetDraft(ContactDrafts, wizardId);
+            var review = GetDraft(ReviewDrafts, wizardId);
+
+            return review with
+            {
+                WizardId = wizardId,
+                ResidentName = intake.ResidentName,
+                AdmissionType = intake.AdmissionType,
+                CareLevel = care.CareLevel,
+                PrimaryDiagnosis = care.PrimaryDiagnosis,
+                ResponsibleParty = contact.ResponsibleParty,
+                Phone = contact.Phone
+            };
+        }
+
+        private static bool TryValidate<T>(IValidator<T> validator, T model, out IActionResult error)
+        {
+            var result = validator.Validate(model);
+            if (result.IsValid)
+            {
+                error = null!;
+                return true;
+            }
+
+            var errors = new Dictionary<string, string[]>();
+            CollectErrors(result, errors);
+            error = ValidationError(errors);
+            return false;
+        }
+
+        private static void CollectErrors(FluentValidation.Results.ValidationResult result, Dictionary<string, string[]> errors)
+        {
+            foreach (var failure in result.Errors)
+            {
+                if (!errors.TryGetValue(failure.PropertyName, out var existing))
+                    errors[failure.PropertyName] = [failure.ErrorMessage];
+                else
+                    errors[failure.PropertyName] = [.. existing, failure.ErrorMessage];
+            }
         }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/TextAreaController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/TextAreaController.cs
@@ -1,0 +1,16 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/TextArea")]
+    public class TextAreaController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/TextArea/Index.cshtml", new TextAreaModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/TextBoxController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/TextBoxController.cs
@@ -1,0 +1,16 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/TextBox")]
+    public class TextBoxController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View("~/Areas/Sandbox/Views/Components/Fusion/TextBox/Index.cshtml", new TextBoxModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ToolbarController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ToolbarController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Toolbar;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/FusionToolbar")]
+    public class ToolbarController : Controller
+    {
+        [HttpGet("")]
+        [HttpGet("Index")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/Toolbar/Index.cshtml",
+                new FusionToolbarModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Breadcrumb/FusionBreadcrumbModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Breadcrumb/FusionBreadcrumbModel.cs
@@ -6,4 +6,19 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
     public sealed class FusionBreadcrumbModel
     {
     }
+
+    public sealed class FusionBreadcrumbRouteRequest
+    {
+        public string Text { get; set; } = "";
+        public string Id { get; set; } = "";
+        public string Url { get; set; } = "";
+        public bool Disabled { get; set; }
+    }
+
+    public sealed class FusionBreadcrumbRouteResponse
+    {
+        public string Message { get; set; } = "";
+        public string RouteCategory { get; set; } = "";
+        public string Trail { get; set; } = "";
+    }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Breadcrumb/FusionBreadcrumbModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Breadcrumb/FusionBreadcrumbModel.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>
+    /// Model for the FusionBreadcrumb sandbox demo.
+    /// </summary>
+    public sealed class FusionBreadcrumbModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/BulletChart/BulletChartModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/BulletChart/BulletChartModel.cs
@@ -6,4 +6,18 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Bullet
     public sealed class FusionBulletChartModel
     {
     }
+
+    public sealed class FusionBulletChartClickAuditRequest
+    {
+        public string Target { get; set; } = "";
+        public double X { get; set; }
+        public double Y { get; set; }
+    }
+
+    public sealed class FusionBulletChartClickAuditResponse
+    {
+        public string Message { get; set; } = "";
+        public string Wing { get; set; } = "";
+        public string Coordinates { get; set; } = "";
+    }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/BulletChart/BulletChartModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/BulletChart/BulletChartModel.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart
+{
+    /// <summary>
+    /// Model for the FusionBulletChart sandbox demo.
+    /// </summary>
+    public sealed class FusionBulletChartModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/BulletChart/BulletChartPoint.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/BulletChart/BulletChartPoint.cs
@@ -1,0 +1,14 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart
+{
+    /// <summary>
+    /// Bullet chart data row for the sandbox demo.
+    /// </summary>
+    public sealed class BulletChartPoint
+    {
+        public string Category { get; set; } = string.Empty;
+
+        public int Value { get; set; }
+
+        public int Target { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Button/ButtonModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Button/ButtonModel.cs
@@ -1,0 +1,34 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class ButtonModel
+    {
+    }
+
+    public sealed class ButtonEchoRequest
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+
+        public bool IsPrimary { get; set; }
+
+        public bool IsToggle { get; set; }
+    }
+
+    public sealed class ButtonEchoResponse
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+
+        public bool IsPrimary { get; set; }
+
+        public bool IsToggle { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Carousel/FusionCarouselModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Carousel/FusionCarouselModel.cs
@@ -6,4 +6,18 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
     public sealed class FusionCarouselModel
     {
     }
+
+    public sealed class FusionCarouselAuditRequest
+    {
+        public int CurrentIndex { get; set; }
+        public int PreviousIndex { get; set; }
+        public string SlideDirection { get; set; } = "";
+    }
+
+    public sealed class FusionCarouselAuditResponse
+    {
+        public string Message { get; set; } = "";
+        public string Section { get; set; } = "";
+        public string Direction { get; set; } = "";
+    }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Carousel/FusionCarouselModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Carousel/FusionCarouselModel.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>
+    /// Model for the FusionCarousel sandbox demo.
+    /// </summary>
+    public sealed class FusionCarouselModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/CheckBox/FusionCheckBoxModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/CheckBox/FusionCheckBoxModel.cs
@@ -1,0 +1,29 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionCheckBoxModel
+    {
+        public bool ConsentAccepted { get; set; }
+
+        public bool ReviewNeeded { get; set; }
+    }
+
+    public sealed class FusionCheckBoxEchoRequest
+    {
+        public bool Checked { get; set; }
+
+        public bool Indeterminate { get; set; }
+
+        public bool Disabled { get; set; }
+    }
+
+    public sealed class FusionCheckBoxEchoResponse
+    {
+        public bool Checked { get; set; }
+
+        public bool Indeterminate { get; set; }
+
+        public bool Disabled { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ComboBox/FusionComboBoxModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ComboBox/FusionComboBoxModel.cs
@@ -1,0 +1,36 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionComboBoxModel
+    {
+        public string? Resident { get; set; }
+    }
+
+    public sealed class ComboBoxResidentItem
+    {
+        public string Value { get; set; } = string.Empty;
+
+        public string Text { get; set; } = string.Empty;
+
+        public string Unit { get; set; } = string.Empty;
+    }
+
+    public sealed class FusionComboBoxEchoRequest
+    {
+        public string? Value { get; set; }
+
+        public string? Text { get; set; }
+
+        public int Index { get; set; }
+    }
+
+    public sealed class FusionComboBoxEchoResponse
+    {
+        public string? Value { get; set; }
+
+        public string? Text { get; set; }
+
+        public int Index { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ContextMenu/FusionContextMenuModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ContextMenu/FusionContextMenuModel.cs
@@ -1,0 +1,12 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.ContextMenu
+{
+    /// <summary>
+    /// Model for the FusionContextMenu sandbox demo.
+    /// </summary>
+    public sealed class FusionContextMenuModel
+    {
+        public bool BlockOpen { get; set; }
+
+        public bool BlockClose { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/DropDownButton/FusionDropDownButtonModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/DropDownButton/FusionDropDownButtonModel.cs
@@ -1,0 +1,26 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionDropDownButtonModel
+    {
+    }
+
+    public sealed class FusionDropDownButtonEchoRequest
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+    }
+
+    public sealed class FusionDropDownButtonEchoResponse
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/DropDownTree/FusionDropDownTreeModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/DropDownTree/FusionDropDownTreeModel.cs
@@ -1,0 +1,36 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionDropDownTreeModel
+    {
+        public string[]? ResidentIds { get; set; }
+    }
+
+    public sealed class DropDownTreeResidentNode
+    {
+        public string Value { get; set; } = string.Empty;
+
+        public string Text { get; set; } = string.Empty;
+
+        public string? ParentValue { get; set; }
+
+        public bool HasChildren { get; set; }
+
+        public bool Expanded { get; set; }
+    }
+
+    public sealed class FusionDropDownTreeEchoRequest
+    {
+        public string[]? Value { get; set; }
+
+        public string? Text { get; set; }
+    }
+
+    public sealed class FusionDropDownTreeEchoResponse
+    {
+        public string ValueSummary { get; set; } = string.Empty;
+
+        public string? Text { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/BillingModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/BillingModel.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using Alis.Reactive.FluentValidator;
+using Alis.Reactive.Fusion.Components;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>
+    /// Page model for the resident month-end billing board.
+    /// Carries the server-side filter panel inputs plus the templated "Add charge" dialog inputs.
+    /// </summary>
+    public class ResidentBillingViewModel
+    {
+        public string? FilterCareLevel { get; set; }
+        public string? FilterWing { get; set; }
+        public string? FilterStatus { get; set; }
+
+        public string? NewResidentName { get; set; }
+        public string? NewCareLevel { get; set; }
+        public decimal? NewMonthlyRate { get; set; }
+        public decimal? NewAddOnCharges { get; set; }
+    }
+
+    /// <summary>
+    /// One resident's monthly billing row. Used both as the server store record and the grid DTO.
+    /// </summary>
+    public class ResidentBillingItem
+    {
+        public int ResidentId { get; set; }
+        public string ResidentName { get; set; } = "";
+        public string CareLevel { get; set; } = "";
+        public string Wing { get; set; } = "";
+        public decimal MonthlyRate { get; set; }
+        public decimal AddOnCharges { get; set; }
+        public decimal BalanceDue { get; set; }
+        public string BillingStatus { get; set; } = "";
+    }
+
+    /// <summary>Server-side billing response. SF Grid custom binding expects {result, count}.</summary>
+    public class ResidentBillingResponse
+    {
+        public List<ResidentBillingItem> Result { get; set; } = new();
+        public int Count { get; set; }
+        public string Summary { get; set; } = "";
+    }
+
+    /// <summary>One-row response for the templated dialog add and per-row server patches.</summary>
+    public class ResidentBillingRowResponse
+    {
+        public ResidentBillingItem Row { get; set; } = new ResidentBillingItem();
+        public string Summary { get; set; } = "";
+    }
+
+    public class BillingDataRequest
+    {
+        public int Skip { get; set; }
+        public int Take { get; set; }
+        public List<GridSortRequest>? Sorted { get; set; }
+        public List<string>? Group { get; set; }
+        public string? FilterCareLevel { get; set; }
+        public string? FilterWing { get; set; }
+        public string? FilterStatus { get; set; }
+    }
+
+    public class BillingBulkRequest
+    {
+        public List<ResidentBillingItem>? SelectedRecords { get; set; }
+        public decimal? Percent { get; set; }
+    }
+
+    public class BillingSaveRequest
+    {
+        public FusionGridBatchChanges<ResidentBillingItem>? BatchChanges { get; set; }
+    }
+
+    /// <summary>
+    /// Client + server validation for the templated "Add charge" dialog.
+    /// Only the New* fields participate; the filter inputs are untouched.
+    /// </summary>
+    public class ResidentBillingAddValidator : ReactiveValidator<ResidentBillingViewModel>
+    {
+        public ResidentBillingAddValidator()
+        {
+            ClientRule(x => x.NewResidentName)
+                .Required("Resident name is required.");
+
+            ClientRule(x => x.NewResidentName)
+                .MinLength(3, "Resident name must be at least 3 characters.");
+
+            ClientRule(x => x.NewCareLevel)
+                .Required("Care level is required.");
+
+            ClientRule(x => x.NewMonthlyRate)
+                .Required("Monthly rate is required.");
+
+            ClientRule(x => x.NewMonthlyRate)
+                .Range(0m, 20000m, "Monthly rate must be between 0 and 20,000.");
+
+            ClientRule(x => x.NewAddOnCharges)
+                .Required("Add-on charges are required.");
+
+            ClientRule(x => x.NewAddOnCharges)
+                .Range(0m, 5000m, "Add-on charges must be between 0 and 5,000.");
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/CareOpsModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/CareOpsModel.cs
@@ -87,4 +87,18 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
                 .Range(0m, 12m, "Open tasks must be between 0 and 12.");
         }
     }
+
+    /// <summary>
+    /// Client + server validation for an in-cell care row edit. The same
+    /// <c>ClientRule</c> metadata drives EJ2-native column validation in the grid
+    /// (via <c>FusionGridValidation</c>) and a full server check on save.
+    /// </summary>
+    public class ResidentCareItemValidator : ReactiveValidator<ResidentCareItem>
+    {
+        public ResidentCareItemValidator()
+        {
+            ClientRule(r => r.OpenTasks)
+                .Range(0, 7, "Open tasks must be between 0 and 7.");
+        }
+    }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/CareOpsModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/CareOpsModel.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Alis.Reactive.FluentValidator;
+using Alis.Reactive.Fusion.Components;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>
+    /// Page model for the Care Operations board. Carries the templated "Admit resident"
+    /// dialog inputs. Fast filters come from chips, so no filter fields live here.
+    /// </summary>
+    public class CareOpsViewModel
+    {
+        public string? NewResidentName { get; set; }
+        public string? NewWing { get; set; }
+        public string? NewCareLevel { get; set; }
+        public string? NewRiskLevel { get; set; }
+        public decimal? NewOpenTasks { get; set; }
+    }
+
+    /// <summary>One resident's care row. Server store record and grid DTO.</summary>
+    public class ResidentCareItem
+    {
+        public int ResidentId { get; set; }
+        public string ResidentName { get; set; } = "";
+        public string Wing { get; set; } = "";
+        public string CareLevel { get; set; } = "";
+        public string RiskLevel { get; set; } = "";
+        public string PrimaryNurse { get; set; } = "";
+        public int OpenTasks { get; set; }
+        public string NextReview { get; set; } = "";
+    }
+
+    /// <summary>Server-side care response. SF Grid custom binding expects {result, count}.</summary>
+    public class CareOpsResponse
+    {
+        public List<ResidentCareItem> Result { get; set; } = new();
+        public int Count { get; set; }
+        public string Summary { get; set; } = "";
+    }
+
+    public class CareOpsDataRequest
+    {
+        public int Skip { get; set; }
+        public int Take { get; set; }
+        public List<GridSortRequest>? Sorted { get; set; }
+        public string? FilterRisk { get; set; }
+        public string? FilterCareLevel { get; set; }
+    }
+
+    public class CareOpsBulkRequest
+    {
+        public List<ResidentCareItem>? SelectedRecords { get; set; }
+        public string? Nurse { get; set; }
+        public string? Risk { get; set; }
+    }
+
+    public class CareOpsSaveRequest
+    {
+        public FusionGridBatchChanges<ResidentCareItem>? BatchChanges { get; set; }
+    }
+
+    /// <summary>Client + server validation for the templated "Admit resident" dialog.</summary>
+    public class CareOpsAdmitValidator : ReactiveValidator<CareOpsViewModel>
+    {
+        public CareOpsAdmitValidator()
+        {
+            ClientRule(x => x.NewResidentName)
+                .Required("Resident name is required.");
+
+            ClientRule(x => x.NewResidentName)
+                .MinLength(3, "Resident name must be at least 3 characters.");
+
+            ClientRule(x => x.NewWing)
+                .Required("Wing is required.");
+
+            ClientRule(x => x.NewCareLevel)
+                .Required("Care level is required.");
+
+            ClientRule(x => x.NewRiskLevel)
+                .Required("Risk level is required.");
+
+            ClientRule(x => x.NewOpenTasks)
+                .Required("Open tasks is required.");
+
+            ClientRule(x => x.NewOpenTasks)
+                .Range(0m, 12m, "Open tasks must be between 0 and 12.");
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/GridModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/GridModel.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Alis.Reactive.FluentValidator;
+using FluentValidation;
 
 namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
 {
@@ -23,5 +25,88 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
     {
         public List<ResidentGridItem> Result { get; set; } = new();
         public int Count { get; set; }
+    }
+
+    public class ResidentDirectoryModel
+    {
+        public string? ResidentSearch { get; set; }
+        public string? CareLevel { get; set; }
+        public string? RiskLevel { get; set; }
+        public decimal? MinimumAge { get; set; }
+    }
+
+    public class ResidentDirectoryGridItem
+    {
+        public int ResidentId { get; set; }
+        public string ResidentName { get; set; } = "";
+        public int Age { get; set; }
+        public string CareLevel { get; set; } = "";
+        public string Wing { get; set; } = "";
+        public string Suite { get; set; } = "";
+        public string RiskLevel { get; set; } = "";
+        public string PrimaryNurse { get; set; } = "";
+        public int OpenTasks { get; set; }
+        public string NextReviewDate { get; set; } = "";
+
+        public string? Key { get; set; }
+        public int Count { get; set; }
+        public List<ResidentDirectoryGridItem>? Items { get; set; }
+        public string? Field { get; set; }
+    }
+
+    public class ResidentDirectoryResponse
+    {
+        public List<ResidentDirectoryGridItem> Result { get; set; } = new();
+        public int Count { get; set; }
+        public string Summary { get; set; } = "";
+    }
+
+    public class ResidentDirectorySelectionResponse
+    {
+        public string Summary { get; set; } = "";
+        public string ResidentName { get; set; } = "";
+    }
+
+    public class ResidentGridEditingModel
+    {
+        public string? ResidentName { get; set; }
+        public string? RiskLevel { get; set; }
+        public decimal? OpenTasks { get; set; }
+    }
+
+    public class ResidentGridEditResponse
+    {
+        public ResidentDirectoryGridItem Row { get; set; } = new ResidentDirectoryGridItem();
+        public string Summary { get; set; } = "";
+    }
+
+    public class ResidentGridBatchSummaryResponse
+    {
+        public string Summary { get; set; } = "";
+    }
+
+    public class ResidentGridEditingValidator : ReactiveValidator<ResidentGridEditingModel>
+    {
+        public ResidentGridEditingValidator()
+        {
+            ClientRule(x => x.ResidentName)
+                .Required("Resident name is required.");
+
+            ClientRule(x => x.ResidentName)
+                .MinLength(3, "Resident name must be at least 3 characters.");
+
+            ClientRule(x => x.RiskLevel)
+                .Required("Risk level is required.");
+
+            RuleFor(x => x.RiskLevel)
+                .Must(value => value is "Low" or "Moderate" or "High")
+                .WithMessage("Risk level must be Low, Moderate, or High.");
+
+            ClientRule(x => x.OpenTasks)
+                .Required("Open tasks is required.");
+
+            ClientRule(x => x.OpenTasks)
+                .Range(0m, 7m, "Open tasks must be between 0 and 7.");
+        }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/GridModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Grid/GridModel.cs
@@ -74,7 +74,19 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
         public decimal? OpenTasks { get; set; }
     }
 
+    public class GridOperationsModel
+    {
+        public string? PatchRiskLevel { get; set; }
+        public decimal? PatchOpenTasks { get; set; }
+    }
+
     public class ResidentGridEditResponse
+    {
+        public ResidentDirectoryGridItem Row { get; set; } = new ResidentDirectoryGridItem();
+        public string Summary { get; set; } = "";
+    }
+
+    public class ResidentGridOperationsResponse
     {
         public ResidentDirectoryGridItem Row { get; set; } = new ResidentDirectoryGridItem();
         public string Summary { get; set; } = "";
@@ -83,6 +95,11 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
     public class ResidentGridBatchSummaryResponse
     {
         public string Summary { get; set; } = "";
+    }
+
+    public class GridTemplateActionPayload
+    {
+        public int Id { get; set; }
     }
 
     public class ResidentGridEditingValidator : ReactiveValidator<ResidentGridEditingModel>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ListBox/FusionListBoxModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ListBox/FusionListBoxModel.cs
@@ -1,0 +1,27 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionListBoxModel
+    {
+    }
+
+    public sealed class ListBoxResidentItem
+    {
+        public string Value { get; set; } = string.Empty;
+
+        public string Text { get; set; } = string.Empty;
+
+        public string Unit { get; set; } = string.Empty;
+    }
+
+    public sealed class FusionListBoxEchoRequest
+    {
+        public string[]? Value { get; set; }
+    }
+
+    public sealed class FusionListBoxEchoResponse
+    {
+        public string ValueSummary { get; set; } = string.Empty;
+
+        public string CountSummary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ListView/FusionListViewModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ListView/FusionListViewModel.cs
@@ -1,0 +1,6 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionListViewModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Menu/FusionMenuModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Menu/FusionMenuModel.cs
@@ -1,0 +1,12 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Menu
+{
+    /// <summary>
+    /// Model for the FusionMenu sandbox demo.
+    /// </summary>
+    public sealed class FusionMenuModel
+    {
+        public bool BlockOpen { get; set; }
+
+        public bool BlockClose { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/OtpInput/OtpInputModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/OtpInput/OtpInputModel.cs
@@ -1,0 +1,21 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public class OtpInputModel
+    {
+        public string? Passcode { get; set; }
+
+        public string? AutoBlurCode { get; set; }
+    }
+
+    public sealed class OtpInputEchoRequest
+    {
+        public string? Passcode { get; set; }
+    }
+
+    public sealed class OtpInputEchoResponse
+    {
+        public string? Passcode { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ProgressButton/FusionProgressButtonModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/ProgressButton/FusionProgressButtonModel.cs
@@ -1,0 +1,30 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionProgressButtonModel
+    {
+    }
+
+    public sealed class FusionProgressButtonEchoRequest
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+
+        public bool ProgressEnabled { get; set; }
+    }
+
+    public sealed class FusionProgressButtonEchoResponse
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+
+        public bool ProgressEnabled { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/RadioButton/FusionRadioButtonModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/RadioButton/FusionRadioButtonModel.cs
@@ -1,0 +1,31 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionRadioButtonModel
+    {
+        public string RoomType { get; set; } = string.Empty;
+    }
+
+    public sealed class FusionRadioButtonEchoRequest
+    {
+        public string SelectedValue { get; set; } = string.Empty;
+
+        public bool PrivateChecked { get; set; }
+
+        public bool SharedChecked { get; set; }
+
+        public bool SharedDisabled { get; set; }
+    }
+
+    public sealed class FusionRadioButtonEchoResponse
+    {
+        public string SelectedValue { get; set; } = string.Empty;
+
+        public bool PrivateChecked { get; set; }
+
+        public bool SharedChecked { get; set; }
+
+        public bool SharedDisabled { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Rating/RatingModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Rating/RatingModel.cs
@@ -1,0 +1,19 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public class RatingModel
+    {
+        public double SatisfactionScore { get; set; }
+    }
+
+    public sealed class RatingEchoRequest
+    {
+        public double SatisfactionScore { get; set; }
+    }
+
+    public sealed class RatingEchoResponse
+    {
+        public double SatisfactionScore { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Sidebar/FusionSidebarModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Sidebar/FusionSidebarModel.cs
@@ -6,4 +6,16 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Sideba
     public sealed class FusionSidebarModel
     {
     }
+
+    public sealed class FusionSidebarOpenRequest
+    {
+        public bool IsInteracted { get; set; }
+    }
+
+    public sealed class FusionSidebarOpenResponse
+    {
+        public string Message { get; set; } = "";
+        public string PanelTitle { get; set; } = "";
+        public string OpenMode { get; set; } = "";
+    }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Sidebar/FusionSidebarModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Sidebar/FusionSidebarModel.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Sidebar
+{
+    /// <summary>
+    /// Model for the FusionSidebar sandbox demo.
+    /// </summary>
+    public sealed class FusionSidebarModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Slider/SliderModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Slider/SliderModel.cs
@@ -1,0 +1,25 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public class SliderModel
+    {
+        public double PainScore { get; set; }
+
+        public double[] PreferredRange { get; set; } = [];
+    }
+
+    public sealed class SliderEchoRequest
+    {
+        public double PainScore { get; set; }
+
+        public double[] PreferredRange { get; set; } = [];
+    }
+
+    public sealed class SliderEchoResponse
+    {
+        public double PainScore { get; set; }
+
+        public double[] PreferredRange { get; set; } = [];
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/SplitButton/FusionSplitButtonModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/SplitButton/FusionSplitButtonModel.cs
@@ -1,0 +1,26 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public sealed class FusionSplitButtonModel
+    {
+    }
+
+    public sealed class FusionSplitButtonEchoRequest
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+    }
+
+    public sealed class FusionSplitButtonEchoResponse
+    {
+        public string Content { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; }
+
+        public string CssClass { get; set; } = string.Empty;
+
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Stepper/FusionStepperModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Stepper/FusionStepperModel.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
+{
+    /// <summary>
+    /// Model for the FusionStepper sandbox demo.
+    /// </summary>
+    public sealed class FusionStepperModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Stepper/FusionStepperWizardModels.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Stepper/FusionStepperWizardModels.cs
@@ -1,0 +1,152 @@
+using Alis.Reactive.FluentValidator;
+using FluentValidation;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
+{
+    public sealed record FusionStepperWizardShellModel
+    {
+        public string? WizardId { get; init; }
+    }
+
+    public sealed record FusionStepperWizardLoadStepRequest
+    {
+        public string? WizardId { get; init; }
+        public int Step { get; init; }
+    }
+
+    public sealed record FusionStepperWizardIntakeModel
+    {
+        public string? WizardId { get; init; }
+        public string? ResidentName { get; init; }
+        public decimal? Age { get; init; }
+        public string? AdmissionType { get; init; }
+    }
+
+    public sealed record FusionStepperWizardCareModel
+    {
+        public string? WizardId { get; init; }
+        public string? ResidentName { get; init; }
+        public string? CareLevel { get; init; }
+        public string? PrimaryDiagnosis { get; init; }
+        public string? MemoryAssessment { get; init; }
+        public decimal? FallRiskScore { get; init; }
+    }
+
+    public sealed record FusionStepperWizardContactModel
+    {
+        public string? WizardId { get; init; }
+        public string? ResponsibleParty { get; init; }
+        public string? Phone { get; init; }
+        public string? Email { get; init; }
+    }
+
+    public sealed record FusionStepperWizardReviewModel
+    {
+        public string? WizardId { get; init; }
+        public string? ResidentName { get; init; }
+        public string? AdmissionType { get; init; }
+        public string? CareLevel { get; init; }
+        public string? PrimaryDiagnosis { get; init; }
+        public string? ResponsibleParty { get; init; }
+        public string? Phone { get; init; }
+        public string? AdmissionCoordinator { get; init; }
+    }
+
+    public sealed record FusionStepperWizardSaveResponse
+    {
+        public string WizardId { get; init; } = "";
+        public string Message { get; init; } = "";
+    }
+
+    public sealed record FusionStepperWizardSubmitResponse
+    {
+        public string WizardId { get; init; } = "";
+        public string Message { get; init; } = "";
+        public string CareSummary { get; init; } = "";
+        public string ContactSummary { get; init; } = "";
+    }
+
+    public sealed class FusionStepperWizardIntakeValidator : ReactiveValidator<FusionStepperWizardIntakeModel>
+    {
+        public FusionStepperWizardIntakeValidator()
+        {
+            RuleFor(x => x.ResidentName).NotEmpty().MinimumLength(2);
+            ClientRule(x => x.ResidentName)
+                .Required("'Resident Name' is required.")
+                .MinLength(2, "'Resident Name' must have a minimum length of 2.");
+
+            RuleFor(x => x.Age).NotNull().InclusiveBetween(55m, 120m);
+            ClientRule(x => x.Age)
+                .Required("'Age' is required.")
+                .GreaterThanOrEqualTo(55m, "'Age' must be at least 55.")
+                .LessThanOrEqualTo(120m, "'Age' must be at most 120.");
+
+            RuleFor(x => x.AdmissionType).NotEmpty();
+            ClientRule(x => x.AdmissionType)
+                .Required("'Admission Type' is required.");
+        }
+    }
+
+    public sealed class FusionStepperWizardCareValidator : ReactiveValidator<FusionStepperWizardCareModel>
+    {
+        public FusionStepperWizardCareValidator()
+        {
+            RuleFor(x => x.CareLevel).NotEmpty();
+            ClientRule(x => x.CareLevel)
+                .Required("'Care Level' is required.");
+
+            RuleFor(x => x.PrimaryDiagnosis).NotEmpty();
+            ClientRule(x => x.PrimaryDiagnosis)
+                .Required("'Primary Diagnosis' is required.");
+
+            RuleFor(x => x.FallRiskScore).NotNull().InclusiveBetween(0m, 10m);
+            ClientRule(x => x.FallRiskScore)
+                .Required("'Fall Risk Score' is required.")
+                .GreaterThanOrEqualTo(0m, "'Fall Risk Score' must be at least 0.")
+                .LessThanOrEqualTo(10m, "'Fall Risk Score' must be at most 10.");
+
+            When(x => x.CareLevel == "Memory Care", () =>
+            {
+                RuleFor(x => x.MemoryAssessment).NotEmpty();
+            });
+
+            WhenField(x => x.CareLevel, "Memory Care", () =>
+            {
+                ClientRule(x => x.MemoryAssessment)
+                    .Required("'Memory Assessment' is required for Memory Care.");
+            });
+        }
+    }
+
+    public sealed class FusionStepperWizardContactValidator : ReactiveValidator<FusionStepperWizardContactModel>
+    {
+        public FusionStepperWizardContactValidator()
+        {
+            RuleFor(x => x.ResponsibleParty).NotEmpty().MinimumLength(2);
+            ClientRule(x => x.ResponsibleParty)
+                .Required("'Responsible Party' is required.")
+                .MinLength(2, "'Responsible Party' must have a minimum length of 2.");
+
+            RuleFor(x => x.Phone).NotEmpty().Matches(@"^\d{3}-\d{3}-\d{4}$");
+            ClientRule(x => x.Phone)
+                .Required("'Phone' is required.")
+                .Regex(@"^\d{3}-\d{3}-\d{4}$", "'Phone' must match 123-456-7890.");
+
+            RuleFor(x => x.Email).NotEmpty().EmailAddress();
+            ClientRule(x => x.Email)
+                .Required("'Email' is required.")
+                .Email("'Email' must be a valid email address.");
+        }
+    }
+
+    public sealed class FusionStepperWizardReviewValidator : ReactiveValidator<FusionStepperWizardReviewModel>
+    {
+        public FusionStepperWizardReviewValidator()
+        {
+            RuleFor(x => x.AdmissionCoordinator).NotEmpty().MinimumLength(2);
+            ClientRule(x => x.AdmissionCoordinator)
+                .Required("'Admission Coordinator' is required.")
+                .MinLength(2, "'Admission Coordinator' must have a minimum length of 2.");
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Stepper/FusionStepperWizardModels.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Stepper/FusionStepperWizardModels.cs
@@ -6,6 +6,7 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Steppe
     public sealed record FusionStepperWizardShellModel
     {
         public string? WizardId { get; init; }
+        public string MaxUnlockedStep { get; init; } = "0";
     }
 
     public sealed record FusionStepperWizardLoadStepRequest

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/TextArea/TextAreaModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/TextArea/TextAreaModel.cs
@@ -1,0 +1,8 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public class TextAreaModel
+    {
+        public string? CareNote { get; set; }
+        public string? AutoBlurNote { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/TextBox/TextBoxModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/TextBox/TextBoxModel.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    public class TextBoxModel
+    {
+        public string? ResidentName { get; set; }
+        public string? SearchNote { get; set; }
+        public string? AutoBlurNote { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Toolbar/FusionToolbarModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/Components/Fusion/Toolbar/FusionToolbarModel.cs
@@ -1,0 +1,9 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Toolbar
+{
+    /// <summary>
+    /// Model for the FusionToolbar sandbox demo.
+    /// </summary>
+    public sealed class FusionToolbarModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml
@@ -1,0 +1,86 @@
+@model FusionBreadcrumbModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionBreadcrumb";
+
+    const string BreadcrumbId = "navigation-breadcrumb";
+
+    var plan = Html.ReactivePlan<FusionBreadcrumbModel>();
+    var items = new List<BreadcrumbItem>
+    {
+        new() { Text = "Home", Id = "home", Url = "/home" },
+        new() { Text = "Docs", Id = "docs", Url = "/docs" },
+        new() { Text = "Guide", Id = "guide", Url = "/docs/guide" }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var breadcrumb = p.Component<FusionBreadcrumb>(BreadcrumbId);
+        p.Element("active-item-echo").SetText(breadcrumb.ActiveItem());
+
+        p.When(breadcrumb.ActiveItem()).NotEmpty()
+            .Then(t => t.Element("active-state").SetText("has active item"))
+            .Else(e => e.Element("active-state").SetText("empty"));
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionBreadcrumb</native-heading>
+    <native-text color="Secondary">
+        Navigation component. Exercises the typed active-item source, active-item setter, and item-click payload reads.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Breadcrumb</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            The breadcrumb starts with Docs active. Click Home or Docs, or set Guide programmatically.
+        </p>
+
+        @(Html.FusionBreadcrumb(plan, BreadcrumbId, b =>
+        {
+            b.Items(items);
+            b.ActiveItem("/docs");
+            b.EnableNavigation(false);
+            b.OverflowMode(BreadcrumbOverflowMode.None);
+        })
+        .Reactive(evt => evt.ItemClick, (args, p) =>
+        {
+            p.Element("clicked-text").SetText(args, x => x.Item.Text);
+            p.Element("clicked-url").SetText(args, x => x.Item.Url);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Commands</native-heading>
+        <native-hstack gap="Sm" class="flex-wrap">
+            @(Html.NativeButton("set-guide-btn", "Set Guide Active")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var breadcrumb = p.Component<FusionBreadcrumb>(BreadcrumbId);
+                    breadcrumb.SetActiveItem("/docs/guide");
+                    p.Element("active-item-echo").SetText(breadcrumb.ActiveItem());
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Active item source: <span id="active-item-echo" class="text-text-muted">pending</span></p>
+            <p>Active item state: <span id="active-state" class="text-text-muted">pending</span></p>
+            <p>Clicked text: <span id="clicked-text" class="text-text-muted">pending</span></p>
+            <p>Clicked url: <span id="clicked-url" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml
@@ -7,6 +7,8 @@
     ViewData["Title"] = "FusionBreadcrumb";
 
     const string BreadcrumbId = "navigation-breadcrumb";
+    var routeUrl = Url.Action("Route", "Breadcrumb", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Breadcrumb.Route.");
 
     var plan = Html.ReactivePlan<FusionBreadcrumbModel>();
     var items = new List<BreadcrumbItem>
@@ -53,6 +55,18 @@
             p.Element("clicked-url").SetText(args, x => x.Item.Url);
             p.Element("clicked-icon-css").SetText(args, x => x.Item.IconCss);
             p.Element("clicked-disabled").SetText(args, x => x.Item.Disabled);
+            p.Post(routeUrl)
+                .Gather(g => g
+                    .FromEvent(args, x => x.Item.Text, "text")
+                    .FromEvent(args, x => x.Item.Id, "id")
+                    .FromEvent(args, x => x.Item.Url, "url")
+                    .FromEvent(args, x => x.Item.Disabled, "disabled"))
+                .Response(r => r.OnSuccess<FusionBreadcrumbRouteResponse>((json, s) =>
+                {
+                    s.Element("route-message").SetText(json, x => x.Message);
+                    s.Element("route-category").SetText(json, x => x.RouteCategory);
+                    s.Element("route-trail").SetText(json, x => x.Trail);
+                }));
         }))
     </native-card-body></native-card>
 
@@ -80,6 +94,9 @@
             <p>Clicked url: <span id="clicked-url" class="text-text-muted">pending</span></p>
             <p>Clicked icon CSS: <span id="clicked-icon-css" class="text-text-muted">pending</span></p>
             <p>Clicked disabled: <span id="clicked-disabled" class="text-text-muted">pending</span></p>
+            <p>Route message: <span id="route-message" class="text-text-muted">pending</span></p>
+            <p>Route category: <span id="route-category" class="text-text-muted">pending</span></p>
+            <p>Route trail: <span id="route-trail" class="text-text-muted">pending</span></p>
         </native-vstack>
     </native-card-body></native-card>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Breadcrumb/Index.cshtml
@@ -11,7 +11,7 @@
     var plan = Html.ReactivePlan<FusionBreadcrumbModel>();
     var items = new List<BreadcrumbItem>
     {
-        new() { Text = "Home", Id = "home", Url = "/home" },
+        new() { Text = "Home", Id = "home", Url = "/home", IconCss = "e-icons e-home", Disabled = false },
         new() { Text = "Docs", Id = "docs", Url = "/docs" },
         new() { Text = "Guide", Id = "guide", Url = "/docs/guide" }
     };
@@ -49,7 +49,10 @@
         .Reactive(evt => evt.ItemClick, (args, p) =>
         {
             p.Element("clicked-text").SetText(args, x => x.Item.Text);
+            p.Element("clicked-id").SetText(args, x => x.Item.Id);
             p.Element("clicked-url").SetText(args, x => x.Item.Url);
+            p.Element("clicked-icon-css").SetText(args, x => x.Item.IconCss);
+            p.Element("clicked-disabled").SetText(args, x => x.Item.Disabled);
         }))
     </native-card-body></native-card>
 
@@ -73,7 +76,10 @@
             <p>Active item source: <span id="active-item-echo" class="text-text-muted">pending</span></p>
             <p>Active item state: <span id="active-state" class="text-text-muted">pending</span></p>
             <p>Clicked text: <span id="clicked-text" class="text-text-muted">pending</span></p>
+            <p>Clicked id: <span id="clicked-id" class="text-text-muted">pending</span></p>
             <p>Clicked url: <span id="clicked-url" class="text-text-muted">pending</span></p>
+            <p>Clicked icon CSS: <span id="clicked-icon-css" class="text-text-muted">pending</span></p>
+            <p>Clicked disabled: <span id="clicked-disabled" class="text-text-muted">pending</span></p>
         </native-vstack>
     </native-card-body></native-card>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml
@@ -1,0 +1,114 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart.FusionBulletChartModel
+@using System.Collections.Generic
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Charts
+@using BulletRange = Syncfusion.EJ2.Charts.Range
+@{
+    ViewData["Title"] = "FusionBulletChart";
+
+    const string BulletChartId = "resident-bullet-chart";
+
+    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart.FusionBulletChartModel>();
+    var data = new List<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart.BulletChartPoint>
+    {
+        new() { Category = "North Wing", Value = 72, Target = 80 },
+        new() { Category = "South Wing", Value = 54, Target = 68 },
+        new() { Category = "Rehab", Value = 88, Target = 92 }
+    };
+
+    var ranges = new List<BulletRange>
+    {
+        new() { End = 40, Name = "Poor", Color = "#ef4444" },
+        new() { End = 70, Name = "Average", Color = "#f59e0b" },
+        new() { End = 100, Name = "Good", Color = "#10b981" }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var chart = p.Component<FusionBulletChart>(BulletChartId);
+        p.Element("tooltip-state").SetText("pending");
+        p.Element("tooltip-value").SetText("pending");
+        p.Element("tooltip-target").SetText("pending");
+        p.Element("tooltip-text").SetText("pending");
+        p.Element("mouse-click-state").SetText("pending");
+        p.Element("mouse-click-target").SetText("pending");
+        p.Element("mouse-click-x").SetText("pending");
+        p.Element("mouse-click-y").SetText("pending");
+        p.Element("actual-index-negative").SetText(chart.GetActualIndex(-1, 3));
+        p.Element("actual-index-overflow").SetText(chart.GetActualIndex(3, 3));
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionBulletChart</native-heading>
+    <native-text color="Secondary">
+        Bullet chart slice. Exercises load and render lifecycle events, tooltip mutation, click payloads, and a wrapped index method read.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Bullet chart</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            Hover the feature bar to trigger tooltip rendering and click it to capture mouse metadata.
+        </p>
+
+        @(Html.FusionBulletChart(plan, BulletChartId, b =>
+        {
+            b.Width("100%");
+            b.Height("280px");
+            b.Title("Resident readiness");
+            b.Subtitle("Load, tooltip, click, and method reads");
+            b.Minimum(0);
+            b.Maximum(100);
+            b.Interval(20);
+            b.CategoryField("category");
+            b.ValueField("value");
+            b.TargetField("target");
+            b.DataSource(data);
+            b.Ranges(ranges);
+            b.Tooltip(new BulletChartBulletTooltipSettings
+            {
+                Enable = true
+            });
+        })
+        .Reactive(evt => evt.TooltipRender, (args, p) =>
+        {
+            p.Element("tooltip-state").SetText("rendered");
+            p.Element("tooltip-value").SetText(args, x => x.Value);
+            p.Element("tooltip-target").SetText(args, x => x.Target[0]);
+            args.SetText(p, "Bullet tooltip rewritten");
+            p.Element("tooltip-text").SetText("Bullet tooltip rewritten");
+        })
+        .Reactive(evt => evt.BulletChartMouseClick, (args, p) =>
+        {
+            p.Element("mouse-click-state").SetText("clicked");
+            p.Element("mouse-click-target").SetText(args, x => x.Target);
+            p.Element("mouse-click-x").SetText(args, x => x.X);
+            p.Element("mouse-click-y").SetText(args, x => x.Y);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Tooltip state: <span id="tooltip-state" class="text-text-muted">pending</span></p>
+            <p>Tooltip value: <span id="tooltip-value" class="text-text-muted">pending</span></p>
+            <p>Tooltip target: <span id="tooltip-target" class="text-text-muted">pending</span></p>
+            <p>Tooltip text: <span id="tooltip-text" class="text-text-muted">pending</span></p>
+            <p>Mouse click state: <span id="mouse-click-state" class="text-text-muted">pending</span></p>
+            <p>Mouse click target: <span id="mouse-click-target" class="text-text-muted">pending</span></p>
+            <p>Mouse click x: <span id="mouse-click-x" class="text-text-muted">pending</span></p>
+            <p>Mouse click y: <span id="mouse-click-y" class="text-text-muted">pending</span></p>
+            <p>Actual index -1: <span id="actual-index-negative" class="text-text-muted">pending</span></p>
+            <p>Actual index 3: <span id="actual-index-overflow" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml
@@ -3,12 +3,15 @@
 @using Alis.Reactive.Fusion.Components
 @using Alis.Reactive.Native.Components
 @using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart
 @using Syncfusion.EJ2.Charts
 @using BulletRange = Syncfusion.EJ2.Charts.Range
 @{
     ViewData["Title"] = "FusionBulletChart";
 
     const string BulletChartId = "resident-bullet-chart";
+    var clickAuditUrl = Url.Action("ClickAudit", "BulletChart", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve BulletChart.ClickAudit.");
 
     var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart.FusionBulletChartModel>();
     var data = new List<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.BulletChart.BulletChartPoint>
@@ -92,6 +95,17 @@
             p.Element("mouse-click-target").SetText(args, x => x.Target);
             p.Element("mouse-click-x").SetText(args, x => x.X);
             p.Element("mouse-click-y").SetText(args, x => x.Y);
+            p.Post(clickAuditUrl)
+                .Gather(g => g
+                    .FromEvent(args, x => x.Target, "target")
+                    .FromEvent(args, x => x.X, "x")
+                    .FromEvent(args, x => x.Y, "y"))
+                .Response(r => r.OnSuccess<FusionBulletChartClickAuditResponse>((json, s) =>
+                {
+                    s.Element("click-audit-message").SetText(json, x => x.Message);
+                    s.Element("click-audit-wing").SetText(json, x => x.Wing);
+                    s.Element("click-audit-coordinates").SetText(json, x => x.Coordinates);
+                }));
         }))
     </native-card-body></native-card>
 
@@ -108,6 +122,9 @@
             <p>Mouse click target: <span id="mouse-click-target" class="text-text-muted">pending</span></p>
             <p>Mouse click x: <span id="mouse-click-x" class="text-text-muted">pending</span></p>
             <p>Mouse click y: <span id="mouse-click-y" class="text-text-muted">pending</span></p>
+            <p>Click audit message: <span id="click-audit-message" class="text-text-muted">pending</span></p>
+            <p>Click audit wing: <span id="click-audit-wing" class="text-text-muted">pending</span></p>
+            <p>Click audit coordinates: <span id="click-audit-coordinates" class="text-text-muted">pending</span></p>
             <p>Actual index -1: <span id="actual-index-negative" class="text-text-muted">pending</span></p>
             <p>Actual index 3: <span id="actual-index-overflow" class="text-text-muted">pending</span></p>
         </native-vstack>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/BulletChart/Index.cshtml
@@ -31,6 +31,8 @@
         p.Element("tooltip-state").SetText("pending");
         p.Element("tooltip-value").SetText("pending");
         p.Element("tooltip-target").SetText("pending");
+        p.Element("tooltip-name").SetText("pending");
+        p.Element("tooltip-template").SetText("pending");
         p.Element("tooltip-text").SetText("pending");
         p.Element("mouse-click-state").SetText("pending");
         p.Element("mouse-click-target").SetText("pending");
@@ -77,8 +79,12 @@
             p.Element("tooltip-state").SetText("rendered");
             p.Element("tooltip-value").SetText(args, x => x.Value);
             p.Element("tooltip-target").SetText(args, x => x.Target[0]);
+            p.Element("tooltip-name").SetText(args, x => x.Name);
+            p.When(args, x => x.Template).NotEmpty()
+                .Then(t => t.Element("tooltip-template").SetText(args, x => x.Template))
+                .Else(e => e.Element("tooltip-template").SetText("none"));
             args.SetText(p, "Bullet tooltip rewritten");
-            p.Element("tooltip-text").SetText("Bullet tooltip rewritten");
+            p.Element("tooltip-text").SetText(args, x => x.Text);
         })
         .Reactive(evt => evt.BulletChartMouseClick, (args, p) =>
         {
@@ -95,6 +101,8 @@
             <p>Tooltip state: <span id="tooltip-state" class="text-text-muted">pending</span></p>
             <p>Tooltip value: <span id="tooltip-value" class="text-text-muted">pending</span></p>
             <p>Tooltip target: <span id="tooltip-target" class="text-text-muted">pending</span></p>
+            <p>Tooltip name: <span id="tooltip-name" class="text-text-muted">pending</span></p>
+            <p>Tooltip template: <span id="tooltip-template" class="text-text-muted">pending</span></p>
             <p>Tooltip text: <span id="tooltip-text" class="text-text-muted">pending</span></p>
             <p>Mouse click state: <span id="mouse-click-state" class="text-text-muted">pending</span></p>
             <p>Mouse click target: <span id="mouse-click-target" class="text-text-muted">pending</span></p>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Button/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Button/Index.cshtml
@@ -1,0 +1,177 @@
+@model ButtonModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionButton";
+
+    const string buttonId = "fusion-action-button";
+    var plan = Html.ReactivePlan<ButtonModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var button = p.Component<FusionButton>(buttonId);
+        button.SetContent("Ready");
+        p.Element("content-echo").SetText(button.Content());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionButton</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Button Runtime State</native-heading>
+        <native-hstack gap="Base" align="Center">
+            @(Html.FusionButton(plan, buttonId, b => b
+                .Type("button")
+                .Content("Initial")
+                .IconCss("e-icons e-search")
+                .IconPosition(Syncfusion.EJ2.Buttons.IconPosition.Left)
+                .IsToggle(true)))
+        </native-hstack>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-content-btn", "Set Content")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionButton>(buttonId);
+                    button.SetContent("Queued");
+                    p.Element("content-echo").SetText(button.Content());
+                    p.Element("command-state").SetText("content set");
+                }))
+            @(Html.NativeButton("disable-btn", "Disable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionButton>(buttonId);
+                    button.SetDisabled(true);
+                    p.Element("disabled-echo").SetText(button.Disabled());
+                    p.Element("command-state").SetText("disabled");
+                }))
+            @(Html.NativeButton("enable-btn", "Enable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionButton>(buttonId);
+                    button.SetDisabled(false);
+                    p.Element("disabled-echo").SetText(button.Disabled());
+                    p.Element("command-state").SetText("enabled");
+                }))
+            @(Html.NativeButton("set-icon-btn", "Set Icon")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionButton>(buttonId).SetIcon("e-icons e-edit", FusionButtonIconPosition.Right);
+                    p.Element("command-state").SetText("icon set");
+                }))
+            @(Html.NativeButton("set-css-btn", "Set Css")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionButton>(buttonId);
+                    button.SetCssClass("e-success extra-class");
+                    p.Element("css-echo").SetText(button.CssClass());
+                    p.Element("command-state").SetText("css set");
+                }))
+            @(Html.NativeButton("set-primary-btn", "Set Primary")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionButton>(buttonId);
+                    button.SetPrimary(true);
+                    p.Element("primary-echo").SetText(button.IsPrimary());
+                    p.Element("command-state").SetText("primary set");
+                }))
+            @(Html.NativeButton("set-toggle-btn", "Disable Toggle")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionButton>(buttonId);
+                    button.SetToggle(false);
+                    p.Element("toggle-echo").SetText(button.IsToggle());
+                    p.Element("command-state").SetText("toggle disabled");
+                }))
+            @(Html.NativeButton("click-button-btn", "Click Button")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionButton>(buttonId).Click();
+                    p.Element("click-state").SetText("click called");
+                }))
+            @(Html.NativeButton("focus-button-btn", "Focus Button")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionButton>(buttonId).FocusIn();
+                    p.Element("focus-state").SetText("focus called");
+                }))
+            @(Html.NativeButton("check-button-btn", "Check Disabled")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionButton>(buttonId);
+                    p.When(button.Disabled()).Eq(true)
+                        .Then(t => t.Element("disabled-state").SetText("disabled"))
+                        .Else(e => e.Element("disabled-state").SetText("enabled"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather Button")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var button = p.Component<FusionButton>(buttonId);
+                p.Post("/Sandbox/Components/Button/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(button.Content(), "content");
+                        g.Include(button.Disabled(), "disabled");
+                        g.Include(button.CssClass(), "cssClass");
+                        g.Include(button.IsPrimary(), "isPrimary");
+                        g.Include(button.IsToggle(), "isToggle");
+                    })
+                    .Response(r => r.OnSuccess<ButtonEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-content").SetText(json, x => x.Content);
+                        s.Element("gather-disabled").SetText(json, x => x.Disabled);
+                        s.Element("gather-css").SetText(json, x => x.CssClass);
+                        s.Element("gather-primary").SetText(json, x => x.IsPrimary);
+                        s.Element("gather-toggle").SetText(json, x => x.IsToggle);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Content echo: <span id="content-echo" class="text-text-muted">pending</span></p>
+            <p>Disabled echo: <span id="disabled-echo" class="text-text-muted">pending</span></p>
+            <p>Css echo: <span id="css-echo" class="text-text-muted">pending</span></p>
+            <p>Primary echo: <span id="primary-echo" class="text-text-muted">pending</span></p>
+            <p>Toggle echo: <span id="toggle-echo" class="text-text-muted">pending</span></p>
+            <p>Click state: <span id="click-state" class="text-text-muted">pending</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">pending</span></p>
+            <p>Disabled state: <span id="disabled-state" class="text-text-muted">pending</span></p>
+            <p>Gather content: <span id="gather-content" class="text-text-muted">pending</span></p>
+            <p>Gather disabled: <span id="gather-disabled" class="text-text-muted">pending</span></p>
+            <p>Gather css: <span id="gather-css" class="text-text-muted">pending</span></p>
+            <p>Gather primary: <span id="gather-primary" class="text-text-muted">pending</span></p>
+            <p>Gather toggle: <span id="gather-toggle" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml
@@ -1,0 +1,119 @@
+@model FusionCarouselModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionCarousel";
+
+    const string CarouselId = "resident-carousel";
+
+    var plan = Html.ReactivePlan<FusionCarouselModel>();
+    var items = new List<CarouselItem>
+    {
+        new() { Template = "<div class='carousel-slide carousel-slide-one'>One</div>" },
+        new() { Template = "<div class='carousel-slide carousel-slide-two'>Two</div>" },
+        new() { Template = "<div class='carousel-slide carousel-slide-three'>Three</div>" }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var carousel = p.Component<FusionCarousel>(CarouselId);
+        p.Element("selected-index-echo").SetText(carousel.SelectedIndex());
+        p.When(carousel.SelectedIndex()).Eq(1)
+            .Then(t => t.Element("selected-state").SetText("second slide"))
+            .Else(e => e.Element("selected-state").SetText("other slide"));
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionCarousel</native-heading>
+    <native-text color="Secondary">
+        Navigation component. Exercises selected-index reads, next/previous methods, and slide change cancellation.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Carousel</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            The middle slide is active on load. Previous is canceled when it would move to the first slide.
+        </p>
+
+        @(Html.FusionCarousel(plan, CarouselId, b =>
+        {
+            b.Items(items);
+            b.SelectedIndex(1);
+            b.AnimationEffect(CarouselAnimationEffect.None);
+            b.AutoPlay(false);
+            b.ButtonsVisibility(CarouselButtonVisibility.Hidden);
+            b.ShowIndicators(false);
+            b.ShowPlayButton(false);
+            b.AllowKeyboardInteraction(false);
+            b.EnableTouchSwipe(false);
+            b.Loop(false);
+        })
+        .Reactive(evt => evt.SlideChanging, (args, p) =>
+        {
+            p.Element("changing-current").SetText(args, x => x.CurrentIndex);
+            p.Element("changing-next").SetText(args, x => x.NextIndex);
+            p.Element("changing-direction").SetText(args, x => x.SlideDirection);
+
+            p.When(args, x => x.NextIndex).Eq(0)
+                .Then(t =>
+                {
+                    t.Element("cancel-state").SetText("cancelled");
+                    args.PreventTransition(t);
+                })
+                .Else(e => e.Element("cancel-state").SetText("allowed"));
+        })
+        .Reactive(evt => evt.SlideChanged, (args, p) =>
+        {
+            var carousel = p.Component<FusionCarousel>(CarouselId);
+            p.Element("selected-index-echo").SetText(carousel.SelectedIndex());
+            p.Element("changed-current").SetText(args, x => x.CurrentIndex);
+            p.Element("changed-previous").SetText(args, x => x.PreviousIndex);
+            p.Element("changed-direction").SetText(args, x => x.SlideDirection);
+            p.Element("changed-state").SetText("changed");
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Commands</native-heading>
+        <native-hstack gap="Sm" class="flex-wrap">
+            @(Html.NativeButton("next-btn", "Next")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionCarousel>(CarouselId).Next();
+                }))
+            @(Html.NativeButton("prev-btn", "Previous")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionCarousel>(CarouselId).Previous();
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Selected index: <span id="selected-index-echo" class="text-text-muted">pending</span></p>
+            <p>Selected state: <span id="selected-state" class="text-text-muted">pending</span></p>
+            <p>Changing current: <span id="changing-current" class="text-text-muted">pending</span></p>
+            <p>Changing next: <span id="changing-next" class="text-text-muted">pending</span></p>
+            <p>Changing direction: <span id="changing-direction" class="text-text-muted">pending</span></p>
+            <p>Cancel state: <span id="cancel-state" class="text-text-muted">pending</span></p>
+            <p>Changed current: <span id="changed-current" class="text-text-muted">pending</span></p>
+            <p>Changed previous: <span id="changed-previous" class="text-text-muted">pending</span></p>
+            <p>Changed direction: <span id="changed-direction" class="text-text-muted">pending</span></p>
+            <p>Changed state: <span id="changed-state" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml
@@ -7,13 +7,15 @@
     ViewData["Title"] = "FusionCarousel";
 
     const string CarouselId = "resident-carousel";
+    var auditUrl = Url.Action("Audit", "Carousel", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Carousel.Audit.");
 
     var plan = Html.ReactivePlan<FusionCarouselModel>();
     var items = new List<CarouselItem>
     {
-        new() { Template = "<div class='carousel-slide carousel-slide-one'>One</div>" },
-        new() { Template = "<div class='carousel-slide carousel-slide-two'>Two</div>" },
-        new() { Template = "<div class='carousel-slide carousel-slide-three'>Three</div>" }
+        new() { Template = "<div class='carousel-slide carousel-slide-one'><strong>Vitals Snapshot</strong><span>Respiration, pain score, and overnight alerts.</span></div>" },
+        new() { Template = "<div class='carousel-slide carousel-slide-two'><strong>Care Plan Review</strong><span>Therapy notes and medication adjustments.</span></div>" },
+        new() { Template = "<div class='carousel-slide carousel-slide-three'><strong>Discharge Readiness</strong><span>Family teaching and follow-up tasks.</span></div>" }
     };
 
     Html.On(plan, t => t.DomReady(p =>
@@ -77,6 +79,17 @@
             p.Element("changed-is-swiped").SetText(args, x => x.IsSwiped);
             p.Element("changed-direction").SetText(args, x => x.SlideDirection);
             p.Element("changed-state").SetText("changed");
+            p.Post(auditUrl)
+                .Gather(g => g
+                    .FromEvent(args, x => x.CurrentIndex, "currentIndex")
+                    .FromEvent(args, x => x.PreviousIndex, "previousIndex")
+                    .FromEvent(args, x => x.SlideDirection, "slideDirection"))
+                .Response(r => r.OnSuccess<FusionCarouselAuditResponse>((json, s) =>
+                {
+                    s.Element("review-persisted").SetText(json, x => x.Message);
+                    s.Element("review-section").SetText(json, x => x.Section);
+                    s.Element("review-direction").SetText(json, x => x.Direction);
+                }));
         }))
     </native-card-body></native-card>
 
@@ -114,6 +127,9 @@
             <p>Changed is swiped: <span id="changed-is-swiped" class="text-text-muted">pending</span></p>
             <p>Changed direction: <span id="changed-direction" class="text-text-muted">pending</span></p>
             <p>Changed state: <span id="changed-state" class="text-text-muted">pending</span></p>
+            <p>Review persisted: <span id="review-persisted" class="text-text-muted">pending</span></p>
+            <p>Review section: <span id="review-section" class="text-text-muted">pending</span></p>
+            <p>Review direction: <span id="review-direction" class="text-text-muted">pending</span></p>
         </native-vstack>
     </native-card-body></native-card>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Carousel/Index.cshtml
@@ -55,13 +55,16 @@
         {
             p.Element("changing-current").SetText(args, x => x.CurrentIndex);
             p.Element("changing-next").SetText(args, x => x.NextIndex);
+            p.Element("changing-is-swiped").SetText(args, x => x.IsSwiped);
             p.Element("changing-direction").SetText(args, x => x.SlideDirection);
+            p.Element("changing-cancel").SetText(args, x => x.Cancel);
 
             p.When(args, x => x.NextIndex).Eq(0)
                 .Then(t =>
                 {
                     t.Element("cancel-state").SetText("cancelled");
                     args.PreventTransition(t);
+                    t.Element("changing-cancel").SetText(args, x => x.Cancel);
                 })
                 .Else(e => e.Element("cancel-state").SetText("allowed"));
         })
@@ -71,6 +74,7 @@
             p.Element("selected-index-echo").SetText(carousel.SelectedIndex());
             p.Element("changed-current").SetText(args, x => x.CurrentIndex);
             p.Element("changed-previous").SetText(args, x => x.PreviousIndex);
+            p.Element("changed-is-swiped").SetText(args, x => x.IsSwiped);
             p.Element("changed-direction").SetText(args, x => x.SlideDirection);
             p.Element("changed-state").SetText("changed");
         }))
@@ -101,10 +105,13 @@
             <p>Selected state: <span id="selected-state" class="text-text-muted">pending</span></p>
             <p>Changing current: <span id="changing-current" class="text-text-muted">pending</span></p>
             <p>Changing next: <span id="changing-next" class="text-text-muted">pending</span></p>
+            <p>Changing is swiped: <span id="changing-is-swiped" class="text-text-muted">pending</span></p>
             <p>Changing direction: <span id="changing-direction" class="text-text-muted">pending</span></p>
+            <p>Changing cancel: <span id="changing-cancel" class="text-text-muted">pending</span></p>
             <p>Cancel state: <span id="cancel-state" class="text-text-muted">pending</span></p>
             <p>Changed current: <span id="changed-current" class="text-text-muted">pending</span></p>
             <p>Changed previous: <span id="changed-previous" class="text-text-muted">pending</span></p>
+            <p>Changed is swiped: <span id="changed-is-swiped" class="text-text-muted">pending</span></p>
             <p>Changed direction: <span id="changed-direction" class="text-text-muted">pending</span></p>
             <p>Changed state: <span id="changed-state" class="text-text-muted">pending</span></p>
         </native-vstack>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/CheckBox/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/CheckBox/Index.cshtml
@@ -1,0 +1,157 @@
+@model FusionCheckBoxModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionCheckBox";
+
+    var plan = Html.ReactivePlan<FusionCheckBoxModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var consent = p.Component<FusionCheckBox>(m => m.ConsentAccepted);
+        consent.SetChecked(true);
+        p.Element("checked-echo").SetText(consent.Checked());
+
+        var review = p.Component<FusionCheckBox>(m => m.ReviewNeeded);
+        review.SetIndeterminate(true);
+        p.Element("indeterminate-echo").SetText(review.Indeterminate());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionCheckBox</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">State and Events</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.ConsentAccepted, o => o.Label("Consent Accepted"))
+                .FusionCheckBox(b => b
+                    .Label("Consent accepted")
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        p.Element("change-checked").SetText(args, x => x.Checked);
+                        p.When(args, x => x.Checked).Truthy()
+                            .Then(t => t.Element("args-condition").SetText("checked"))
+                            .Else(e => e.Element("args-condition").SetText("unchecked"));
+                    })); }
+
+            @{ Html.InputField(plan, m => m.ReviewNeeded, o => o.Label("Review Needed"))
+                .FusionCheckBox(b => b.Label("Review needed")); }
+        </native-grid>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-unchecked-btn", "Set Unchecked")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var consent = p.Component<FusionCheckBox>(m => m.ConsentAccepted);
+                    consent.SetChecked(false);
+                    p.Element("checked-echo").SetText(consent.Checked());
+                    p.Element("command-state").SetText("unchecked set");
+                }))
+            @(Html.NativeButton("set-indeterminate-btn", "Set Indeterminate")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var review = p.Component<FusionCheckBox>(m => m.ReviewNeeded);
+                    review.SetIndeterminate(true);
+                    p.Element("indeterminate-echo").SetText(review.Indeterminate());
+                    p.Element("command-state").SetText("indeterminate set");
+                }))
+            @(Html.NativeButton("disable-review-btn", "Disable Review")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var review = p.Component<FusionCheckBox>(m => m.ReviewNeeded);
+                    review.SetDisabled(true);
+                    p.Element("disabled-echo").SetText(review.Disabled());
+                    p.Element("command-state").SetText("review disabled");
+                }))
+            @(Html.NativeButton("enable-review-btn", "Enable Review")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var review = p.Component<FusionCheckBox>(m => m.ReviewNeeded);
+                    review.SetDisabled(false);
+                    p.Element("disabled-echo").SetText(review.Disabled());
+                    p.Element("command-state").SetText("review enabled");
+                }))
+            @(Html.NativeButton("click-consent-btn", "Click Consent")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionCheckBox>(m => m.ConsentAccepted).Click();
+                    p.Element("click-state").SetText("click called");
+                }))
+            @(Html.NativeButton("focus-consent-btn", "Focus Consent")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionCheckBox>(m => m.ConsentAccepted).FocusIn();
+                    p.Element("focus-state").SetText("focus called");
+                }))
+            @(Html.NativeButton("check-consent-btn", "Check Consent")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var consent = p.Component<FusionCheckBox>(m => m.ConsentAccepted);
+                    p.When(consent.Checked()).Truthy()
+                        .Then(t => t.Element("checked-state").SetText("accepted"))
+                        .Else(e => e.Element("checked-state").SetText("missing"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather CheckBox")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var consent = p.Component<FusionCheckBox>(m => m.ConsentAccepted);
+                var review = p.Component<FusionCheckBox>(m => m.ReviewNeeded);
+                p.Post("/Sandbox/Components/FusionCheckBox/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(consent.Checked(), "checked");
+                        g.Include(review.Indeterminate(), "indeterminate");
+                        g.Include(review.Disabled(), "disabled");
+                    })
+                    .Response(r => r.OnSuccess<FusionCheckBoxEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-checked").SetText(json, x => x.Checked);
+                        s.Element("gather-indeterminate").SetText(json, x => x.Indeterminate);
+                        s.Element("gather-disabled").SetText(json, x => x.Disabled);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Checked echo: <span id="checked-echo" class="text-text-muted">pending</span></p>
+            <p>Indeterminate echo: <span id="indeterminate-echo" class="text-text-muted">pending</span></p>
+            <p>Disabled echo: <span id="disabled-echo" class="text-text-muted">pending</span></p>
+            <p>Change checked: <span id="change-checked" class="text-text-muted">pending</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">pending</span></p>
+            <p>Click state: <span id="click-state" class="text-text-muted">pending</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">pending</span></p>
+            <p>Checked state: <span id="checked-state" class="text-text-muted">pending</span></p>
+            <p>Gather checked: <span id="gather-checked" class="text-text-muted">pending</span></p>
+            <p>Gather indeterminate: <span id="gather-indeterminate" class="text-text-muted">pending</span></p>
+            <p>Gather disabled: <span id="gather-disabled" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ComboBox/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ComboBox/Index.cshtml
@@ -1,0 +1,199 @@
+@model FusionComboBoxModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@using Syncfusion.EJ2.DropDowns
+@{
+    ViewData["Title"] = "FusionComboBox";
+
+    var plan = Html.ReactivePlan<FusionComboBoxModel>();
+    var residents = (List<ComboBoxResidentItem>)ViewBag.Residents;
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var combo = p.Component<FusionComboBox>(m => m.Resident);
+        combo.SetValue("alice").DataBind();
+        p.Element("value-echo").SetText(combo.Value());
+        p.Element("text-echo").SetText(combo.Text());
+        p.Element("index-echo").SetText(combo.Index());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionComboBox</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Resident ComboBox</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.Resident, o => o.Label("Resident (SF ComboBox)"))
+                .FusionComboBox(b => b
+                    .DataSource(residents)
+                    .Fields(new ComboBoxFieldSettings { Text = "text", Value = "value" })
+                    .Placeholder("Select or enter a resident")
+                    .AllowCustom(true)
+                    .PopupHeight("160px")
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        p.Element("change-value").SetText(args, x => x.Value);
+                        p.Element("change-interacted").SetText(args, x => x.IsInteracted);
+                        p.When(args, x => x.Value).Eq("alice")
+                            .Then(t => t.Element("args-condition").SetText("alice selected"))
+                            .Else(e => e.Element("args-condition").SetText("other resident"));
+
+                        var combo = p.Component<FusionComboBox>(m => m.Resident);
+                        p.Element("event-text").SetText(combo.Text());
+                        p.When(combo.Value()).NotNull()
+                            .Then(t =>
+                            {
+                                t.Element("selected-indicator").Show();
+                                t.Element("selected-indicator").SetText("selected");
+                            })
+                            .Else(e => e.Element("selected-indicator").Hide());
+                    })
+                    .Reactive(plan, evt => evt.Focus, (args, p) =>
+                    {
+                        p.Element("focus-state").SetText("focused");
+                    })
+                    .Reactive(plan, evt => evt.Blur, (args, p) =>
+                    {
+                        p.Element("blur-state").SetText("blurred");
+                    })); }
+        </native-grid>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-value-btn", "Set Value")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var combo = p.Component<FusionComboBox>(m => m.Resident);
+                    combo.SetValue("bennett").DataBind();
+                    p.Element("value-echo").SetText(combo.Value());
+                    p.Element("text-echo").SetText(combo.Text());
+                    p.Element("index-echo").SetText(combo.Index());
+                    p.Element("command-state").SetText("value set");
+                }))
+            @(Html.NativeButton("set-text-btn", "Set Text")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var combo = p.Component<FusionComboBox>(m => m.Resident);
+                    combo.SetText("Carey").DataBind();
+                    p.Element("value-echo").SetText(combo.Value());
+                    p.Element("text-echo").SetText(combo.Text());
+                    p.Element("index-echo").SetText(combo.Index());
+                    p.Element("command-state").SetText("text set");
+                }))
+            @(Html.NativeButton("set-index-btn", "Set Index")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var combo = p.Component<FusionComboBox>(m => m.Resident);
+                    combo.SetIndex(3).DataBind();
+                    p.Element("value-echo").SetText(combo.Value());
+                    p.Element("text-echo").SetText(combo.Text());
+                    p.Element("index-echo").SetText(combo.Index());
+                    p.Element("command-state").SetText("index set");
+                }))
+            @(Html.NativeButton("show-popup-btn", "Show Popup")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionComboBox>(m => m.Resident).ShowPopup();
+                }))
+            @(Html.NativeButton("hide-popup-btn", "Hide Popup")
+                .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionComboBox>(m => m.Resident).HidePopup();
+                }))
+            @(Html.NativeButton("focus-combo-btn", "Focus")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionComboBox>(m => m.Resident).FocusIn();
+                }))
+            @(Html.NativeButton("blur-combo-btn", "Blur")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionComboBox>(m => m.Resident).FocusOut();
+                }))
+            @(Html.NativeButton("clear-combo-btn", "Clear")
+                .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var combo = p.Component<FusionComboBox>(m => m.Resident);
+                    combo.Clear().DataBind();
+                    p.Element("command-state").SetText("cleared");
+                    p.Element("value-echo").SetText(combo.Value());
+                    p.Element("text-echo").SetText(combo.Text());
+                    p.When(combo.Value()).NotNull()
+                        .Then(t => t.Element("selected-indicator").Show())
+                        .Else(e => e.Element("selected-indicator").Hide());
+                }))
+            @(Html.NativeButton("check-index-btn", "Check Index")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var combo = p.Component<FusionComboBox>(m => m.Resident);
+                    p.When(combo.Index()).Eq(3)
+                        .Then(t => t.Element("index-condition").SetText("index three"))
+                        .Else(e => e.Element("index-condition").SetText("other index"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather ComboBox")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var combo = p.Component<FusionComboBox>(m => m.Resident);
+                p.Post("/Sandbox/Components/FusionComboBox/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(combo.Value(), "value");
+                        g.Include(combo.Text(), "text");
+                        g.Include(combo.Index(), "index");
+                    })
+                    .Response(r => r.OnSuccess<FusionComboBoxEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-value").SetText(json, x => x.Value);
+                        s.Element("gather-text").SetText(json, x => x.Text);
+                        s.Element("gather-index").SetText(json, x => x.Index);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Value echo: <span id="value-echo" class="text-text-muted">pending</span></p>
+            <p>Text echo: <span id="text-echo" class="text-text-muted">pending</span></p>
+            <p>Index echo: <span id="index-echo" class="text-text-muted">pending</span></p>
+            <p>Change value: <span id="change-value" class="text-text-muted">pending</span></p>
+            <p>Change interacted: <span id="change-interacted" class="text-text-muted">pending</span></p>
+            <p>Event text: <span id="event-text" class="text-text-muted">pending</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">pending</span></p>
+            <p>Selected: <span id="selected-indicator" hidden class="text-emerald-600">pending</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">pending</span></p>
+            <p>Blur state: <span id="blur-state" class="text-text-muted">pending</span></p>
+            <p>Index condition: <span id="index-condition" class="text-text-muted">pending</span></p>
+            <p>Gather value: <span id="gather-value" class="text-text-muted">pending</span></p>
+            <p>Gather text: <span id="gather-text" class="text-text-muted">pending</span></p>
+            <p>Gather index: <span id="gather-index" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ContextMenu/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ContextMenu/Index.cshtml
@@ -13,15 +13,17 @@
     var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.ContextMenu.FusionContextMenuModel>();
     var items = new List<MenuItem>
     {
-        new() { Id = "dashboard-item", Text = "Dashboard" },
+        new() { Id = "dashboard-item", Text = "Dashboard", Url = "/dashboard", IconCss = "e-icons e-home", Separator = false },
         new()
         {
             Id = "projects-item",
             Text = "Projects",
+            IconCss = "e-icons e-folder",
+            Separator = false,
             Items = new List<MenuItem>
             {
-                new() { Id = "reports-item", Text = "Reports" },
-                new() { Id = "archive-item", Text = "Archive" }
+                new() { Id = "reports-item", Text = "Reports", IconCss = "e-icons e-description", Separator = false },
+                new() { Id = "archive-item", Text = "Archive", IconCss = "e-icons e-archive", Separator = false }
             }
         },
         new() { Id = "help-item", Text = "Help" }
@@ -32,22 +34,37 @@
         p.Element("before-item-state").SetText("pending");
         p.Element("before-item-text").SetText("pending");
         p.Element("before-item-id").SetText("pending");
+        p.Element("before-item-url").SetText("pending");
+        p.Element("before-item-icon-css").SetText("pending");
+        p.Element("before-item-separator").SetText("pending");
         p.Element("before-open-state").SetText("pending");
         p.Element("before-open-kind").SetText("pending");
         p.Element("before-open-top").SetText("pending");
         p.Element("before-open-left").SetText("pending");
+        p.Element("before-open-focused").SetText("pending");
+        p.Element("before-open-first-item").SetText("pending");
         p.Element("before-open-parent").SetText("pending");
         p.Element("before-open-cancel").SetText("pending");
+        p.Element("before-open-cancel-value").SetText("pending");
         p.Element("open-state").SetText("pending");
         p.Element("open-kind").SetText("pending");
+        p.Element("open-first-item").SetText("pending");
+        p.Element("open-parent").SetText("pending");
         p.Element("menu-visibility").SetText("pending");
         p.Element("before-close-state").SetText("pending");
+        p.Element("before-close-first-item").SetText("pending");
+        p.Element("before-close-parent").SetText("pending");
         p.Element("before-close-cancel").SetText("pending");
+        p.Element("before-close-cancel-value").SetText("pending");
         p.Element("close-state").SetText("pending");
+        p.Element("close-first-item").SetText("pending");
+        p.Element("close-parent").SetText("pending");
         p.Element("select-state").SetText("pending");
         p.Element("select-text").SetText("pending");
         p.Element("select-id").SetText("pending");
         p.Element("select-url").SetText("pending");
+        p.Element("select-icon-css").SetText("pending");
+        p.Element("select-separator").SetText("pending");
     }));
 }
 
@@ -110,9 +127,19 @@
             p.Element("before-item-state").SetText("rendered");
             p.Element("before-item-text").SetText(args, x => x.Item.Text);
             p.Element("before-item-id").SetText(args, x => x.Item.Id);
+            p.Element("before-item-url").SetText(args, x => x.Item.Url);
+            p.Element("before-item-icon-css").SetText(args, x => x.Item.IconCss);
+            p.Element("before-item-separator").SetText(args, x => x.Item.Separator);
         })
         .Reactive(evt => evt.BeforeOpen, (args, p) =>
         {
+            p.Element("before-open-state").SetText("rendered");
+            p.When(args, x => x.IsFocused).Truthy()
+                .Then(t => t.Element("before-open-focused").SetText("true"))
+                .Else(e => e.Element("before-open-focused").SetText("false"));
+            p.Element("before-open-first-item").SetText(args, x => x.Items[0].Text);
+            p.Element("before-open-cancel-value").SetText(args, x => x.Cancel);
+
             p.When(args, x => x.ParentItem).IsNull()
                 .Then(t =>
                 {
@@ -134,33 +161,53 @@
                 {
                     t.Element("before-open-cancel").SetText("cancelled");
                     args.PreventOpen(t);
+                    t.Element("before-open-cancel-value").SetText(args, x => x.Cancel);
                 })
                 .Else(e => e.Element("before-open-cancel").SetText("allowed"));
         })
         .Reactive(evt => evt.Opened, (args, p) =>
         {
             p.When(args, x => x.ParentItem).IsNull()
-                .Then(t => t.Element("open-kind").SetText("root"))
-                .Else(e => e.Element("open-kind").SetText("submenu"));
+                .Then(t =>
+                {
+                    t.Element("open-kind").SetText("root");
+                    t.Element("open-parent").SetText("root");
+                })
+                .Else(e =>
+                {
+                    e.Element("open-kind").SetText("submenu");
+                    e.Element("open-parent").SetText(args, x => x.ParentItem!.Text);
+                });
 
             p.Element("open-state").SetText("opened");
+            p.Element("open-first-item").SetText(args, x => x.Items[0].Text);
             p.Element("menu-visibility").SetText("visible");
         })
         .Reactive(evt => evt.BeforeClose, (args, p) =>
         {
             p.Element("before-close-state").SetText("rendered");
+            p.Element("before-close-first-item").SetText(args, x => x.Items[0].Text);
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t => t.Element("before-close-parent").SetText("root"))
+                .Else(e => e.Element("before-close-parent").SetText(args, x => x.ParentItem!.Text));
+            p.Element("before-close-cancel-value").SetText(args, x => x.Cancel);
 
             p.When(p.Component<NativeCheckBox>(m => m.BlockClose).Value()).Truthy()
                 .Then(t =>
                 {
                     t.Element("before-close-cancel").SetText("cancelled");
                     args.PreventClose(t);
+                    t.Element("before-close-cancel-value").SetText(args, x => x.Cancel);
                 })
                 .Else(e => e.Element("before-close-cancel").SetText("allowed"));
         })
         .Reactive(evt => evt.Closed, (args, p) =>
         {
             p.Element("close-state").SetText("closed");
+            p.Element("close-first-item").SetText(args, x => x.Items[0].Text);
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t => t.Element("close-parent").SetText("root"))
+                .Else(e => e.Element("close-parent").SetText(args, x => x.ParentItem!.Text));
             p.Element("menu-visibility").SetText("hidden");
         })
         .Reactive(evt => evt.Select, (args, p) =>
@@ -169,6 +216,8 @@
             p.Element("select-text").SetText(args, x => x.Item.Text);
             p.Element("select-id").SetText(args, x => x.Item.Id);
             p.Element("select-url").SetText(args, x => x.Item.Url);
+            p.Element("select-icon-css").SetText(args, x => x.Item.IconCss);
+            p.Element("select-separator").SetText(args, x => x.Item.Separator);
         }))
     </native-card-body></native-card>
 
@@ -178,22 +227,37 @@
             <p>Before item state: <span id="before-item-state" class="text-text-muted">pending</span></p>
             <p>Before item text: <span id="before-item-text" class="text-text-muted">pending</span></p>
             <p>Before item id: <span id="before-item-id" class="text-text-muted">pending</span></p>
+            <p>Before item url: <span id="before-item-url" class="text-text-muted">pending</span></p>
+            <p>Before item icon CSS: <span id="before-item-icon-css" class="text-text-muted">pending</span></p>
+            <p>Before item separator: <span id="before-item-separator" class="text-text-muted">pending</span></p>
             <p>Before open state: <span id="before-open-state" class="text-text-muted">pending</span></p>
             <p>Before open kind: <span id="before-open-kind" class="text-text-muted">pending</span></p>
             <p>Before open top: <span id="before-open-top" class="text-text-muted">pending</span></p>
             <p>Before open left: <span id="before-open-left" class="text-text-muted">pending</span></p>
+            <p>Before open focused: <span id="before-open-focused" class="text-text-muted">pending</span></p>
+            <p>Before open first item: <span id="before-open-first-item" class="text-text-muted">pending</span></p>
             <p>Before open parent: <span id="before-open-parent" class="text-text-muted">pending</span></p>
             <p>Before open cancel: <span id="before-open-cancel" class="text-text-muted">pending</span></p>
+            <p>Before open cancel value: <span id="before-open-cancel-value" class="text-text-muted">pending</span></p>
             <p>Open state: <span id="open-state" class="text-text-muted">pending</span></p>
             <p>Open kind: <span id="open-kind" class="text-text-muted">pending</span></p>
+            <p>Open first item: <span id="open-first-item" class="text-text-muted">pending</span></p>
+            <p>Open parent: <span id="open-parent" class="text-text-muted">pending</span></p>
             <p>Menu visibility: <span id="menu-visibility" class="text-text-muted">pending</span></p>
             <p>Before close state: <span id="before-close-state" class="text-text-muted">pending</span></p>
+            <p>Before close first item: <span id="before-close-first-item" class="text-text-muted">pending</span></p>
+            <p>Before close parent: <span id="before-close-parent" class="text-text-muted">pending</span></p>
             <p>Before close cancel: <span id="before-close-cancel" class="text-text-muted">pending</span></p>
+            <p>Before close cancel value: <span id="before-close-cancel-value" class="text-text-muted">pending</span></p>
             <p>Close state: <span id="close-state" class="text-text-muted">pending</span></p>
+            <p>Close first item: <span id="close-first-item" class="text-text-muted">pending</span></p>
+            <p>Close parent: <span id="close-parent" class="text-text-muted">pending</span></p>
             <p>Select state: <span id="select-state" class="text-text-muted">pending</span></p>
             <p>Select text: <span id="select-text" class="text-text-muted">pending</span></p>
             <p>Select id: <span id="select-id" class="text-text-muted">pending</span></p>
             <p>Select url: <span id="select-url" class="text-text-muted">pending</span></p>
+            <p>Select icon CSS: <span id="select-icon-css" class="text-text-muted">pending</span></p>
+            <p>Select separator: <span id="select-separator" class="text-text-muted">pending</span></p>
         </native-vstack>
     </native-card-body></native-card>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ContextMenu/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ContextMenu/Index.cshtml
@@ -1,0 +1,206 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.ContextMenu.FusionContextMenuModel
+@using System.Collections.Generic
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionContextMenu";
+
+    const string ContextMenuId = "resident-context-menu";
+    const string ContextTargetId = "resident-context-target";
+
+    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.ContextMenu.FusionContextMenuModel>();
+    var items = new List<MenuItem>
+    {
+        new() { Id = "dashboard-item", Text = "Dashboard" },
+        new()
+        {
+            Id = "projects-item",
+            Text = "Projects",
+            Items = new List<MenuItem>
+            {
+                new() { Id = "reports-item", Text = "Reports" },
+                new() { Id = "archive-item", Text = "Archive" }
+            }
+        },
+        new() { Id = "help-item", Text = "Help" }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        p.Element("before-item-state").SetText("pending");
+        p.Element("before-item-text").SetText("pending");
+        p.Element("before-item-id").SetText("pending");
+        p.Element("before-open-state").SetText("pending");
+        p.Element("before-open-kind").SetText("pending");
+        p.Element("before-open-top").SetText("pending");
+        p.Element("before-open-left").SetText("pending");
+        p.Element("before-open-parent").SetText("pending");
+        p.Element("before-open-cancel").SetText("pending");
+        p.Element("open-state").SetText("pending");
+        p.Element("open-kind").SetText("pending");
+        p.Element("menu-visibility").SetText("pending");
+        p.Element("before-close-state").SetText("pending");
+        p.Element("before-close-cancel").SetText("pending");
+        p.Element("close-state").SetText("pending");
+        p.Element("select-state").SetText("pending");
+        p.Element("select-text").SetText("pending");
+        p.Element("select-id").SetText("pending");
+        p.Element("select-url").SetText("pending");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionContextMenu</native-heading>
+    <native-text color="Secondary">
+        Context menu slice. Exercises programmatic open and close methods, typed nested item payloads, cancelable open and close guards, item render payloads, and item selection.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Controls</native-heading>
+        <native-vstack gap="Md">
+            <div class="flex flex-wrap gap-4">
+                @{ Html.InputField(plan, m => m.BlockOpen, o => o.Label("Block open"))
+                    .NativeCheckBox(b => b.CssClass("h-4 w-4 rounded border-border text-accent")); }
+                @{ Html.InputField(plan, m => m.BlockClose, o => o.Label("Block close"))
+                    .NativeCheckBox(b => b.CssClass("h-4 w-4 rounded border-border text-accent")); }
+            </div>
+
+            <native-hstack gap="Sm" class="flex-wrap">
+                @(Html.NativeButton("open-context-menu-btn", "Open menu")
+                    .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                    .Reactive(plan, evt => evt.Click, (_, p) =>
+                    {
+                        var menu = p.Component<FusionContextMenu>(ContextMenuId);
+                        menu.Open(96, 168);
+                    }))
+                @(Html.NativeButton("close-context-menu-btn", "Close menu")
+                    .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                    .Reactive(plan, evt => evt.Click, (_, p) =>
+                    {
+                        var menu = p.Component<FusionContextMenu>(ContextMenuId);
+                        menu.Close();
+                    }))
+            </native-hstack>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Target</native-heading>
+        <div id="@ContextTargetId" class="rounded-md border border-dashed border-border p-8 bg-slate-50 min-h-28">
+            <p class="text-sm text-text-secondary">
+                Right click here to open the context menu. The same menu can also be opened programmatically from the controls above.
+            </p>
+        </div>
+        @(Html.FusionContextMenu(plan, ContextMenuId, b =>
+        {
+            b.Target("#" + ContextTargetId);
+            b.Items(items);
+            b.EnableScrolling(false);
+            b.AnimationSettings(new ContextMenuAnimationSettings
+            {
+                Effect = MenuEffect.None,
+                Duration = 0,
+                Easing = "linear"
+            });
+        })
+        .Reactive(evt => evt.BeforeItemRender, (args, p) =>
+        {
+            p.Element("before-item-state").SetText("rendered");
+            p.Element("before-item-text").SetText(args, x => x.Item.Text);
+            p.Element("before-item-id").SetText(args, x => x.Item.Id);
+        })
+        .Reactive(evt => evt.BeforeOpen, (args, p) =>
+        {
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t =>
+                {
+                    t.Element("before-open-kind").SetText("root");
+                    t.Element("before-open-top").SetText(args, x => x.Top);
+                    t.Element("before-open-left").SetText(args, x => x.Left);
+                    t.Element("before-open-parent").SetText("root");
+                })
+                .Else(e =>
+                {
+                    e.Element("before-open-kind").SetText("submenu");
+                    e.Element("before-open-top").SetText(args, x => x.Top);
+                    e.Element("before-open-left").SetText(args, x => x.Left);
+                    e.Element("before-open-parent").SetText(args, x => x.ParentItem!.Text);
+                });
+
+            p.When(p.Component<NativeCheckBox>(m => m.BlockOpen).Value()).Truthy()
+                .Then(t =>
+                {
+                    t.Element("before-open-cancel").SetText("cancelled");
+                    args.PreventOpen(t);
+                })
+                .Else(e => e.Element("before-open-cancel").SetText("allowed"));
+        })
+        .Reactive(evt => evt.Opened, (args, p) =>
+        {
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t => t.Element("open-kind").SetText("root"))
+                .Else(e => e.Element("open-kind").SetText("submenu"));
+
+            p.Element("open-state").SetText("opened");
+            p.Element("menu-visibility").SetText("visible");
+        })
+        .Reactive(evt => evt.BeforeClose, (args, p) =>
+        {
+            p.Element("before-close-state").SetText("rendered");
+
+            p.When(p.Component<NativeCheckBox>(m => m.BlockClose).Value()).Truthy()
+                .Then(t =>
+                {
+                    t.Element("before-close-cancel").SetText("cancelled");
+                    args.PreventClose(t);
+                })
+                .Else(e => e.Element("before-close-cancel").SetText("allowed"));
+        })
+        .Reactive(evt => evt.Closed, (args, p) =>
+        {
+            p.Element("close-state").SetText("closed");
+            p.Element("menu-visibility").SetText("hidden");
+        })
+        .Reactive(evt => evt.Select, (args, p) =>
+        {
+            p.Element("select-state").SetText("selected");
+            p.Element("select-text").SetText(args, x => x.Item.Text);
+            p.Element("select-id").SetText(args, x => x.Item.Id);
+            p.Element("select-url").SetText(args, x => x.Item.Url);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Before item state: <span id="before-item-state" class="text-text-muted">pending</span></p>
+            <p>Before item text: <span id="before-item-text" class="text-text-muted">pending</span></p>
+            <p>Before item id: <span id="before-item-id" class="text-text-muted">pending</span></p>
+            <p>Before open state: <span id="before-open-state" class="text-text-muted">pending</span></p>
+            <p>Before open kind: <span id="before-open-kind" class="text-text-muted">pending</span></p>
+            <p>Before open top: <span id="before-open-top" class="text-text-muted">pending</span></p>
+            <p>Before open left: <span id="before-open-left" class="text-text-muted">pending</span></p>
+            <p>Before open parent: <span id="before-open-parent" class="text-text-muted">pending</span></p>
+            <p>Before open cancel: <span id="before-open-cancel" class="text-text-muted">pending</span></p>
+            <p>Open state: <span id="open-state" class="text-text-muted">pending</span></p>
+            <p>Open kind: <span id="open-kind" class="text-text-muted">pending</span></p>
+            <p>Menu visibility: <span id="menu-visibility" class="text-text-muted">pending</span></p>
+            <p>Before close state: <span id="before-close-state" class="text-text-muted">pending</span></p>
+            <p>Before close cancel: <span id="before-close-cancel" class="text-text-muted">pending</span></p>
+            <p>Close state: <span id="close-state" class="text-text-muted">pending</span></p>
+            <p>Select state: <span id="select-state" class="text-text-muted">pending</span></p>
+            <p>Select text: <span id="select-text" class="text-text-muted">pending</span></p>
+            <p>Select id: <span id="select-id" class="text-text-muted">pending</span></p>
+            <p>Select url: <span id="select-url" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/DropDownButton/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/DropDownButton/Index.cshtml
@@ -1,0 +1,175 @@
+@model FusionDropDownButtonModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionDropDownButton";
+
+    const string menuId = "resident-actions-menu";
+    var plan = Html.ReactivePlan<FusionDropDownButtonModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var menu = p.Component<FusionDropDownButton>(menuId);
+        menu.SetContent("Ready Actions");
+        p.Element("content-echo").SetText(menu.Content());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionDropDownButton</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Runtime State and Selection</native-heading>
+        <native-hstack gap="Base" align="Center">
+            @(Html.FusionDropDownButton(plan, menuId, b => b
+                .Content("Initial Actions")
+                .CssClass("care-actions")
+                .Items(new[]
+                {
+                    new { id = "view", text = "View profile", disabled = false },
+                    new { id = "assign", text = "Assign nurse", disabled = false },
+                    new { id = "hold", text = "Place hold", disabled = true }
+                }))
+                .Reactive(evt => evt.Selected, (args, p) =>
+                {
+                    p.Element("selected-id").SetText(args, x => x.Item.Id);
+                    p.Element("selected-text").SetText(args, x => x.Item.Text);
+                    p.Element("selected-disabled").SetText(args, x => x.Item.Disabled);
+                    p.When(args, x => x.Item.Id).Eq("assign")
+                        .Then(t => t.Element("selected-condition").SetText("assign selected"))
+                        .Else(e => e.Element("selected-condition").SetText("other selected"));
+                }))
+        </native-hstack>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-content-btn", "Set Content")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionDropDownButton>(menuId);
+                    menu.SetContent("Discharge Actions");
+                    p.Element("content-echo").SetText(menu.Content());
+                    p.Element("command-state").SetText("content set");
+                }))
+            @(Html.NativeButton("disable-menu-btn", "Disable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionDropDownButton>(menuId);
+                    menu.SetDisabled(true);
+                    p.Element("disabled-echo").SetText(menu.Disabled());
+                    p.Element("command-state").SetText("disabled");
+                }))
+            @(Html.NativeButton("enable-menu-btn", "Enable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionDropDownButton>(menuId);
+                    menu.SetDisabled(false);
+                    p.Element("disabled-echo").SetText(menu.Disabled());
+                    p.Element("command-state").SetText("enabled");
+                }))
+            @(Html.NativeButton("set-css-btn", "Set Css")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionDropDownButton>(menuId);
+                    menu.SetCssClass("e-success extra-class");
+                    p.Element("css-echo").SetText(menu.CssClass());
+                    p.Element("command-state").SetText("css set");
+                }))
+            @(Html.NativeButton("toggle-menu-btn", "Toggle Menu")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionDropDownButton>(menuId).Toggle();
+                    p.Element("toggle-state").SetText("toggle called");
+                }))
+            @(Html.NativeButton("focus-menu-btn", "Focus Menu")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionDropDownButton>(menuId).FocusIn();
+                    p.Element("focus-state").SetText("focus called");
+                }))
+            @(Html.NativeButton("remove-assign-btn", "Remove Assign")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionDropDownButton>(menuId).RemoveItemsByText("Assign nurse");
+                    p.Element("remove-state").SetText("assign removed");
+                }))
+            @(Html.NativeButton("remove-hold-btn", "Remove Hold")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionDropDownButton>(menuId).RemoveItemsById("hold");
+                    p.Element("remove-state").SetText("hold removed");
+                }))
+            @(Html.NativeButton("check-disabled-btn", "Check Disabled")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionDropDownButton>(menuId);
+                    p.When(menu.Disabled()).Eq(true)
+                        .Then(t => t.Element("disabled-state").SetText("disabled"))
+                        .Else(e => e.Element("disabled-state").SetText("enabled"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather DropDownButton")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var menu = p.Component<FusionDropDownButton>(menuId);
+                p.Post("/Sandbox/Components/FusionDropDownButton/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(menu.Content(), "content");
+                        g.Include(menu.Disabled(), "disabled");
+                        g.Include(menu.CssClass(), "cssClass");
+                    })
+                    .Response(r => r.OnSuccess<FusionDropDownButtonEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-content").SetText(json, x => x.Content);
+                        s.Element("gather-disabled").SetText(json, x => x.Disabled);
+                        s.Element("gather-css").SetText(json, x => x.CssClass);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Content echo: <span id="content-echo" class="text-text-muted">pending</span></p>
+            <p>Disabled echo: <span id="disabled-echo" class="text-text-muted">pending</span></p>
+            <p>Css echo: <span id="css-echo" class="text-text-muted">pending</span></p>
+            <p>Toggle state: <span id="toggle-state" class="text-text-muted">pending</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">pending</span></p>
+            <p>Remove state: <span id="remove-state" class="text-text-muted">pending</span></p>
+            <p>Disabled state: <span id="disabled-state" class="text-text-muted">pending</span></p>
+            <p>Selected id: <span id="selected-id" class="text-text-muted">pending</span></p>
+            <p>Selected text: <span id="selected-text" class="text-text-muted">pending</span></p>
+            <p>Selected disabled: <span id="selected-disabled" class="text-text-muted">pending</span></p>
+            <p>Selected condition: <span id="selected-condition" class="text-text-muted">pending</span></p>
+            <p>Gather content: <span id="gather-content" class="text-text-muted">pending</span></p>
+            <p>Gather disabled: <span id="gather-disabled" class="text-text-muted">pending</span></p>
+            <p>Gather css: <span id="gather-css" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/DropDownTree/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/DropDownTree/Index.cshtml
@@ -1,0 +1,163 @@
+@model FusionDropDownTreeModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@using Syncfusion.EJ2.DropDowns
+@{
+    ViewData["Title"] = "FusionDropDownTree";
+
+    var plan = Html.ReactivePlan<FusionDropDownTreeModel>();
+    var residents = (List<DropDownTreeResidentNode>)ViewBag.Residents;
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var tree = p.Component<FusionDropDownTree>(m => m.ResidentIds);
+        tree.SetValue(new[] { "alice" }).DataBind();
+        p.Element("text-echo").SetText(tree.Text());
+        p.When(tree.Value()).NotEmpty()
+            .Then(t => t.Element("value-state").SetText("has values"))
+            .Else(e => e.Element("value-state").SetText("empty"));
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionDropDownTree</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Resident Tree</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.ResidentIds, o => o.Label("Resident (SF DropDownTree)"))
+                .FusionDropDownTree(b => b
+                    .Fields(new DropDownTreeFields
+                    {
+                        DataSource = residents,
+                        Value = "value",
+                        Text = "text",
+                        ParentValue = "parentValue",
+                        HasChildren = "hasChildren",
+                        Expanded = "expanded"
+                    })
+                    .Placeholder("Select resident")
+                    .ChangeOnBlur(false)
+                    .PopupHeight("180px")
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        p.Element("change-interacted").SetText(args, x => x.IsInteracted);
+                        p.When(args, x => x.Value).NotEmpty()
+                            .Then(t => t.Element("change-value-state").SetText("has values"))
+                            .Else(e => e.Element("change-value-state").SetText("empty"));
+                        p.When(args, x => x.OldValue).NotEmpty()
+                            .Then(t => t.Element("change-old-value-state").SetText("had old values"))
+                            .Else(e => e.Element("change-old-value-state").SetText("no old values"));
+
+                        var tree = p.Component<FusionDropDownTree>(m => m.ResidentIds);
+                        p.Element("event-text").SetText(tree.Text());
+                        p.When(tree.Value()).NotEmpty()
+                            .Then(t =>
+                            {
+                                t.Element("selected-indicator").Show();
+                                t.Element("selected-indicator").SetText("selected");
+                            })
+                            .Else(e => e.Element("selected-indicator").Hide());
+                    })); }
+        </native-grid>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-value-btn", "Set Value")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var tree = p.Component<FusionDropDownTree>(m => m.ResidentIds);
+                    tree.SetValue(new[] { "bennett" }).DataBind();
+                    p.Element("text-echo").SetText(tree.Text());
+                    p.When(tree.Value()).NotEmpty()
+                        .Then(t => t.Element("value-state").SetText("has values"))
+                        .Else(e => e.Element("value-state").SetText("empty"));
+                    p.Element("command-state").SetText("value set");
+                }))
+            @(Html.NativeButton("set-text-btn", "Set Text")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var tree = p.Component<FusionDropDownTree>(m => m.ResidentIds);
+                    tree.SetText("Carey").DataBind();
+                    p.Element("text-echo").SetText(tree.Text());
+                    p.Element("command-state").SetText("text set");
+                }))
+            @(Html.NativeButton("show-popup-btn", "Show Popup")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionDropDownTree>(m => m.ResidentIds).ShowPopup();
+                }))
+            @(Html.NativeButton("hide-popup-btn", "Hide Popup")
+                .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionDropDownTree>(m => m.ResidentIds).HidePopup();
+                }))
+            @(Html.NativeButton("clear-tree-btn", "Clear")
+                .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var tree = p.Component<FusionDropDownTree>(m => m.ResidentIds);
+                    tree.Clear();
+                    p.Element("command-state").SetText("cleared");
+                    p.Element("text-echo").SetText(tree.Text());
+                    p.When(tree.Value()).NotEmpty()
+                        .Then(t => t.Element("value-state").SetText("has values"))
+                        .Else(e => e.Element("value-state").SetText("empty"));
+                    p.When(tree.Value()).NotEmpty()
+                        .Then(t => t.Element("selected-indicator").Show())
+                        .Else(e => e.Element("selected-indicator").Hide());
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather DropDownTree")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var tree = p.Component<FusionDropDownTree>(m => m.ResidentIds);
+                p.Post("/Sandbox/Components/FusionDropDownTree/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(tree.Value(), "value");
+                        g.Include(tree.Text(), "text");
+                    })
+                    .Response(r => r.OnSuccess<FusionDropDownTreeEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-value").SetText(json, x => x.ValueSummary);
+                        s.Element("gather-text").SetText(json, x => x.Text);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Text echo: <span id="text-echo" class="text-text-muted">pending</span></p>
+            <p>Value state: <span id="value-state" class="text-text-muted">pending</span></p>
+            <p>Change interacted: <span id="change-interacted" class="text-text-muted">pending</span></p>
+            <p>Change value state: <span id="change-value-state" class="text-text-muted">pending</span></p>
+            <p>Change old value state: <span id="change-old-value-state" class="text-text-muted">pending</span></p>
+            <p>Event text: <span id="event-text" class="text-text-muted">pending</span></p>
+            <p>Selected: <span id="selected-indicator" hidden class="text-emerald-600">pending</span></p>
+            <p>Gather value: <span id="gather-value" class="text-text-muted">pending</span></p>
+            <p>Gather text: <span id="gather-text" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Billing.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Billing.cshtml
@@ -1,0 +1,382 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.ResidentBillingViewModel
+@using Alis.Reactive
+@using Alis.Reactive.Builders
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Fusion.Templates
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@using Syncfusion.EJ2.Grids
+@{
+    ViewData["Title"] = "FusionGrid Month-End Billing";
+
+    const string GridId = "billing-grid";
+    const string AddFormId = "billing-add-form";
+    const string ButtonPrimary = "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90";
+    const string ButtonSecondary = "rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle";
+    const string ButtonAccent = "rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90";
+
+    var plan = Html.ReactivePlan<ResidentBillingViewModel>();
+    var careLevels = (List<string>)ViewBag.CareLevels;
+    var wings = (List<string>)ViewBag.Wings;
+    var statuses = (List<string>)ViewBag.Statuses;
+
+    var statusTemplate = FusionTemplate.Create<ResidentBillingItem>()
+        .When(m => m.BillingStatus == "Paid",
+            then: t => t.Badge(m => m.BillingStatus, "rounded bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700"),
+            @else: e => e.Badge(m => m.BillingStatus, "rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700"))
+        .Render();
+
+    void LoadBilling(PipelineBuilder<ResidentBillingViewModel> p, string status)
+    {
+        p.Post("/Sandbox/Components/Grid/BillingData")
+            .Gather(g =>
+            {
+                g.Static("skip", 0);
+                g.Static("take", 12);
+            })
+            .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+            {
+                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                s.Element("billing-summary").SetText(json, x => x.Summary);
+                s.Element("billing-status").SetText(status);
+            }));
+    }
+
+    Html.On(plan, t => t.DomReady(p => LoadBilling(p, "loaded current census")));
+}
+
+<!-- Templated "Add charge" dialog -->
+<div id="add-charge-dialog" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4">
+    <div class="w-full max-w-lg rounded-lg border border-border bg-white p-6 shadow-xl">
+        <native-heading level="H2">Add Resident Charge</native-heading>
+        <native-text color="Secondary">Open a new monthly charge for a resident. Validated before it posts.</native-text>
+        <form id="@AddFormId" class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            @{ Html.InputField(plan, m => m.NewResidentName, o => o.Required().Label("Resident"))
+                .FusionTextBox(b => b.Placeholder("Resident name").ShowClearButton(true)); }
+            @{ Html.InputField(plan, m => m.NewCareLevel, o => o.Required().Label("Care level"))
+                .FusionDropDownList(b => b.DataSource(careLevels).Placeholder("Select care level")); }
+            @{ Html.InputField(plan, m => m.NewMonthlyRate, o => o.Required().Label("Monthly rate"))
+                .FusionNumericTextBox(b => b.Format("c0").Min(0).Max(20000).Step(50).Placeholder("0")); }
+            @{ Html.InputField(plan, m => m.NewAddOnCharges, o => o.Required().Label("Add-on charges"))
+                .FusionNumericTextBox(b => b.Format("c0").Min(0).Max(5000).Step(25).Placeholder("0")); }
+        </form>
+        <div data-reactive-validation-summary hidden
+             class="mt-3 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700"></div>
+        <native-hstack gap="Sm" justify="End" class="mt-5">
+            @(Html.NativeButton("add-charge-cancel", "Cancel")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Element("add-charge-dialog").AddClass("hidden");
+                }))
+            @(Html.NativeButton("add-charge-save", "Save Charge")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/BillingAddCharge", g =>
+                    {
+                        g.Include<FusionTextBox, ResidentBillingViewModel>(m => m.NewResidentName);
+                        g.Include<FusionDropDownList, ResidentBillingViewModel>(m => m.NewCareLevel);
+                        g.Include<FusionNumericTextBox, ResidentBillingViewModel>(m => m.NewMonthlyRate);
+                        g.Include<FusionNumericTextBox, ResidentBillingViewModel>(m => m.NewAddOnCharges);
+                    })
+                    .Validate<ResidentBillingAddValidator>(AddFormId)
+                    .Response(r => r
+                        .OnSuccess<ResidentBillingResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("billing-summary").SetText(json, x => x.Summary);
+                            s.Element("billing-status").SetText("charge added");
+                            s.Element("add-charge-dialog").AddClass("hidden");
+                        })
+                        .OnError(400, e =>
+                        {
+                            e.ValidationErrors(AddFormId);
+                            e.Element("billing-status").SetText("add validation failed");
+                        }));
+                }))
+        </native-hstack>
+    </div>
+</div>
+
+<native-vstack gap="Lg">
+    <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
+        <div>
+            <native-heading level="H1">Month-End Billing Board</native-heading>
+            <native-text color="Secondary">
+                Server-side filtering, bulk batch charge edits, rate increases, and templated-dialog admits over the resident census.
+            </native-text>
+        </div>
+        <native-hstack gap="Sm" class="flex-wrap">
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Directory grid
+            </a>
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Editing"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Editing grid
+            </a>
+        </native-hstack>
+    </native-hstack>
+
+    <!-- Filter panel: our own buttons, server-side reload -->
+    <native-card><native-card-body>
+        <native-heading level="H2">Filter Census</native-heading>
+        <native-grid cols="C3" gap="Base" class="mt-4">
+            @{ Html.InputField(plan, m => m.FilterCareLevel, o => o.Label("Care level"))
+                .FusionDropDownList(b => b.DataSource(careLevels).Placeholder("All care levels")); }
+            @{ Html.InputField(plan, m => m.FilterWing, o => o.Label("Wing"))
+                .FusionDropDownList(b => b.DataSource(wings).Placeholder("All wings")); }
+            @{ Html.InputField(plan, m => m.FilterStatus, o => o.Label("Status"))
+                .FusionDropDownList(b => b.DataSource(statuses).Placeholder("All statuses")); }
+        </native-grid>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("billing-apply-filters", "Apply Filters")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/BillingData")
+                        .Gather(g =>
+                        {
+                            g.Static("skip", 0);
+                            g.Static("take", 12);
+                            g.Include<FusionDropDownList, ResidentBillingViewModel>(m => m.FilterCareLevel);
+                            g.Include<FusionDropDownList, ResidentBillingViewModel>(m => m.FilterWing);
+                            g.Include<FusionDropDownList, ResidentBillingViewModel>(m => m.FilterStatus);
+                        })
+                        .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("billing-summary").SetText(json, x => x.Summary);
+                            s.Element("billing-status").SetText("filters applied");
+                        }));
+                }))
+            @(Html.NativeButton("billing-quick-unbilled", "Unbilled Only")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/BillingData")
+                        .Gather(g =>
+                        {
+                            g.Static("skip", 0);
+                            g.Static("take", 12);
+                            g.Static("filterStatus", "Pending");
+                        })
+                        .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("billing-summary").SetText(json, x => x.Summary);
+                            s.Element("billing-status").SetText("showing unbilled residents");
+                        }));
+                }))
+            @(Html.NativeButton("billing-quick-memory", "Memory Care")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/BillingData")
+                        .Gather(g =>
+                        {
+                            g.Static("skip", 0);
+                            g.Static("take", 12);
+                            g.Static("filterCareLevel", "Memory Care");
+                        })
+                        .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("billing-summary").SetText(json, x => x.Summary);
+                            s.Element("billing-status").SetText("showing memory care residents");
+                        }));
+                }))
+            @(Html.NativeButton("billing-clear-filters", "Clear")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    LoadBilling(p, "filters cleared");
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <!-- Bulk operations panel -->
+    <native-card><native-card-body>
+        <native-heading level="H2">Bulk Charge Operations</native-heading>
+        <native-text color="Secondary">
+            Edit Monthly Rate and Add-ons in the grid, select residents, then save or bulk-apply. Every change posts to the server.
+        </native-text>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("billing-add-open", "Add Charge")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Element("add-charge-dialog").RemoveClass("hidden");
+                }))
+            @(Html.NativeButton("billing-save-all", "Save All Charges")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    grid.SaveCell();
+                    p.Post("/Sandbox/Components/Grid/BillingSave")
+                        .Gather(g => g.Include(grid.BatchChanges<ResidentBillingViewModel, ResidentBillingItem>(), "batchChanges"))
+                        .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("billing-summary").SetText(json, x => x.Summary);
+                            s.Element("billing-status").SetText("charges saved");
+                        }));
+                }))
+            @(Html.NativeButton("billing-bulk-increase", "Apply 5% Increase To Selected")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/BillingBulkIncrease")
+                        .Gather(g =>
+                        {
+                            g.Static("percent", 5);
+                            g.Include(grid.SelectedRecords<ResidentBillingViewModel, ResidentBillingItem>(), "selectedRecords");
+                        })
+                        .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("billing-summary").SetText(json, x => x.Summary);
+                            s.Element("billing-status").SetText("rate increase applied");
+                        }));
+                }))
+            @(Html.NativeButton("billing-mark-billed", "Mark Selected Billed")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/BillingMarkBilled")
+                        .Gather(g => g.Include(grid.SelectedRecords<ResidentBillingViewModel, ResidentBillingItem>(), "selectedRecords"))
+                        .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("billing-summary").SetText(json, x => x.Summary);
+                            s.Element("billing-status").SetText("residents marked billed");
+                        }));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <!-- Tooling panel: onboarded export / print / column-chooser / auto-fit methods -->
+    <native-card><native-card-body>
+        <native-heading level="H2">Roster Tools</native-heading>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("billing-export-excel", "Export Excel")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).ExcelExport();
+                    p.Element("tool-status").SetText("excel export started");
+                }))
+            @(Html.NativeButton("billing-export-csv", "Export CSV")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).CsvExport();
+                    p.Element("tool-status").SetText("csv export started");
+                }))
+            @(Html.NativeButton("billing-export-pdf", "Export PDF")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).PdfExport();
+                    p.Element("tool-status").SetText("pdf export started");
+                }))
+            @(Html.NativeButton("billing-print", "Print Roster")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).Print();
+                    p.Element("tool-status").SetText("print opened");
+                }))
+            @(Html.NativeButton("billing-columns", "Choose Columns")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).ShowColumnChooser();
+                    p.Element("tool-status").SetText("column chooser opened");
+                }))
+            @(Html.NativeButton("billing-autofit", "Auto-fit Columns")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).AutoFitColumns();
+                    p.Element("tool-status").SetText("columns auto-fitted");
+                }))
+        </native-hstack>
+        <native-vstack gap="Xs" class="mt-4 font-mono text-sm">
+            <p>Status: <span id="billing-status" class="text-text-muted">waiting</span></p>
+            <p>Summary: <span id="billing-summary" class="text-text-muted">waiting</span></p>
+            <p>Tools: <span id="tool-status" class="text-text-muted">waiting</span></p>
+            <p>Toolbar: <span id="toolbar-status" class="text-text-muted">waiting</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        @(Html.FusionGrid<ResidentBillingViewModel, ResidentBillingItem>(plan, GridId, b => b
+            .AllowPaging(true)
+            .AllowSorting(true)
+            .AllowSelection(true)
+            .AllowExcelExport(true)
+            .AllowPdfExport(true)
+            .ShowColumnChooser(true)
+            .Toolbar(new List<object>
+            {
+                new { text = "Email Statements", id = "emailStatements", tooltipText = "Email statements", prefixIcon = "e-icons e-send-1" },
+                "ColumnChooser"
+            })
+            .PageSettings(new GridPageSettings { PageSize = 12 })
+            .SelectionSettings(new GridSelectionSettings { Type = SelectionType.Multiple, PersistSelection = true })
+            .EditSettings(new GridEditSettings
+            {
+                AllowEditing = true,
+                Mode = EditMode.Batch,
+                ShowConfirmDialog = false
+            })
+            .Columns(new List<GridColumn>
+            {
+                new GridColumn { Field = "residentId", HeaderText = "ID", Width = "70", TextAlign = TextAlign.Right, IsPrimaryKey = true, AllowEditing = false },
+                new GridColumn { Field = "residentName", HeaderText = "Resident", Width = "170", AllowEditing = false },
+                new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "150", AllowEditing = false },
+                new GridColumn { Field = "wing", HeaderText = "Wing", Width = "90", AllowEditing = false },
+                new GridColumn { Field = "monthlyRate", HeaderText = "Monthly Rate", Width = "140", Format = "C0", TextAlign = TextAlign.Right, EditType = "numericedit" },
+                new GridColumn { Field = "addOnCharges", HeaderText = "Add-ons", Width = "120", Format = "C0", TextAlign = TextAlign.Right, EditType = "numericedit" },
+                new GridColumn { Field = "balanceDue", HeaderText = "Balance Due", Width = "140", Format = "C0", TextAlign = TextAlign.Right, AllowEditing = false },
+                new GridColumn { Field = "billingStatus", HeaderText = "Status", Width = "120", AllowEditing = false, Template = statusTemplate }
+            }))
+            .Reactive(evt => evt.DataStateChange, (args, p) =>
+            {
+                p.When(args, x => x.Action.RequestType).NotEq(FusionGridAction.Refresh)
+                    .Then(t =>
+                    {
+                        t.Post("/Sandbox/Components/Grid/BillingData")
+                            .Gather(g =>
+                            {
+                                g.FromEvent(args, x => x.Skip, "skip");
+                                g.FromEvent(args, x => x.Take, "take");
+                                g.FromEvent(args, x => x.Sorted, "sorted");
+                                g.Include<FusionDropDownList, ResidentBillingViewModel>(m => m.FilterCareLevel);
+                                g.Include<FusionDropDownList, ResidentBillingViewModel>(m => m.FilterWing);
+                                g.Include<FusionDropDownList, ResidentBillingViewModel>(m => m.FilterStatus);
+                            })
+                            .Response(r => r.OnSuccess<ResidentBillingResponse>((json, s) =>
+                            {
+                                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                                s.Element("billing-summary").SetText(json, x => x.Summary);
+                                s.Element("billing-status").SetText("grid state sent to server");
+                            }));
+                    });
+            })
+            .Reactive(evt => evt.ToolbarClick, (args, p) =>
+            {
+                p.When(args, x => x.Item.Id).Eq("emailStatements")
+                    .Then(t => t.Element("toolbar-status").SetText("statements queued for emailing"));
+            }))
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/CareOps.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/CareOps.cshtml
@@ -9,8 +9,13 @@
 @using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
 @using Syncfusion.EJ2.Buttons
 @using Syncfusion.EJ2.Grids
+@inject Alis.Reactive.Validation.IClientValidationRuleSource ClientRules
 @{
     ViewData["Title"] = "FusionGrid Care Operations";
+
+    // EJ2-native column validation generated from the SAME ResidentCareItemValidator
+    // ClientRule metadata — single source, client-side in-cell validation for free.
+    var careValidation = FusionGridValidation.From<ResidentCareItemValidator, ResidentCareItem>(ClientRules);
 
     const string GridId = "careops-grid";
     const string AdmitFormId = "careops-admit-form";
@@ -300,7 +305,7 @@
                 new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "180", EditTemplate = FusionGridEditTemplates.Select((ResidentCareItem r) => r.CareLevel, careLevelEditOptions) },
                 new GridColumn { Field = "riskLevel", HeaderText = "Risk", Width = "150", Template = riskTemplate, EditTemplate = FusionGridEditTemplates.Select((ResidentCareItem r) => r.RiskLevel, riskEditOptions) },
                 new GridColumn { Field = "primaryNurse", HeaderText = "Primary Nurse", Width = "200", EditTemplate = FusionGridEditTemplates.Select((ResidentCareItem r) => r.PrimaryNurse, nurseEditOptions) },
-                new GridColumn { Field = "openTasks", HeaderText = "Open Tasks", Width = "130", TextAlign = TextAlign.Right, EditType = "numericedit" },
+                new GridColumn { Field = "openTasks", HeaderText = "Open Tasks", Width = "130", TextAlign = TextAlign.Right, EditType = "numericedit", ValidationRules = careValidation.Field(r => r.OpenTasks) },
                 new GridColumn { Field = "nextReview", HeaderText = "Next Review", Width = "150", EditTemplate = FusionGridEditTemplates.DateInput((ResidentCareItem r) => r.NextReview) }
             }))
             .Reactive(evt => evt.DataStateChange, (args, p) =>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/CareOps.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/CareOps.cshtml
@@ -1,0 +1,339 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.CareOpsViewModel
+@using Alis.Reactive
+@using Alis.Reactive.Builders
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Fusion.Templates
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@using Syncfusion.EJ2.Buttons
+@using Syncfusion.EJ2.Grids
+@{
+    ViewData["Title"] = "FusionGrid Care Operations";
+
+    const string GridId = "careops-grid";
+    const string AdmitFormId = "careops-admit-form";
+    const string ButtonPrimary = "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90";
+    const string ButtonSecondary = "rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle";
+    const string ButtonAccent = "rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90";
+
+    var plan = Html.ReactivePlan<CareOpsViewModel>();
+    var wings = (List<string>)ViewBag.Wings;
+    var careLevels = (List<string>)ViewBag.CareLevels;
+    var riskLevels = (List<string>)ViewBag.RiskLevels;
+    var nurses = (List<string>)ViewBag.Nurses;
+    var careLevelEditOptions = careLevels.Where(c => !string.IsNullOrEmpty(c)).ToArray();
+    var riskEditOptions = riskLevels.Where(r => !string.IsNullOrEmpty(r)).ToArray();
+    var nurseEditOptions = nurses.ToArray();
+
+    var riskChips = new List<ChipCollection>
+    {
+        new() { Text = "All" }, new() { Text = "Low" }, new() { Text = "Moderate" },
+        new() { Text = "High" }, new() { Text = "Critical" }
+    };
+    var careChips = new List<ChipCollection>
+    {
+        new() { Text = "All" }, new() { Text = "Independent" }, new() { Text = "Assisted Living" },
+        new() { Text = "Memory Care" }, new() { Text = "Skilled Nursing" }
+    };
+
+    var riskTemplate = FusionTemplate.Create<ResidentCareItem>()
+        .When(m => m.RiskLevel == "Critical",
+            then: t => t.Badge(m => m.RiskLevel, "rounded bg-red-100 px-2 py-0.5 text-xs font-bold text-red-700"),
+            @else: e => e.Badge(m => m.RiskLevel, "rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700"))
+        .Render();
+
+    void LoadCareOps(PipelineBuilder<CareOpsViewModel> p, string status)
+    {
+        p.Post("/Sandbox/Components/Grid/CareOpsData")
+            .Gather(g => { g.Static("skip", 0); g.Static("take", 10); })
+            .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+            {
+                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                s.Element("careops-summary").SetText(json, x => x.Summary);
+                s.Element("careops-status").SetText(status);
+            }));
+    }
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        LoadCareOps(p, "loaded care census");
+        p.Get("/Sandbox/Components/Grid/CareOpsActionRows")
+            .Response(r => r.OnSuccess(s => s.Into("careops-action-rows")));
+    }));
+
+    Html.On(plan, t => t.CustomEvent("careops-rows-refresh", p =>
+    {
+        p.Get("/Sandbox/Components/Grid/CareOpsActionRows")
+            .Response(r => r.OnSuccess(s => s.Into("careops-action-rows")));
+    }));
+
+    Html.On(plan, t => t.CustomEvent("careops-rows-refresh", p => LoadCareOps(p, "census updated")));
+}
+
+<!-- Templated "Admit resident" dialog -->
+<div id="admit-dialog" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4">
+    <div class="w-full max-w-xl rounded-lg border border-border bg-white p-6 shadow-xl">
+        <native-heading level="H2">Admit Resident</native-heading>
+        <native-text color="Secondary">Validated through the same ReactiveValidator the form layer uses.</native-text>
+        <form id="@AdmitFormId" class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            @{ Html.InputField(plan, m => m.NewResidentName, o => o.Required().Label("Resident"))
+                .FusionTextBox(b => b.Placeholder("Resident name").ShowClearButton(true)); }
+            @{ Html.InputField(plan, m => m.NewWing, o => o.Required().Label("Wing"))
+                .FusionDropDownList(b => b.DataSource(wings).Placeholder("Select wing")); }
+            @{ Html.InputField(plan, m => m.NewCareLevel, o => o.Required().Label("Care level"))
+                .FusionDropDownList(b => b.DataSource(careLevels).Placeholder("Select care level")); }
+            @{ Html.InputField(plan, m => m.NewRiskLevel, o => o.Required().Label("Risk level"))
+                .FusionDropDownList(b => b.DataSource(riskLevels).Placeholder("Select risk")); }
+            @{ Html.InputField(plan, m => m.NewOpenTasks, o => o.Required().Label("Open tasks"))
+                .FusionNumericTextBox(b => b.Format("n0").Min(0).Max(12).Step(1).Placeholder("0")); }
+        </form>
+        <div data-reactive-validation-summary hidden
+             class="mt-3 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700"></div>
+        <native-hstack gap="Sm" justify="End" class="mt-5">
+            @(Html.NativeButton("admit-cancel", "Cancel")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) => { p.Element("admit-dialog").AddClass("hidden"); }))
+            @(Html.NativeButton("admit-save", "Admit")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/CareOpsAdmit", g =>
+                    {
+                        g.Include<FusionTextBox, CareOpsViewModel>(m => m.NewResidentName);
+                        g.Include<FusionDropDownList, CareOpsViewModel>(m => m.NewWing);
+                        g.Include<FusionDropDownList, CareOpsViewModel>(m => m.NewCareLevel);
+                        g.Include<FusionDropDownList, CareOpsViewModel>(m => m.NewRiskLevel);
+                        g.Include<FusionNumericTextBox, CareOpsViewModel>(m => m.NewOpenTasks);
+                    })
+                    .Validate<CareOpsAdmitValidator>(AdmitFormId)
+                    .Response(r => r
+                        .OnSuccess<CareOpsResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("careops-summary").SetText(json, x => x.Summary);
+                            s.Element("careops-status").SetText("resident admitted");
+                            s.Element("admit-dialog").AddClass("hidden");
+                        })
+                        .OnError(400, e =>
+                        {
+                            e.ValidationErrors(AdmitFormId);
+                            e.Element("careops-status").SetText("admit validation failed");
+                        }));
+                }))
+        </native-hstack>
+    </div>
+</div>
+
+<native-vstack gap="Lg">
+    <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
+        <div>
+            <native-heading level="H1">Care Operations Board</native-heading>
+            <native-text color="Secondary">
+                Chip fast-filters, checkbox bulk selection, dropdown/date cell editors, frozen columns, sticky header, and per-row discharge action links.
+            </native-text>
+        </div>
+        <native-hstack gap="Sm" class="flex-wrap">
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Billing"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Billing board
+            </a>
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Editing"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Editing grid
+            </a>
+        </native-hstack>
+    </native-hstack>
+
+    <!-- Chip fast filters -->
+    <native-card><native-card-body>
+        <native-heading level="H2">Fast Filters</native-heading>
+        <native-vstack gap="Sm" class="mt-4">
+            <div>
+                <p class="mb-1 text-xs font-medium uppercase tracking-wide text-text-muted">Risk</p>
+                @(Html.FusionChipList(plan, "careops-risk-chips", b => b
+                    .Chips(riskChips)
+                    .Selection(Selection.Single))
+                    .Reactive(evt => evt.Clicked, (args, p) =>
+                    {
+                        p.Post("/Sandbox/Components/Grid/CareOpsData")
+                            .Gather(g =>
+                            {
+                                g.Static("skip", 0);
+                                g.Static("take", 10);
+                                g.FromEvent(args, x => x.Text, "filterRisk");
+                            })
+                            .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+                            {
+                                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                                s.Element("careops-summary").SetText(json, x => x.Summary);
+                                s.Element("careops-status").SetText(args, x => x.Text);
+                            }));
+                    }))
+            </div>
+            <div>
+                <p class="mb-1 text-xs font-medium uppercase tracking-wide text-text-muted">Care level</p>
+                @(Html.FusionChipList(plan, "careops-care-chips", b => b
+                    .Chips(careChips)
+                    .Selection(Selection.Single))
+                    .Reactive(evt => evt.Clicked, (args, p) =>
+                    {
+                        p.Post("/Sandbox/Components/Grid/CareOpsData")
+                            .Gather(g =>
+                            {
+                                g.Static("skip", 0);
+                                g.Static("take", 10);
+                                g.FromEvent(args, x => x.Text, "filterCareLevel");
+                            })
+                            .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+                            {
+                                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                                s.Element("careops-summary").SetText(json, x => x.Summary);
+                                s.Element("careops-status").SetText(args, x => x.Text);
+                            }));
+                    }))
+            </div>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <!-- Bulk operations -->
+    <native-card><native-card-body>
+        <native-heading level="H2">Bulk Care Operations</native-heading>
+        <native-text color="Secondary">
+            Select residents with the checkboxes, edit Care Level / Risk / Nurse / Tasks / Review date in the grid, then save or bulk-apply.
+        </native-text>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("careops-admit-open", "Admit Resident")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) => { p.Element("admit-dialog").RemoveClass("hidden"); }))
+            @(Html.NativeButton("careops-save-all", "Save All Care Edits")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    grid.SaveCell();
+                    p.Post("/Sandbox/Components/Grid/CareOpsSave")
+                        .Gather(g => g.Include(grid.BatchChanges<CareOpsViewModel, ResidentCareItem>(), "batchChanges"))
+                        .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("careops-summary").SetText(json, x => x.Summary);
+                            s.Element("careops-status").SetText("care edits saved");
+                        }));
+                }))
+            @(Html.NativeButton("careops-reassign", "Reassign Selected To Night Float")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/CareOpsBulkNurse")
+                        .Gather(g =>
+                        {
+                            g.Static("nurse", "Night Float Team");
+                            g.Include(grid.SelectedRecords<CareOpsViewModel, ResidentCareItem>(), "selectedRecords");
+                        })
+                        .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("careops-summary").SetText(json, x => x.Summary);
+                            s.Element("careops-status").SetText("nurse reassigned");
+                        }));
+                }))
+            @(Html.NativeButton("careops-flag-risk", "Flag Selected Critical")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/CareOpsBulkRisk")
+                        .Gather(g =>
+                        {
+                            g.Static("risk", "Critical");
+                            g.Include(grid.SelectedRecords<CareOpsViewModel, ResidentCareItem>(), "selectedRecords");
+                        })
+                        .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(GridId).SetDataSource(json);
+                            s.Element("careops-summary").SetText(json, x => x.Summary);
+                            s.Element("careops-status").SetText("residents flagged critical");
+                        }));
+                }))
+            @(Html.NativeActionLink("Discharge Selected", "/Sandbox/Components/Grid/CareOpsDischargeSelected", p => p
+                .Confirm("Discharge the selected resident(s) from the active census?")
+                .Then(t2 => t2.Post("/Sandbox/Components/Grid/CareOpsDischargeSelected")
+                    .Gather(g => g.Include(p.Component<FusionGrid>(GridId).SelectedRecords<CareOpsViewModel, ResidentCareItem>(), "selectedRecords"))
+                    .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+                    {
+                        s.Component<FusionGrid>(GridId).SetDataSource(json);
+                        s.Element("careops-summary").SetText(json, x => x.Summary);
+                        s.Element("careops-status").SetText("resident discharged");
+                    }))))
+                .CssClass("inline-flex items-center rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700"))
+        </native-hstack>
+        <native-vstack gap="Xs" class="mt-4 font-mono text-sm">
+            <p>Status: <span id="careops-status" class="text-text-muted">waiting</span></p>
+            <p>Summary: <span id="careops-summary" class="text-text-muted">waiting</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        @(Html.FusionGrid<CareOpsViewModel, ResidentCareItem>(plan, GridId, b => b
+            .AllowPaging(true)
+            .AllowSorting(true)
+            .AllowSelection(true)
+            .EnableStickyHeader(true)
+            .Height("360")
+            .SelectionSettings(new GridSelectionSettings
+            {
+                Type = SelectionType.Multiple,
+                CheckboxMode = CheckboxSelectionType.Default,
+                PersistSelection = true
+            })
+            .EditSettings(new GridEditSettings { AllowEditing = true, Mode = EditMode.Batch, ShowConfirmDialog = false })
+            .PageSettings(new GridPageSettings { PageSize = 10 })
+            .Columns(new List<GridColumn>
+            {
+                new GridColumn { Type = "checkbox", Width = "50", AllowEditing = false, Freeze = FreezeDirection.Left },
+                new GridColumn { Field = "residentId", HeaderText = "ID", Width = "90", TextAlign = TextAlign.Right, IsPrimaryKey = true, AllowEditing = false, Freeze = FreezeDirection.Left },
+                new GridColumn { Field = "residentName", HeaderText = "Resident", Width = "190", AllowEditing = false, Freeze = FreezeDirection.Left },
+                new GridColumn { Field = "wing", HeaderText = "Wing", Width = "120", AllowEditing = false },
+                new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "180", EditTemplate = FusionGridEditTemplates.Select((ResidentCareItem r) => r.CareLevel, careLevelEditOptions) },
+                new GridColumn { Field = "riskLevel", HeaderText = "Risk", Width = "150", Template = riskTemplate, EditTemplate = FusionGridEditTemplates.Select((ResidentCareItem r) => r.RiskLevel, riskEditOptions) },
+                new GridColumn { Field = "primaryNurse", HeaderText = "Primary Nurse", Width = "200", EditTemplate = FusionGridEditTemplates.Select((ResidentCareItem r) => r.PrimaryNurse, nurseEditOptions) },
+                new GridColumn { Field = "openTasks", HeaderText = "Open Tasks", Width = "130", TextAlign = TextAlign.Right, EditType = "numericedit" },
+                new GridColumn { Field = "nextReview", HeaderText = "Next Review", Width = "150", EditTemplate = FusionGridEditTemplates.DateInput((ResidentCareItem r) => r.NextReview) }
+            }))
+            .Reactive(evt => evt.DataStateChange, (args, p) =>
+            {
+                p.When(args, x => x.Action.RequestType).NotEq(FusionGridAction.Refresh)
+                    .Then(t =>
+                    {
+                        t.Post("/Sandbox/Components/Grid/CareOpsData")
+                            .Gather(g =>
+                            {
+                                g.FromEvent(args, x => x.Skip, "skip");
+                                g.FromEvent(args, x => x.Take, "take");
+                                g.FromEvent(args, x => x.Sorted, "sorted");
+                            })
+                            .Response(r => r.OnSuccess<CareOpsResponse>((json, s) =>
+                            {
+                                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                                s.Element("careops-summary").SetText(json, x => x.Summary);
+                                s.Element("careops-status").SetText("grid state sent to server");
+                            }));
+                    });
+            }))
+    </native-card-body></native-card>
+
+    <!-- Per-resident NativeActionLink quick actions (server-rendered partial, Into-injected) -->
+    <native-card><native-card-body>
+        <native-heading level="H2">Per-Resident Quick Actions</native-heading>
+        <native-text color="Secondary">
+            Each row is a real NativeActionLink — Flag Critical (immediate) and Discharge (confirm-gated). The list re-injects itself after each action.
+        </native-text>
+        <p class="mt-2 font-mono text-sm">Action: <span id="careops-rows-status" class="text-text-muted">waiting</span></p>
+        <div id="careops-action-rows" class="mt-3"></div>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Directory.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Directory.cshtml
@@ -1,0 +1,381 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.ResidentDirectoryModel
+@using Alis.Reactive
+@using Alis.Reactive.Builders
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@using Syncfusion.EJ2.Grids
+@{
+    ViewData["Title"] = "FusionGrid Resident Directory";
+
+    const string GridId = "resident-directory-grid";
+    const string VirtualGridId = "resident-virtual-grid";
+    var plan = Html.ReactivePlan<ResidentDirectoryModel>();
+    var careLevels = (List<string>)ViewBag.CareLevels;
+    var riskLevels = (List<string>)ViewBag.RiskLevels;
+
+    void LoadDirectory(PipelineBuilder<ResidentDirectoryModel> p, string status)
+    {
+        p.Post("/Sandbox/Components/Grid/DirectoryData")
+            .Gather(g =>
+            {
+                g.Static("skip", 0);
+                g.Static("take", 8);
+                g.Include<FusionTextBox, ResidentDirectoryModel>(m => m.ResidentSearch);
+                g.Include<FusionDropDownList, ResidentDirectoryModel>(m => m.CareLevel);
+                g.Include<FusionDropDownList, ResidentDirectoryModel>(m => m.RiskLevel);
+                g.Include<FusionNumericTextBox, ResidentDirectoryModel>(m => m.MinimumAge);
+            })
+            .Response(r => r.OnSuccess<ResidentDirectoryResponse>((json, s) =>
+            {
+                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                s.Element("directory-summary").SetText(json, x => x.Summary);
+                s.Element("directory-status").SetText(status);
+            }));
+    }
+
+    void LoadVirtualDirectory(PipelineBuilder<ResidentDirectoryModel> p, string status)
+    {
+        p.Post("/Sandbox/Components/Grid/DirectoryData")
+            .Gather(g =>
+            {
+                g.Static("skip", 0);
+                g.Static("take", 24);
+            })
+            .Response(r => r.OnSuccess<ResidentDirectoryResponse>((json, s) =>
+            {
+                s.Component<FusionGrid>(VirtualGridId).SetDataSource(json);
+                s.Element("virtual-status").SetText(status);
+                s.Element("virtual-summary").SetText(json, x => x.Summary);
+            }));
+    }
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        LoadDirectory(p, "loaded first page");
+        LoadVirtualDirectory(p, "loaded first virtual block");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
+        <div>
+            <native-heading level="H1">FusionGrid Resident Directory</native-heading>
+            <native-text color="Secondary">
+                Server-side paging, sorting, filtering, search, grouping, typed row events, and public Grid methods.
+            </native-text>
+        </div>
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Index"
+           class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+            Basic grid
+        </a>
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Editing"
+           class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+            Editing workflows
+        </a>
+    </native-hstack>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Directory Filters</native-heading>
+        <native-grid cols="C4" gap="Base" class="mt-4">
+            @{ Html.InputField(plan, m => m.ResidentSearch, o => o.Label("Resident name"))
+                .FusionTextBox(b => b
+                    .Placeholder("Search by name")
+                    .ShowClearButton(true)
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        LoadDirectory(p, "name filter applied");
+                    })); }
+
+            @{ Html.InputField(plan, m => m.CareLevel, o => o.Label("Care level"))
+                .FusionDropDownList(b => b
+                    .DataSource(careLevels)
+                    .Placeholder("All care levels")
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        LoadDirectory(p, "care level filter applied");
+                    })); }
+
+            @{ Html.InputField(plan, m => m.RiskLevel, o => o.Label("Risk level"))
+                .FusionDropDownList(b => b
+                    .DataSource(riskLevels)
+                    .Placeholder("All risk levels")
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        LoadDirectory(p, "risk filter applied");
+                    })); }
+
+            @{ Html.InputField(plan, m => m.MinimumAge, o => o.Label("Minimum age"))
+                .FusionNumericTextBox(b => b
+                    .Format("n0")
+                    .Min(0)
+                    .Max(120)
+                    .Placeholder("Any age")
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        LoadDirectory(p, "age filter applied");
+                    })); }
+        </native-grid>
+        <native-vstack gap="Xs" class="mt-4 font-mono text-sm">
+            <p>Status: <span id="directory-status" class="text-text-muted">waiting</span></p>
+            <p>Summary: <span id="directory-summary" class="text-text-muted">waiting</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Public Grid Method Controls</native-heading>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("grid-page-2", "Page 2")
+                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).GoToPage(2);
+                    p.Element("method-status").SetText("goToPage called");
+                }))
+            @(Html.NativeButton("grid-sort-risk", "Sort Risk Desc")
+                .CssClass("rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId)
+                        .SortBy((ResidentDirectoryGridItem x) => x.RiskLevel, FusionGridSortDirection.Descending);
+                    p.Element("method-status").SetText("sortColumn called");
+                }))
+            @(Html.NativeButton("grid-search-memory", "Search Memory")
+                .CssClass("rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).Search("Memory");
+                    p.Element("method-status").SetText("search called");
+                }))
+            @(Html.NativeButton("grid-clear-search", "Clear Search")
+                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).ClearSearch();
+                    p.Element("method-status").SetText("search cleared");
+                }))
+            @(Html.NativeButton("grid-filter-north", "Filter North Wing")
+                .CssClass("rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId)
+                        .FilterTextBy((ResidentDirectoryGridItem x) => x.Wing, FusionGridTextFilterOperator.Equal, "North");
+                    p.Element("method-status").SetText("filterByColumn called");
+                }))
+            @(Html.NativeButton("grid-clear-filters", "Clear Filters")
+                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).ClearFiltering();
+                    p.Element("method-status").SetText("filters cleared");
+                    LoadDirectory(p, "filters cleared");
+                }))
+            @(Html.NativeButton("grid-group-care", "Group Care Level")
+                .CssClass("rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId)
+                        .GroupBy((ResidentDirectoryGridItem x) => x.CareLevel);
+                    p.Element("method-status").SetText("groupColumn called");
+                }))
+            @(Html.NativeButton("grid-clear-grouping", "Clear Grouping")
+                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).ClearGrouping();
+                    p.Element("method-status").SetText("grouping cleared");
+                }))
+            @(Html.NativeButton("grid-select-second", "Select Row 2")
+                .CssClass("rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).SelectRow(1);
+                    p.Element("method-status").SetText("selectRow called");
+                }))
+            @(Html.NativeButton("grid-clear-selection", "Clear Selection")
+                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId).ClearSelection();
+                    p.Element("method-status").SetText("selection cleared");
+                }))
+            @(Html.NativeButton("grid-gather-selection", "Gather Selection")
+                .CssClass("rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/SelectionIndexes")
+                        .Gather(g => g.Include(grid.SelectedRowIndexes(), "selectedRowIndexes"))
+                        .Response(r => r.OnSuccess<ResidentDirectorySelectionResponse>((json, s) =>
+                        {
+                            s.Element("selection-indexes").SetText(json, x => x.Summary);
+                        }));
+                }))
+            @(Html.NativeButton("grid-gather-selected-records", "Gather Selected Records")
+                .CssClass("rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/SelectionRecords")
+                        .Gather(g => g.Include(grid.SelectedRecords<ResidentDirectoryModel, ResidentDirectoryGridItem>(), "selectedRecords"))
+                        .Response(r => r.OnSuccess<ResidentDirectorySelectionResponse>((json, s) =>
+                        {
+                            s.Element("selected-records").SetText(json, x => x.Summary);
+                        }));
+                }))
+        </native-hstack>
+        <native-vstack gap="Xs" class="mt-4 font-mono text-sm">
+            <p>Method status: <span id="method-status" class="text-text-muted">waiting</span></p>
+            <p>Selection indexes: <span id="selection-indexes" class="text-text-muted">not gathered</span></p>
+            <p>Selected records: <span id="selected-records" class="text-text-muted">not gathered</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Server Bound Grid</native-heading>
+        @(Html.FusionGrid<ResidentDirectoryModel, ResidentDirectoryGridItem>(plan, GridId, b => b
+            .AllowPaging(true)
+            .AllowSorting(true)
+            .AllowMultiSorting(true)
+            .AllowFiltering(true)
+            .AllowGrouping(true)
+            .AllowSelection(true)
+            .Toolbar(new List<string> { "Search" })
+            .PageSettings(new GridPageSettings { PageSize = 8 })
+            .FilterSettings(new GridFilterSettings { Type = FilterType.FilterBar })
+            .GroupSettings(new GridGroupSettings { ShowDropArea = true })
+            .SearchSettings(new GridSearchSettings
+            {
+                Fields = new[] { "residentName", "careLevel", "wing", "suite", "riskLevel", "primaryNurse" }
+            })
+            .Columns(new List<GridColumn>
+            {
+                new GridColumn { Field = "residentId", HeaderText = "ID", Width = "80", TextAlign = TextAlign.Right, IsPrimaryKey = true, AllowFiltering = false },
+                new GridColumn { Field = "residentName", HeaderText = "Resident", Width = "180" },
+                new GridColumn { Field = "age", HeaderText = "Age", Width = "90", TextAlign = TextAlign.Right, AllowFiltering = false },
+                new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "160" },
+                new GridColumn { Field = "wing", HeaderText = "Wing", Width = "110" },
+                new GridColumn { Field = "suite", HeaderText = "Suite", Width = "110" },
+                new GridColumn { Field = "riskLevel", HeaderText = "Risk", Width = "120" },
+                new GridColumn { Field = "openTasks", HeaderText = "Tasks", Width = "90", TextAlign = TextAlign.Right, AllowFiltering = false },
+                new GridColumn { Field = "primaryNurse", HeaderText = "Primary Nurse", Width = "160" }
+            }))
+            .Reactive(evt => evt.DataStateChange, (args, p) =>
+            {
+                p.When(args, x => x.Action.RequestType).NotEq(FusionGridAction.Refresh)
+                    .Then(t =>
+                    {
+                        t.Element("grid-action").SetText(args, x => x.Action.RequestType);
+                        t.Element("grid-skip").SetText(args, x => x.Skip);
+                        t.Element("grid-take").SetText(args, x => x.Take);
+                        t.Element("grid-column").SetText(args, x => x.Action.ColumnName);
+                        t.Element("grid-direction").SetText(args, x => x.Action.Direction);
+                        t.Post("/Sandbox/Components/Grid/DirectoryData")
+                            .Gather(g =>
+                            {
+                                g.FromEvent(args, x => x.Skip, "skip");
+                                g.FromEvent(args, x => x.Take, "take");
+                                g.FromEvent(args, x => x.Sorted, "sorted");
+                                g.FromEvent(args, x => x.Group, "group");
+                                g.FromEvent(args, x => x.Where, "where");
+                                g.FromEvent(args, x => x.Search, "search");
+                                g.Include<FusionTextBox, ResidentDirectoryModel>(m => m.ResidentSearch);
+                                g.Include<FusionDropDownList, ResidentDirectoryModel>(m => m.CareLevel);
+                                g.Include<FusionDropDownList, ResidentDirectoryModel>(m => m.RiskLevel);
+                                g.Include<FusionNumericTextBox, ResidentDirectoryModel>(m => m.MinimumAge);
+                            })
+                            .Response(r => r.OnSuccess<ResidentDirectoryResponse>((json, s) =>
+                            {
+                                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                                s.Element("directory-summary").SetText(json, x => x.Summary);
+                                s.Element("directory-status").SetText("grid state sent to server");
+                            }));
+                    });
+            })
+            .Reactive(evt => evt.RecordClick<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("clicked-resident").SetText(args, x => x.RowData.ResidentName);
+                p.Element("clicked-cell").SetText(args, x => x.CellIndex);
+            })
+            .Reactive(evt => evt.RowSelected<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("selected-row-index").SetText(args, x => x.RowIndex);
+                p.Post("/Sandbox/Components/Grid/SelectResident")
+                    .Gather(g =>
+                    {
+                        g.FromEvent(args, x => x.Data.ResidentId, "residentId");
+                        g.FromEvent(args, x => x.RowIndex, "rowIndex");
+                    })
+                    .Response(r => r.OnSuccess<ResidentDirectorySelectionResponse>((json, s) =>
+                    {
+                        s.Element("selected-resident").SetText(json, x => x.ResidentName);
+                        s.Element("selected-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+
+        <native-grid cols="C4" gap="Base" class="mt-4 font-mono text-sm">
+            <p>Action: <span id="grid-action" class="text-text-muted">waiting</span></p>
+            <p>Skip: <span id="grid-skip" class="text-text-muted">waiting</span></p>
+            <p>Take: <span id="grid-take" class="text-text-muted">waiting</span></p>
+            <p>Column: <span id="grid-column" class="text-text-muted">waiting</span></p>
+            <p>Direction: <span id="grid-direction" class="text-text-muted">waiting</span></p>
+            <p>Clicked: <span id="clicked-resident" class="text-text-muted">waiting</span></p>
+            <p>Clicked cell: <span id="clicked-cell" class="text-text-muted">waiting</span></p>
+            <p>Selected row: <span id="selected-row-index" class="text-text-muted">waiting</span></p>
+        </native-grid>
+        <native-vstack gap="Xs" class="mt-3 font-mono text-sm">
+            <p>Selected resident: <span id="selected-resident" class="text-text-muted">waiting</span></p>
+            <p>Selection summary: <span id="selected-summary" class="text-text-muted">waiting</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Virtual Scrolling Custom Binding</native-heading>
+        @(Html.FusionGrid<ResidentDirectoryModel, ResidentDirectoryGridItem>(plan, VirtualGridId, b => b
+            .EnableVirtualization(true)
+            .Height("340")
+            .AllowSorting(true)
+            .PageSettings(new GridPageSettings { PageSize = 24 })
+            .Columns(new List<GridColumn>
+            {
+                new GridColumn { Field = "residentId", HeaderText = "ID", Width = "80", TextAlign = TextAlign.Right, IsPrimaryKey = true },
+                new GridColumn { Field = "residentName", HeaderText = "Resident", Width = "180" },
+                new GridColumn { Field = "age", HeaderText = "Age", Width = "90", TextAlign = TextAlign.Right },
+                new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "160" },
+                new GridColumn { Field = "wing", HeaderText = "Wing", Width = "110" },
+                new GridColumn { Field = "riskLevel", HeaderText = "Risk", Width = "120" },
+                new GridColumn { Field = "primaryNurse", HeaderText = "Primary Nurse", Width = "160" }
+            }))
+            .Reactive(evt => evt.DataStateChange, (args, p) =>
+            {
+                p.Element("virtual-action").SetText(args, x => x.Action.RequestType);
+                p.Element("virtual-skip").SetText(args, x => x.Skip);
+                p.Element("virtual-take").SetText(args, x => x.Take);
+                p.Post("/Sandbox/Components/Grid/DirectoryData")
+                    .Gather(g =>
+                    {
+                        g.FromEvent(args, x => x.Skip, "skip");
+                        g.FromEvent(args, x => x.Take, "take");
+                        g.FromEvent(args, x => x.Sorted, "sorted");
+                    })
+                    .Response(r => r.OnSuccess<ResidentDirectoryResponse>((json, s) =>
+                    {
+                        s.Component<FusionGrid>(VirtualGridId).SetDataSource(json);
+                        s.Element("virtual-status").SetText("virtual block refreshed");
+                        s.Element("virtual-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+
+        <native-grid cols="C4" gap="Base" class="mt-4 font-mono text-sm">
+            <p>Virtual status: <span id="virtual-status" class="text-text-muted">waiting</span></p>
+            <p>Virtual summary: <span id="virtual-summary" class="text-text-muted">waiting</span></p>
+            <p>Virtual action: <span id="virtual-action" class="text-text-muted">waiting</span></p>
+            <p>Virtual skip: <span id="virtual-skip" class="text-text-muted">waiting</span></p>
+            <p>Virtual take: <span id="virtual-take" class="text-text-muted">waiting</span></p>
+        </native-grid>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Directory.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Directory.cshtml
@@ -128,7 +128,7 @@
         <native-heading level="H2">Public Grid Method Controls</native-heading>
         <native-hstack gap="Sm" class="mt-4 flex-wrap">
             @(Html.NativeButton("grid-page-2", "Page 2")
-                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .CssClass("rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle")
                 .Reactive(plan, evt => evt.Click, (args, p) =>
                 {
                     p.Component<FusionGrid>(GridId).GoToPage(2);
@@ -150,7 +150,7 @@
                     p.Element("method-status").SetText("search called");
                 }))
             @(Html.NativeButton("grid-clear-search", "Clear Search")
-                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .CssClass("rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle")
                 .Reactive(plan, evt => evt.Click, (args, p) =>
                 {
                     p.Component<FusionGrid>(GridId).ClearSearch();
@@ -165,7 +165,7 @@
                     p.Element("method-status").SetText("filterByColumn called");
                 }))
             @(Html.NativeButton("grid-clear-filters", "Clear Filters")
-                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .CssClass("rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle")
                 .Reactive(plan, evt => evt.Click, (args, p) =>
                 {
                     p.Component<FusionGrid>(GridId).ClearFiltering();
@@ -181,7 +181,7 @@
                     p.Element("method-status").SetText("groupColumn called");
                 }))
             @(Html.NativeButton("grid-clear-grouping", "Clear Grouping")
-                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .CssClass("rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle")
                 .Reactive(plan, evt => evt.Click, (args, p) =>
                 {
                     p.Component<FusionGrid>(GridId).ClearGrouping();
@@ -195,7 +195,7 @@
                     p.Element("method-status").SetText("selectRow called");
                 }))
             @(Html.NativeButton("grid-clear-selection", "Clear Selection")
-                .CssClass("rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90")
+                .CssClass("rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle")
                 .Reactive(plan, evt => evt.Click, (args, p) =>
                 {
                     p.Component<FusionGrid>(GridId).ClearSelection();

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Editing.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Editing.cshtml
@@ -15,7 +15,7 @@
     const string DialogGridId = "resident-dialog-edit-grid";
     const string ValidationFormId = "grid-edit-validation-form";
     const string ButtonPrimary = "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90";
-    const string ButtonSecondary = "rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90";
+    const string ButtonSecondary = "rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle";
     const string ButtonAccent = "rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90";
 
     var plan = Html.ReactivePlan<ResidentGridEditingModel>();
@@ -48,23 +48,6 @@
 
     Html.On(plan, t => t.DomReady(p => LoadEditingGrids(p)));
 }
-
-<script id="resident-dialog-edit-template" type="text/x-template">
-    <div id="resident-dialog-template-marker" class="grid grid-cols-1 gap-3 p-2 text-sm">
-        <label class="grid gap-1">
-            <span class="font-medium text-text">Resident</span>
-            <input name="residentName" value="${residentName}" class="e-field e-input" />
-        </label>
-        <label class="grid gap-1">
-            <span class="font-medium text-text">Risk</span>
-            <input name="riskLevel" value="${riskLevel}" class="e-field e-input" />
-        </label>
-        <label class="grid gap-1">
-            <span class="font-medium text-text">Open tasks</span>
-            <input name="openTasks" value="${openTasks}" class="e-field e-input" />
-        </label>
-    </div>
-</script>
 
 <native-vstack gap="Lg">
     <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
@@ -343,7 +326,10 @@
                 AllowEditing = true,
                 AllowEditOnDblClick = false,
                 Mode = EditMode.Dialog,
-                Template = "#resident-dialog-edit-template"
+                Template = FusionGridEditTemplates.DialogForm<ResidentDirectoryGridItem>(d => d
+                    .Text(m => m.ResidentName, "Resident")
+                    .Select(m => m.RiskLevel, "Risk", riskLevels)
+                    .Number(m => m.OpenTasks, "Open tasks"))
             })
             .Columns(EditColumns()))
             .Reactive(evt => evt.BeginEdit<ResidentDirectoryGridItem>(), (args, p) =>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Editing.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Editing.cshtml
@@ -1,0 +1,425 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.ResidentGridEditingModel
+@using Alis.Reactive
+@using Alis.Reactive.Builders
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@using Syncfusion.EJ2.Grids
+@{
+    ViewData["Title"] = "FusionGrid Editing Workflows";
+
+    const string InlineGridId = "resident-inline-edit-grid";
+    const string BatchGridId = "resident-batch-edit-grid";
+    const string DialogGridId = "resident-dialog-edit-grid";
+    const string ValidationFormId = "grid-edit-validation-form";
+    const string ButtonPrimary = "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90";
+    const string ButtonSecondary = "rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90";
+    const string ButtonAccent = "rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90";
+
+    var plan = Html.ReactivePlan<ResidentGridEditingModel>();
+    var riskLevels = (List<string>)ViewBag.RiskLevels;
+
+    List<GridColumn> EditColumns() => new List<GridColumn>
+    {
+        new GridColumn { Field = "residentId", HeaderText = "ID", Width = "80", TextAlign = TextAlign.Right, IsPrimaryKey = true, IsIdentity = false, AllowEditing = false },
+        new GridColumn { Field = "residentName", HeaderText = "Resident", Width = "170" },
+        new GridColumn { Field = "age", HeaderText = "Age", Width = "90", TextAlign = TextAlign.Right },
+        new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "150" },
+        new GridColumn { Field = "wing", HeaderText = "Wing", Width = "110" },
+        new GridColumn { Field = "suite", HeaderText = "Suite", Width = "110" },
+        new GridColumn { Field = "riskLevel", HeaderText = "Risk", Width = "120" },
+        new GridColumn { Field = "openTasks", HeaderText = "Tasks", Width = "90", TextAlign = TextAlign.Right },
+        new GridColumn { Field = "primaryNurse", HeaderText = "Primary Nurse", Width = "150" }
+    };
+
+    void LoadEditingGrids(PipelineBuilder<ResidentGridEditingModel> p)
+    {
+        p.Get("/Sandbox/Components/Grid/EditingRows")
+            .Response(r => r.OnSuccess<List<ResidentDirectoryGridItem>>((json, s) =>
+            {
+                s.Component<FusionGrid>(InlineGridId).SetDataSource(json);
+                s.Component<FusionGrid>(BatchGridId).SetDataSource(json);
+                s.Component<FusionGrid>(DialogGridId).SetDataSource(json);
+                s.Element("editing-load-status").SetText("loaded editing rows");
+            }));
+    }
+
+    Html.On(plan, t => t.DomReady(p => LoadEditingGrids(p)));
+}
+
+<script id="resident-dialog-edit-template" type="text/x-template">
+    <div id="resident-dialog-template-marker" class="grid grid-cols-1 gap-3 p-2 text-sm">
+        <label class="grid gap-1">
+            <span class="font-medium text-text">Resident</span>
+            <input name="residentName" value="${residentName}" class="e-field e-input" />
+        </label>
+        <label class="grid gap-1">
+            <span class="font-medium text-text">Risk</span>
+            <input name="riskLevel" value="${riskLevel}" class="e-field e-input" />
+        </label>
+        <label class="grid gap-1">
+            <span class="font-medium text-text">Open tasks</span>
+            <input name="openTasks" value="${openTasks}" class="e-field e-input" />
+        </label>
+    </div>
+</script>
+
+<native-vstack gap="Lg">
+    <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
+        <div>
+            <native-heading level="H1">FusionGrid Editing Workflows</native-heading>
+            <native-text color="Secondary">
+                Inline, batch, dialog-template, method-return, event payload, and validation-backed editing paths.
+            </native-text>
+        </div>
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
+           class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+            Directory grid
+        </a>
+    </native-hstack>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Editing Data</native-heading>
+        <p class="mt-2 font-mono text-sm">Load status: <span id="editing-load-status" class="text-text-muted">waiting</span></p>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Inline Editing</native-heading>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("inline-select-first", "Select Row 1")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(InlineGridId).SelectRow(0);
+                    p.Element("inline-command-status").SetText("inline row selected");
+                }))
+            @(Html.NativeButton("inline-start-edit", "Start Edit")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(InlineGridId).StartEdit();
+                    p.Element("inline-command-status").SetText("startEdit called");
+                }))
+            @(Html.NativeButton("inline-end-edit", "End Edit")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(InlineGridId).EndEdit();
+                    p.Element("inline-command-status").SetText("endEdit called");
+                }))
+            @(Html.NativeButton("inline-close-edit", "Close Edit")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(InlineGridId).CloseEdit();
+                    p.Element("inline-command-status").SetText("closeEdit called");
+                }))
+            @(Html.NativeButton("inline-add-literal", "Add Literal Row")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(InlineGridId).AddRecord(new ResidentDirectoryGridItem
+                    {
+                        ResidentId = 7100,
+                        ResidentName = "Zara Inline",
+                        Age = 81,
+                        CareLevel = "Memory Care",
+                        Wing = "North",
+                        Suite = "N-710",
+                        RiskLevel = "High",
+                        PrimaryNurse = "Nora Ellis",
+                        OpenTasks = 5,
+                        NextReviewDate = "2026-06-22"
+                    }, 0);
+                    p.Element("inline-command-status").SetText("literal addRecord called");
+                }))
+            @(Html.NativeButton("inline-add-server", "Add Server Row")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/CreateEditResident")
+                        .Response(r => r.OnSuccess<ResidentGridEditResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(InlineGridId).AddRecord(json, x => x.Row, 0);
+                            s.Element("inline-command-status").SetText(json, x => x.Summary);
+                        }));
+                }))
+            @(Html.NativeButton("inline-update-row", "Update Row 1")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(InlineGridId).UpdateRow(0, new ResidentDirectoryGridItem
+                    {
+                        ResidentId = 6000,
+                        ResidentName = "Amina Updated",
+                        Age = 91,
+                        CareLevel = "Skilled Nursing",
+                        Wing = "West",
+                        Suite = "W-118",
+                        RiskLevel = "Moderate",
+                        PrimaryNurse = "Malik Stone",
+                        OpenTasks = 3,
+                        NextReviewDate = "2026-06-19"
+                    });
+                    p.Element("inline-command-status").SetText("updateRow called");
+                }))
+            @(Html.NativeButton("inline-delete-selected", "Delete Selected")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(InlineGridId).DeleteSelectedRecord();
+                    p.Element("inline-command-status").SetText("deleteRecord called");
+                }))
+        </native-hstack>
+
+        @(Html.FusionGrid<ResidentGridEditingModel, ResidentDirectoryGridItem>(plan, InlineGridId, b => b
+            .AllowSelection(true)
+            .Toolbar(new List<string> { "Add", "Edit", "Update", "Cancel", "Delete" })
+            .EditSettings(new GridEditSettings
+            {
+                AllowAdding = true,
+                AllowEditing = true,
+                AllowDeleting = true,
+                AllowEditOnDblClick = false,
+                Mode = EditMode.Normal,
+                ShowDeleteConfirmDialog = false
+            })
+            .Columns(EditColumns()))
+            .Reactive(evt => evt.BeginEdit<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("inline-begin-row").SetText(args, x => x.RowIndex);
+                p.Element("inline-begin-resident").SetText(args, x => x.RowData.ResidentName);
+            })
+            .Reactive(evt => evt.ActionBegin<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("inline-action-begin").SetText(args, x => x.RequestType);
+            })
+            .Reactive(evt => evt.ActionComplete<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("inline-action-complete").SetText(args, x => x.RequestType);
+                p.When(args, x => x.RequestType).Eq("save")
+                    .Then(t => t.Element("inline-complete-resident").SetText(args, x => x.Data.ResidentName));
+            }))
+
+        <native-grid cols="C4" gap="Base" class="mt-4 font-mono text-sm">
+            <p>Status: <span id="inline-command-status" class="text-text-muted">waiting</span></p>
+            <p>Begin row: <span id="inline-begin-row" class="text-text-muted">waiting</span></p>
+            <p>Begin resident: <span id="inline-begin-resident" class="text-text-muted">waiting</span></p>
+            <p>Action begin: <span id="inline-action-begin" class="text-text-muted">waiting</span></p>
+            <p>Action complete: <span id="inline-action-complete" class="text-text-muted">waiting</span></p>
+            <p>Saved resident: <span id="inline-complete-resident" class="text-text-muted">waiting</span></p>
+        </native-grid>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Batch Editing</native-heading>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("batch-edit-cell", "Edit Tasks Cell")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(BatchGridId)
+                        .EditCell(0, (ResidentDirectoryGridItem x) => x.OpenTasks);
+                    p.Element("batch-command-status").SetText("editCell called");
+                }))
+            @(Html.NativeButton("batch-update-cell", "Set Tasks To 6")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(BatchGridId)
+                        .UpdateCell(0, (ResidentDirectoryGridItem x) => x.OpenTasks, 6);
+                    p.Element("batch-command-status").SetText("updateCell called");
+                }))
+            @(Html.NativeButton("batch-save-cell", "Save Cell")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(BatchGridId).SaveCell();
+                    p.Element("batch-command-status").SetText("saveCell called");
+                }))
+            @(Html.NativeButton("batch-gather-changes", "Gather Changes")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(BatchGridId);
+                    p.Post("/Sandbox/Components/Grid/BatchSummary")
+                        .Gather(g => g.Include(grid.BatchChanges<ResidentGridEditingModel, ResidentDirectoryGridItem>(), "batchChanges"))
+                        .Response(r => r.OnSuccess<ResidentGridBatchSummaryResponse>((json, s) =>
+                        {
+                            s.Element("batch-summary").SetText(json, x => x.Summary);
+                        }));
+                }))
+            @(Html.NativeButton("batch-end-edit", "Commit Batch")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(BatchGridId).EndEdit();
+                    p.Element("batch-command-status").SetText("endEdit called");
+                }))
+        </native-hstack>
+
+        @(Html.FusionGrid<ResidentGridEditingModel, ResidentDirectoryGridItem>(plan, BatchGridId, b => b
+            .AllowSelection(true)
+            .Toolbar(new List<string> { "Update", "Cancel" })
+            .EditSettings(new GridEditSettings
+            {
+                AllowEditing = true,
+                AllowEditOnDblClick = false,
+                Mode = EditMode.Batch,
+                ShowConfirmDialog = false
+            })
+            .Columns(EditColumns()))
+            .Reactive(evt => evt.CellSave<ResidentDirectoryGridItem, int>(), (args, p) =>
+            {
+                p.Element("batch-cell-save-column").SetText(args, x => x.ColumnName);
+                p.Element("batch-cell-save-value").SetText(args, x => x.Value);
+            })
+            .Reactive(evt => evt.CellSaved<ResidentDirectoryGridItem, int>(), (args, p) =>
+            {
+                p.Element("batch-cell-saved-value").SetText(args, x => x.Value);
+            })
+            .Reactive(evt => evt.BeforeBatchSave<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("batch-before-save-resident").SetText(args, x => x.BatchChanges.ChangedRecords[0].ResidentName);
+                p.Element("batch-before-save-tasks").SetText(args, x => x.BatchChanges.ChangedRecords[0].OpenTasks);
+            })
+            .Reactive(evt => evt.ActionComplete<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("batch-action-complete").SetText(args, x => x.RequestType);
+            }))
+
+        <native-grid cols="C4" gap="Base" class="mt-4 font-mono text-sm">
+            <p>Status: <span id="batch-command-status" class="text-text-muted">waiting</span></p>
+            <p>Cell column: <span id="batch-cell-save-column" class="text-text-muted">waiting</span></p>
+            <p>Cell value: <span id="batch-cell-save-value" class="text-text-muted">waiting</span></p>
+            <p>Cell saved: <span id="batch-cell-saved-value" class="text-text-muted">waiting</span></p>
+            <p>Batch resident: <span id="batch-before-save-resident" class="text-text-muted">waiting</span></p>
+            <p>Batch tasks: <span id="batch-before-save-tasks" class="text-text-muted">waiting</span></p>
+            <p>Batch action: <span id="batch-action-complete" class="text-text-muted">waiting</span></p>
+            <p>Batch summary: <span id="batch-summary" class="text-text-muted">not gathered</span></p>
+        </native-grid>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Dialog Template Editing</native-heading>
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("dialog-select-first", "Select Row 1")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(DialogGridId).SelectRow(0);
+                    p.Element("dialog-command-status").SetText("dialog row selected");
+                }))
+            @(Html.NativeButton("dialog-start-edit", "Open Dialog")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(DialogGridId).StartEdit();
+                    p.Element("dialog-command-status").SetText("dialog startEdit called");
+                }))
+            @(Html.NativeButton("dialog-end-edit", "Save Dialog")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(DialogGridId).EndEdit();
+                    p.Element("dialog-command-status").SetText("dialog endEdit called");
+                }))
+            @(Html.NativeButton("dialog-close-edit", "Close Dialog")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(DialogGridId).CloseEdit();
+                    p.Element("dialog-command-status").SetText("dialog closeEdit called");
+                }))
+        </native-hstack>
+
+        @(Html.FusionGrid<ResidentGridEditingModel, ResidentDirectoryGridItem>(plan, DialogGridId, b => b
+            .AllowSelection(true)
+            .Toolbar(new List<string> { "Edit", "Update", "Cancel" })
+            .EditSettings(new GridEditSettings
+            {
+                AllowEditing = true,
+                AllowEditOnDblClick = false,
+                Mode = EditMode.Dialog,
+                Template = "#resident-dialog-edit-template"
+            })
+            .Columns(EditColumns()))
+            .Reactive(evt => evt.BeginEdit<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("dialog-begin-resident").SetText(args, x => x.RowData.ResidentName);
+            })
+            .Reactive(evt => evt.ActionComplete<ResidentDirectoryGridItem>(), (args, p) =>
+            {
+                p.Element("dialog-action-complete").SetText(args, x => x.RequestType);
+                p.When(args, x => x.RequestType).Eq("save")
+                    .Then(t => t.Element("dialog-saved-resident").SetText(args, x => x.Data.ResidentName));
+            }))
+
+        <native-grid cols="C4" gap="Base" class="mt-4 font-mono text-sm">
+            <p>Status: <span id="dialog-command-status" class="text-text-muted">waiting</span></p>
+            <p>Begin resident: <span id="dialog-begin-resident" class="text-text-muted">waiting</span></p>
+            <p>Action complete: <span id="dialog-action-complete" class="text-text-muted">waiting</span></p>
+            <p>Saved resident: <span id="dialog-saved-resident" class="text-text-muted">waiting</span></p>
+        </native-grid>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Validation Backed Grid Update</native-heading>
+        <form id="@ValidationFormId" class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            @{ Html.InputField(plan, m => m.ResidentName, o => o.Required().Label("Resident"))
+                .FusionTextBox(b => b
+                    .Placeholder("Resident name")
+                    .ShowClearButton(true)); }
+            @{ Html.InputField(plan, m => m.RiskLevel, o => o.Required().Label("Risk level"))
+                .FusionDropDownList(b => b
+                    .DataSource(riskLevels)
+                    .Placeholder("Select risk")); }
+            @{ Html.InputField(plan, m => m.OpenTasks, o => o.Required().Label("Open tasks"))
+                .FusionNumericTextBox(b => b
+                    .Format("n0")
+                    .Min(0)
+                    .Max(12)
+                    .Step(1)
+                    .Placeholder("0 to 7")); }
+        </form>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("validation-save-grid-row", "Validate And Update Grid")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/ValidateEditDraft", g =>
+                    {
+                        g.Include<FusionTextBox, ResidentGridEditingModel>(m => m.ResidentName);
+                        g.Include<FusionDropDownList, ResidentGridEditingModel>(m => m.RiskLevel);
+                        g.Include<FusionNumericTextBox, ResidentGridEditingModel>(m => m.OpenTasks);
+                    })
+                    .Validate<ResidentGridEditingValidator>(ValidationFormId)
+                    .Response(r => r
+                        .OnSuccess<ResidentGridEditResponse>((json, s) =>
+                        {
+                            s.Component<FusionGrid>(InlineGridId).UpdateRow(0, json, x => x.Row);
+                            s.Component<FusionGrid>(InlineGridId).Refresh();
+                            s.Element("validation-status").SetText(json, x => x.Summary);
+                            s.Element("validation-status").RemoveClass("text-red-600");
+                            s.Element("validation-status").AddClass("text-green-700");
+                        })
+                        .OnError(400, e =>
+                        {
+                            e.Element("validation-status").SetText("validation errors returned");
+                            e.Element("validation-status").RemoveClass("text-green-700");
+                            e.Element("validation-status").AddClass("text-red-600");
+                            e.ValidationErrors(ValidationFormId);
+                        }));
+                }))
+        </native-hstack>
+
+        <p class="mt-3 font-mono text-sm">Validation status: <span id="validation-status" class="text-text-muted">waiting</span></p>
+        <div data-reactive-validation-summary hidden
+             class="mt-3 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700"></div>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Index.cshtml
@@ -27,10 +27,16 @@
 <native-vstack gap="Lg">
     <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
         <native-heading level="H1">FusionGrid &mdash; Server-Side Sort, Paging &amp; Filter</native-heading>
-        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
-           class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
-            Resident directory
-        </a>
+        <native-hstack gap="Sm" class="flex-wrap">
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Resident directory
+            </a>
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Operations"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Operations board
+            </a>
+        </native-hstack>
     </native-hstack>
     <native-text color="Secondary">
         200 residents in server memory. Grid shows 10 per page with server-side sort + paging.

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Index.cshtml
@@ -36,11 +36,16 @@
                class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
                 Operations board
             </a>
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Billing"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Billing board
+            </a>
         </native-hstack>
     </native-hstack>
     <native-text color="Secondary">
         200 residents in server memory. Grid shows 10 per page with server-side sort + paging.
-        External Min Age filter sends the full state (skip, take, sorted, minAge) on every action.
+        Grid sort and page actions send the full state (skip, take, sorted); the external Min Age
+        filter resets to page 1 and sends the current minAge.
     </native-text>
 
     <!-- Section 1: Grid + Sort + Paging + External Filter -->

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Index.cshtml
@@ -25,7 +25,13 @@
 }
 
 <native-vstack gap="Lg">
-    <native-heading level="H1">FusionGrid &mdash; Server-Side Sort, Paging &amp; Filter</native-heading>
+    <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
+        <native-heading level="H1">FusionGrid &mdash; Server-Side Sort, Paging &amp; Filter</native-heading>
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
+           class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+            Resident directory
+        </a>
+    </native-hstack>
     <native-text color="Secondary">
         200 residents in server memory. Grid shows 10 per page with server-side sort + paging.
         External Min Age filter sends the full state (skip, take, sorted, minAge) on every action.
@@ -65,7 +71,7 @@
             </native-grid>
         </div>
 
-        @(Html.FusionGrid(plan, "residents-grid", b => b
+        @(Html.FusionGrid<GridModel, ResidentGridItem>(plan, "residents-grid", b => b
             .AllowSorting(true)
             .AllowPaging(true)
             .PageSettings(new GridPageSettings { PageSize = 10 })

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Operations.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Operations.cshtml
@@ -12,7 +12,7 @@
 
     const string GridId = "resident-operations-grid";
     const string ButtonPrimary = "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90";
-    const string ButtonSecondary = "rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90";
+    const string ButtonSecondary = "rounded-md border border-border bg-white px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle";
     const string ButtonAccent = "rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90";
 
     var plan = Html.ReactivePlan<GridOperationsModel>();

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Operations.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/Operations.cshtml
@@ -1,0 +1,233 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.GridOperationsModel
+@using Alis.Reactive
+@using Alis.Reactive.Builders
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Fusion.Templates
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@using Syncfusion.EJ2.Grids
+@{
+    ViewData["Title"] = "FusionGrid Operations";
+
+    const string GridId = "resident-operations-grid";
+    const string ButtonPrimary = "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90";
+    const string ButtonSecondary = "rounded-md bg-secondary px-3 py-2 text-sm font-medium text-white hover:bg-secondary/90";
+    const string ButtonAccent = "rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90";
+
+    var plan = Html.ReactivePlan<GridOperationsModel>();
+    var riskLevels = (List<string>)ViewBag.RiskLevels;
+
+    var residentTemplate = FusionTemplate.Create<ResidentDirectoryGridItem>()
+        .Class("grid-resident-template space-y-1")
+        .Div(d => d.Class("font-semibold text-slate-900").Span(m => m.ResidentName))
+        .Div(d => d.Class("text-xs text-slate-600")
+            .Span("Suite ", "font-medium")
+            .Span(m => m.Suite)
+            .Span(" | ")
+            .Span(m => m.CareLevel))
+        .Render();
+
+    var riskTemplate = FusionTemplate.Create<ResidentDirectoryGridItem>()
+        .When(m => m.RiskLevel == "High",
+            then: t => t.Badge(m => m.RiskLevel, "rounded bg-red-100 px-2 py-0.5 text-xs font-bold text-red-700"),
+            @else: e => e.Badge(m => m.RiskLevel, "rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700"))
+        .Render();
+
+    var actionTemplate = FusionTemplate.Create<ResidentDirectoryGridItem>()
+        .Class("grid-action-template")
+        .EventButton("Review", "grid:review-resident", m => m.ResidentId, "e-small e-primary")
+        .Render();
+
+    void LoadOperationsGrid(PipelineBuilder<GridOperationsModel> p)
+    {
+        p.Get("/Sandbox/Components/Grid/OperationRows")
+            .Response(r => r.OnSuccess<List<ResidentDirectoryGridItem>>((json, s) =>
+            {
+                s.Component<FusionGrid>(GridId).SetDataSource(json);
+                s.Element("operations-load-status").SetText("loaded operations rows");
+            }));
+    }
+
+    Html.On(plan, t => t.DomReady(p => LoadOperationsGrid(p)));
+
+    Html.On(plan, t => t.CustomEvent<GridTemplateActionPayload>("grid:review-resident", (payload, p) =>
+    {
+        p.Post("/Sandbox/Components/Grid/ReviewResident")
+            .Gather(g => g.FromEvent(payload, x => x.Id, "id"))
+            .Response(r => r.OnSuccess<ResidentDirectorySelectionResponse>((json, s) =>
+            {
+                s.Element("template-action-status").SetText(json, x => x.Summary);
+            }));
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
+        <div>
+            <native-heading level="H1">FusionGrid Operations Board</native-heading>
+            <native-text color="Secondary">
+                Column personalization, keyed updates, current-view handoff, and typed template actions over resident operations data.
+            </native-text>
+        </div>
+        <native-hstack gap="Sm" class="flex-wrap">
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Directory grid
+            </a>
+            <a asp-area="Sandbox" asp-controller="Grid" asp-action="Editing"
+               class="rounded-md border border-border px-3 py-2 text-sm font-medium text-text hover:bg-surface-subtle">
+                Editing grid
+            </a>
+        </native-hstack>
+    </native-hstack>
+
+    <section class="rounded-lg border border-border bg-white p-5 shadow-sm">
+        <native-heading level="H2">Runtime Controls</native-heading>
+        <form id="operations-patch-form" class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            @{ Html.InputField(plan, m => m.PatchRiskLevel, o => o.Label("Patch risk"))
+                .FusionDropDownList(b => b
+                    .DataSource(riskLevels)
+                    .Placeholder("Risk level")); }
+            @{ Html.InputField(plan, m => m.PatchOpenTasks, o => o.Label("Patch open tasks"))
+                .FusionNumericTextBox(b => b
+                    .Format("n0")
+                    .Min(0)
+                    .Max(12)
+                    .Step(1)
+                    .Placeholder("Task count")); }
+        </form>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("ops-hide-care-columns", "Hide Care Columns")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    grid.HideColumn((ResidentDirectoryGridItem x) => x.PrimaryNurse);
+                    grid.HideColumn((ResidentDirectoryGridItem x) => x.NextReviewDate);
+                    p.Element("column-command-status").SetText("care columns hidden");
+                }))
+            @(Html.NativeButton("ops-show-care-columns", "Show Care Columns")
+                .CssClass(ButtonSecondary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    grid.ShowColumn((ResidentDirectoryGridItem x) => x.PrimaryNurse);
+                    grid.ShowColumn((ResidentDirectoryGridItem x) => x.NextReviewDate);
+                    p.Element("column-command-status").SetText("care columns shown");
+                }))
+            @(Html.NativeButton("ops-reorder-risk", "Move Risk Before Resident")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId)
+                        .ReorderColumnBefore(
+                            (ResidentDirectoryGridItem x) => x.RiskLevel,
+                            (ResidentDirectoryGridItem x) => x.ResidentName);
+                    p.Element("column-command-status").SetText("risk column moved before resident");
+                }))
+            @(Html.NativeButton("ops-select-range", "Select Review Range")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    grid.SelectRowsByRange(0, 2);
+                    p.Post("/Sandbox/Components/Grid/SelectionRecords")
+                        .Gather(g => g.Include(grid.SelectedRecords<GridOperationsModel, ResidentDirectoryGridItem>(), "selectedRecords"))
+                        .Response(r => r.OnSuccess<ResidentDirectorySelectionResponse>((json, s) =>
+                        {
+                            s.Element("selection-range-status").SetText(json, x => x.Summary);
+                        }));
+                }))
+            @(Html.NativeButton("ops-current-view", "Summarize Current View")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/CurrentViewSummary")
+                        .Gather(g => g.Include(grid.CurrentViewRecords<GridOperationsModel, ResidentDirectoryGridItem>(), "records"))
+                        .Response(r => r.OnSuccess<ResidentDirectorySelectionResponse>((json, s) =>
+                        {
+                            s.Element("current-view-status").SetText(json, x => x.Summary);
+                        }));
+                }))
+            @(Html.NativeButton("ops-row-index", "Find Resident 6005")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var grid = p.Component<FusionGrid>(GridId);
+                    p.Post("/Sandbox/Components/Grid/RowIndexSummary")
+                        .Gather(g => g.Include(grid.RowIndexByPrimaryKey(6005), "rowIndex"))
+                        .Response(r => r.OnSuccess<ResidentDirectorySelectionResponse>((json, s) =>
+                        {
+                            s.Element("row-index-status").SetText(json, x => x.Summary);
+                        }));
+                }))
+            @(Html.NativeButton("ops-set-risk-cell", "Flag Resident 6002")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId)
+                        .SetCellValue(6002, (ResidentDirectoryGridItem x) => x.RiskLevel, "Critical");
+                    p.Element("keyed-update-status").SetText("resident 6002 risk flagged");
+                }))
+            @(Html.NativeButton("ops-set-tasks-cell", "Set Tasks For 6003")
+                .CssClass(ButtonAccent)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionGrid>(GridId)
+                        .SetCellValue(6003, (ResidentDirectoryGridItem x) => x.OpenTasks, 7);
+                    p.Element("keyed-update-status").SetText("resident 6003 tasks updated");
+                }))
+            @(Html.NativeButton("ops-server-patch-row", "Apply Server Patch To 6005")
+                .CssClass(ButtonPrimary)
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Post("/Sandbox/Components/Grid/PatchResidentRow", g =>
+                    {
+                        g.Include<FusionDropDownList, GridOperationsModel>(m => m.PatchRiskLevel);
+                        g.Include<FusionNumericTextBox, GridOperationsModel>(m => m.PatchOpenTasks);
+                    })
+                    .Response(r => r.OnSuccess<ResidentGridOperationsResponse>((json, s) =>
+                    {
+                        s.Component<FusionGrid>(GridId).SetRowData(6005, json, x => x.Row);
+                        s.Element("keyed-update-status").SetText(json, x => x.Summary);
+                    }));
+                }))
+        </native-hstack>
+
+        <native-grid cols="C3" gap="Base" class="mt-4 font-mono text-sm">
+            <p>Load: <span id="operations-load-status" class="text-text-muted">waiting</span></p>
+            <p>Columns: <span id="column-command-status" class="text-text-muted">waiting</span></p>
+            <p>Range: <span id="selection-range-status" class="text-text-muted">waiting</span></p>
+            <p>Current view: <span id="current-view-status" class="text-text-muted">waiting</span></p>
+            <p>Row index: <span id="row-index-status" class="text-text-muted">waiting</span></p>
+            <p>Keyed updates: <span id="keyed-update-status" class="text-text-muted">waiting</span></p>
+            <p>Template action: <span id="template-action-status" class="text-text-muted">waiting</span></p>
+        </native-grid>
+    </section>
+
+    <section class="rounded-lg border border-border bg-white p-5 shadow-sm">
+        @(Html.FusionGrid<GridOperationsModel, ResidentDirectoryGridItem>(plan, GridId, b => b
+            .AllowPaging(true)
+            .AllowReordering(true)
+            .AllowSelection(true)
+            .PageSettings(new GridPageSettings { PageSize = 12 })
+            .SelectionSettings(new GridSelectionSettings { Type = SelectionType.Multiple })
+            .Columns(new List<GridColumn>
+            {
+                new GridColumn { Field = "residentId", HeaderText = "ID", Width = "80", IsPrimaryKey = true, TextAlign = TextAlign.Right, Visible = false },
+                new GridColumn { Field = "residentName", HeaderText = "Resident", Width = "240", Template = residentTemplate },
+                new GridColumn { Field = "riskLevel", HeaderText = "Risk", Width = "130", Template = riskTemplate },
+                new GridColumn { Field = "openTasks", HeaderText = "Tasks", Width = "90", TextAlign = TextAlign.Right },
+                new GridColumn { Field = "primaryNurse", HeaderText = "Primary Nurse", Width = "160" },
+                new GridColumn { Field = "nextReviewDate", HeaderText = "Next Review", Width = "130" },
+                new GridColumn { Field = "wing", HeaderText = "Wing", Width = "100" },
+                new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "150" },
+                new GridColumn { HeaderText = "Action", Width = "120", Template = actionTemplate }
+            })))
+    </section>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/_CareOpsActionRows.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Grid/_CareOpsActionRows.cshtml
@@ -1,0 +1,42 @@
+@model IReadOnlyList<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.ResidentCareItem>
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+
+@* Per-row NativeActionLink list: each resident gets its own server-rendered action
+   links. The runtime wires every <a data-reactive-link> through a single delegated
+   click listener, so this partial can be re-injected via Into() with no re-wiring. *@
+<native-vstack gap="Xs">
+    @foreach (var row in Model)
+    {
+        <div data-testid="careops-action-row-@row.ResidentId"
+             class="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
+            <div>
+                <span class="font-medium text-text">@row.ResidentName</span>
+                <span class="text-text-secondary"> · @row.Wing wing · @row.CareLevel · @row.RiskLevel risk</span>
+            </div>
+            <native-hstack gap="Base">
+                @(Html.NativeActionLink("Flag Critical", $"/Sandbox/Components/Grid/CareOpsFlagOne/{row.ResidentId}", p => p
+                    .Post($"/Sandbox/Components/Grid/CareOpsFlagOne/{row.ResidentId}")
+                    .Response(r => r.OnSuccess(s =>
+                    {
+                        s.Element("careops-rows-status").SetText($"{row.ResidentName} flagged critical");
+                        s.Dispatch("careops-rows-refresh");
+                    })))
+                    .CssClass("font-medium text-amber-700 hover:text-amber-800")
+                    .Attr("data-testid", $"careops-flag-{row.ResidentId}"))
+                @(Html.NativeActionLink("Discharge", $"/Sandbox/Components/Grid/CareOpsDischargeOne/{row.ResidentId}", p => p
+                    .Confirm($"Discharge {row.ResidentName} from the active census?")
+                    .Then(t => t
+                        .Post($"/Sandbox/Components/Grid/CareOpsDischargeOne/{row.ResidentId}")
+                        .Response(r => r.OnSuccess(s =>
+                        {
+                            s.Element("careops-rows-status").SetText($"{row.ResidentName} discharged");
+                            s.Dispatch("careops-rows-refresh");
+                        })))
+                    .Else(e => e.Element("careops-rows-status").SetText($"kept {row.ResidentName}")))
+                    .CssClass("font-medium text-red-600 hover:text-red-700")
+                    .Attr("data-testid", $"careops-discharge-{row.ResidentId}"))
+            </native-hstack>
+        </div>
+    }
+</native-vstack>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ListBox/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ListBox/Index.cshtml
@@ -1,0 +1,161 @@
+@model FusionListBoxModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Fusion.Components
+@using Syncfusion.EJ2.DropDowns
+@{
+    ViewData["Title"] = "FusionListBox";
+
+    const string ListBoxId = "resident-list-box";
+
+    var plan = Html.ReactivePlan<FusionListBoxModel>();
+    var residents = (List<ListBoxResidentItem>)ViewBag.Residents;
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var listBox = p.Component<FusionListBox>(ListBoxId);
+        listBox.SetValue(new[] { "alice" }).DataBind();
+        p.Element("value-echo").SetText(listBox.Value());
+        p.When(listBox.Value()).NotEmpty()
+            .Then(t => t.Element("value-state").SetText("has values"))
+            .Else(e => e.Element("value-state").SetText("empty"));
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionListBox</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Resident ListBox</native-heading>
+        @(Html.FusionListBox(plan, ListBoxId, b => b
+            .DataSource(residents)
+            .Fields(new ListBoxFieldSettings { Text = "text", Value = "value" })
+            .Height("220px"))
+            .Reactive(evt => evt.Changed, (args, p) =>
+            {
+                p.Element("change-value").SetText(args, x => x.Value);
+                p.When(args, x => x.Value).NotEmpty()
+                    .Then(t => t.Element("change-state").SetText("has values"))
+                    .Else(e => e.Element("change-state").SetText("empty"));
+
+                var listBox = p.Component<FusionListBox>(ListBoxId);
+                p.When(listBox.Value()).NotEmpty()
+                    .Then(t =>
+                    {
+                        t.Element("selected-indicator").Show();
+                        t.Element("selected-indicator").SetText("selected");
+                    })
+                    .Else(e => e.Element("selected-indicator").Hide());
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Commands</native-heading>
+        <native-hstack gap="Sm" class="flex-wrap">
+            @(Html.NativeButton("set-value-btn", "Set Values")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var listBox = p.Component<FusionListBox>(ListBoxId);
+                    listBox.SetValue(new[] { "bennett", "dawson" }).DataBind();
+                    p.Element("value-echo").SetText(listBox.Value());
+                    p.Element("command-state").SetText("value set");
+                }))
+            @(Html.NativeButton("select-carey-btn", "Select Carey")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var listBox = p.Component<FusionListBox>(ListBoxId);
+                    listBox.SelectValues("carey");
+                    p.Element("value-echo").SetText(listBox.Value());
+                    p.Element("command-state").SetText("carey selected");
+                }))
+            @(Html.NativeButton("unselect-carey-btn", "Unselect Carey")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var listBox = p.Component<FusionListBox>(ListBoxId);
+                    listBox.UnselectValues("carey");
+                    p.Element("value-echo").SetText(listBox.Value());
+                    p.Element("command-state").SetText("carey unselected");
+                }))
+            @(Html.NativeButton("select-all-btn", "Select All")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var listBox = p.Component<FusionListBox>(ListBoxId);
+                    listBox.SelectAll();
+                    p.Element("value-echo").SetText(listBox.Value());
+                    p.Element("command-state").SetText("all selected");
+                }))
+            @(Html.NativeButton("unselect-all-btn", "Unselect All")
+                .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var listBox = p.Component<FusionListBox>(ListBoxId);
+                    listBox.UnselectAll();
+                    p.Element("value-echo").SetText(listBox.Value());
+                    p.Element("command-state").SetText("all unselected");
+                    p.When(listBox.Value()).NotEmpty()
+                        .Then(t => t.Element("value-state").SetText("has values"))
+                        .Else(e => e.Element("value-state").SetText("empty"));
+                }))
+            @(Html.NativeButton("disable-carey-btn", "Disable Carey")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionListBox>(ListBoxId).DisableValues("carey");
+                    p.Element("command-state").SetText("carey disabled");
+                }))
+            @(Html.NativeButton("enable-carey-btn", "Enable Carey")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionListBox>(ListBoxId).EnableValues("carey");
+                    p.Element("command-state").SetText("carey enabled");
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather ListBox")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var listBox = p.Component<FusionListBox>(ListBoxId);
+                p.Post("/Sandbox/Components/FusionListBox/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(listBox.Value(), "value");
+                    })
+                    .Response(r => r.OnSuccess<FusionListBoxEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-value").SetText(json, x => x.ValueSummary);
+                        s.Element("gather-count").SetText(json, x => x.CountSummary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Value echo: <span id="value-echo" class="text-text-muted">pending</span></p>
+            <p>Value state: <span id="value-state" class="text-text-muted">pending</span></p>
+            <p>Change value: <span id="change-value" class="text-text-muted">pending</span></p>
+            <p>Change state: <span id="change-state" class="text-text-muted">pending</span></p>
+            <p>Selected: <span id="selected-indicator" hidden class="text-emerald-600">pending</span></p>
+            <p>Gather value: <span id="gather-value" class="text-text-muted">pending</span></p>
+            <p>Gather count: <span id="gather-count" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ListView/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ListView/Index.cshtml
@@ -1,0 +1,121 @@
+@model FusionListViewModel
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionListView";
+
+    const string ResidentListId = "resident-list";
+    const string TaskListId = "task-list";
+
+    var plan = Html.ReactivePlan<FusionListViewModel>();
+    var residents = (string[])ViewBag.Residents;
+    var tasks = (string[])ViewBag.Tasks;
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        p.Element("command-state").SetText("ready");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionListView</native-heading>
+
+    <native-grid cols="C2" gap="Base">
+        <native-card><native-card-body>
+            <native-heading level="H2">Residents</native-heading>
+            @(Html.FusionListView(plan, ResidentListId, b => b
+                .DataSource(residents)
+                .Height("210px"))
+                .Reactive(evt => evt.Selected, (args, p) =>
+                {
+                    p.Element("selected-text").SetText(args, x => x.Text);
+                    p.Element("selected-index").SetText(args, x => x.Index);
+                    p.Element("selected-interacted").SetText(args, x => x.IsInteracted);
+                    p.When(args, x => x.Text).Eq("Alice")
+                        .Then(t => t.Element("selected-kind").SetText("primary"))
+                        .Else(e => e.Element("selected-kind").SetText("other"));
+                    p.When(args, x => x.Text).Eq("Carey")
+                        .Then(t =>
+                        {
+                            args.CancelSelection(t);
+                            t.Element("cancel-state").SetText("cancelled");
+                        })
+                        .Else(e => e.Element("cancel-state").SetText("allowed"));
+                }))
+        </native-card-body></native-card>
+
+        <native-card><native-card-body>
+            <native-heading level="H2">Care Tasks</native-heading>
+            @(Html.FusionListView(plan, TaskListId, b => b
+                .DataSource(tasks)
+                .ShowCheckBox(true)
+                .Height("210px"))
+                .Reactive(evt => evt.Selected, (args, p) =>
+                {
+                    p.Element("task-selected-text").SetText(args, x => x.Text);
+                    p.Element("task-checked").SetText(args, x => x.IsChecked);
+                    p.When(args, x => x.IsChecked).Truthy()
+                        .Then(t => t.Element("task-check-state").SetText("checked"))
+                        .Else(e => e.Element("task-check-state").SetText("unchecked"));
+                }))
+        </native-card-body></native-card>
+    </native-grid>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Commands</native-heading>
+        <native-hstack gap="Sm" class="flex-wrap">
+            @(Html.NativeButton("select-bennett-btn", "Select Bennett")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionListView>(ResidentListId).SelectText("Bennett");
+                    p.Element("command-state").SetText("selected Bennett");
+                }))
+            @(Html.NativeButton("unselect-bennett-btn", "Unselect Bennett")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionListView>(ResidentListId).UnselectText("Bennett");
+                    p.Element("command-state").SetText("unselected Bennett");
+                }))
+            @(Html.NativeButton("check-all-btn", "Check All")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionListView>(TaskListId).CheckAllItems();
+                    p.Element("task-command-state").SetText("checked all");
+                }))
+            @(Html.NativeButton("uncheck-all-btn", "Uncheck All")
+                .CssClass("rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionListView>(TaskListId).UncheckAllItems();
+                    p.Element("task-command-state").SetText("unchecked all");
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Selected text: <span id="selected-text" class="text-text-muted">pending</span></p>
+            <p>Selected index: <span id="selected-index" class="text-text-muted">pending</span></p>
+            <p>Selected interacted: <span id="selected-interacted" class="text-text-muted">pending</span></p>
+            <p>Selected kind: <span id="selected-kind" class="text-text-muted">pending</span></p>
+            <p>Cancel state: <span id="cancel-state" class="text-text-muted">pending</span></p>
+            <p>Task command: <span id="task-command-state" class="text-text-muted">pending</span></p>
+            <p>Task selected text: <span id="task-selected-text" class="text-text-muted">pending</span></p>
+            <p>Task checked: <span id="task-checked" class="text-text-muted">pending</span></p>
+            <p>Task check state: <span id="task-check-state" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Menu/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Menu/Index.cshtml
@@ -12,15 +12,17 @@
     var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Menu.FusionMenuModel>();
     var items = new List<MenuItem>
     {
-        new() { Id = "dashboard-item", Text = "Dashboard" },
+        new() { Id = "dashboard-item", Text = "Dashboard", Url = "/dashboard", IconCss = "e-icons e-home", Separator = false },
         new()
         {
             Id = "projects-item",
             Text = "Projects",
+            IconCss = "e-icons e-folder",
+            Separator = false,
             Items = new List<MenuItem>
             {
-                new() { Id = "reports-item", Text = "Reports" },
-                new() { Id = "archive-item", Text = "Archive" }
+                new() { Id = "reports-item", Text = "Reports", Url = "/reports", IconCss = "e-icons e-description", Separator = false },
+                new() { Id = "archive-item", Text = "Archive", Url = "/archive", IconCss = "e-icons e-archive", Separator = false }
             }
         },
         new() { Id = "help-item", Text = "Help" }
@@ -31,22 +33,38 @@
         p.Element("before-item-state").SetText("pending");
         p.Element("before-item-text").SetText("pending");
         p.Element("before-item-id").SetText("pending");
+        p.Element("before-item-url").SetText("pending");
+        p.Element("before-item-icon-css").SetText("pending");
+        p.Element("before-item-separator").SetText("pending");
         p.Element("before-open-state").SetText("pending");
         p.Element("before-open-kind").SetText("pending");
         p.Element("before-open-top").SetText("pending");
         p.Element("before-open-left").SetText("pending");
+        p.Element("before-open-focused").SetText("pending");
+        p.Element("before-open-first-item").SetText("pending");
         p.Element("before-open-parent").SetText("pending");
         p.Element("before-open-cancel").SetText("pending");
+        p.Element("before-open-cancel-value").SetText("pending");
         p.Element("open-state").SetText("pending");
         p.Element("open-kind").SetText("pending");
+        p.Element("open-first-item").SetText("pending");
+        p.Element("open-parent").SetText("pending");
         p.Element("menu-visibility").SetText("pending");
         p.Element("before-close-state").SetText("pending");
+        p.Element("before-close-first-item").SetText("pending");
+        p.Element("before-close-parent").SetText("pending");
         p.Element("before-close-cancel").SetText("pending");
+        p.Element("before-close-cancel-value").SetText("pending");
         p.Element("close-state").SetText("pending");
+        p.Element("close-first-item").SetText("pending");
+        p.Element("close-parent").SetText("pending");
         p.Element("select-state").SetText("pending");
         p.Element("select-text").SetText("pending");
         p.Element("select-id").SetText("pending");
         p.Element("select-url").SetText("pending");
+        p.Element("select-icon-css").SetText("pending");
+        p.Element("select-separator").SetText("pending");
+        p.Element("select-first-child").SetText("pending");
     }));
 }
 
@@ -111,9 +129,19 @@
             p.Element("before-item-state").SetText("rendered");
             p.Element("before-item-text").SetText(args, x => x.Item.Text);
             p.Element("before-item-id").SetText(args, x => x.Item.Id);
+            p.Element("before-item-url").SetText(args, x => x.Item.Url);
+            p.Element("before-item-icon-css").SetText(args, x => x.Item.IconCss);
+            p.Element("before-item-separator").SetText(args, x => x.Item.Separator);
         })
         .Reactive(evt => evt.BeforeOpen, (args, p) =>
         {
+            p.Element("before-open-state").SetText("rendered");
+            p.When(args, x => x.IsFocused).Truthy()
+                .Then(t => t.Element("before-open-focused").SetText("true"))
+                .Else(e => e.Element("before-open-focused").SetText("false"));
+            p.Element("before-open-first-item").SetText(args, x => x.Items[0].Text);
+            p.Element("before-open-cancel-value").SetText(args, x => x.Cancel);
+
             p.When(args, x => x.ParentItem).IsNull()
                 .Then(t =>
                 {
@@ -135,33 +163,53 @@
                 {
                     t.Element("before-open-cancel").SetText("cancelled");
                     args.PreventOpen(t);
+                    t.Element("before-open-cancel-value").SetText(args, x => x.Cancel);
                 })
                 .Else(e => e.Element("before-open-cancel").SetText("allowed"));
         })
         .Reactive(evt => evt.Opened, (args, p) =>
         {
             p.When(args, x => x.ParentItem).IsNull()
-                .Then(t => t.Element("open-kind").SetText("root"))
-                .Else(e => e.Element("open-kind").SetText("submenu"));
+                .Then(t =>
+                {
+                    t.Element("open-kind").SetText("root");
+                    t.Element("open-parent").SetText("root");
+                })
+                .Else(e =>
+                {
+                    e.Element("open-kind").SetText("submenu");
+                    e.Element("open-parent").SetText(args, x => x.ParentItem!.Text);
+                });
 
             p.Element("open-state").SetText("opened");
+            p.Element("open-first-item").SetText(args, x => x.Items[0].Text);
             p.Element("menu-visibility").SetText("visible");
         })
         .Reactive(evt => evt.BeforeClose, (args, p) =>
         {
             p.Element("before-close-state").SetText("rendered");
+            p.Element("before-close-first-item").SetText(args, x => x.Items[0].Text);
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t => t.Element("before-close-parent").SetText("root"))
+                .Else(e => e.Element("before-close-parent").SetText(args, x => x.ParentItem!.Text));
+            p.Element("before-close-cancel-value").SetText(args, x => x.Cancel);
 
             p.When(p.Component<NativeCheckBox>(m => m.BlockClose).Value()).Truthy()
                 .Then(t =>
                 {
                     t.Element("before-close-cancel").SetText("cancelled");
                     args.PreventClose(t);
+                    t.Element("before-close-cancel-value").SetText(args, x => x.Cancel);
                 })
                 .Else(e => e.Element("before-close-cancel").SetText("allowed"));
         })
         .Reactive(evt => evt.Closed, (args, p) =>
         {
             p.Element("close-state").SetText("closed");
+            p.Element("close-first-item").SetText(args, x => x.Items[0].Text);
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t => t.Element("close-parent").SetText("root"))
+                .Else(e => e.Element("close-parent").SetText(args, x => x.ParentItem!.Text));
             p.Element("menu-visibility").SetText("hidden");
         })
         .Reactive(evt => evt.Select, (args, p) =>
@@ -170,6 +218,9 @@
             p.Element("select-text").SetText(args, x => x.Item.Text);
             p.Element("select-id").SetText(args, x => x.Item.Id);
             p.Element("select-url").SetText(args, x => x.Item.Url);
+            p.Element("select-icon-css").SetText(args, x => x.Item.IconCss);
+            p.Element("select-separator").SetText(args, x => x.Item.Separator);
+            p.Element("select-first-child").SetText(args, x => x.Item.Items[0].Text);
         }))
     </native-card-body></native-card>
 
@@ -179,22 +230,38 @@
             <p>Before item state: <span id="before-item-state" class="text-text-muted">pending</span></p>
             <p>Before item text: <span id="before-item-text" class="text-text-muted">pending</span></p>
             <p>Before item id: <span id="before-item-id" class="text-text-muted">pending</span></p>
+            <p>Before item url: <span id="before-item-url" class="text-text-muted">pending</span></p>
+            <p>Before item icon CSS: <span id="before-item-icon-css" class="text-text-muted">pending</span></p>
+            <p>Before item separator: <span id="before-item-separator" class="text-text-muted">pending</span></p>
             <p>Before open state: <span id="before-open-state" class="text-text-muted">pending</span></p>
             <p>Before open kind: <span id="before-open-kind" class="text-text-muted">pending</span></p>
             <p>Before open top: <span id="before-open-top" class="text-text-muted">pending</span></p>
             <p>Before open left: <span id="before-open-left" class="text-text-muted">pending</span></p>
+            <p>Before open focused: <span id="before-open-focused" class="text-text-muted">pending</span></p>
+            <p>Before open first item: <span id="before-open-first-item" class="text-text-muted">pending</span></p>
             <p>Before open parent: <span id="before-open-parent" class="text-text-muted">pending</span></p>
             <p>Before open cancel: <span id="before-open-cancel" class="text-text-muted">pending</span></p>
+            <p>Before open cancel value: <span id="before-open-cancel-value" class="text-text-muted">pending</span></p>
             <p>Open state: <span id="open-state" class="text-text-muted">pending</span></p>
             <p>Open kind: <span id="open-kind" class="text-text-muted">pending</span></p>
+            <p>Open first item: <span id="open-first-item" class="text-text-muted">pending</span></p>
+            <p>Open parent: <span id="open-parent" class="text-text-muted">pending</span></p>
             <p>Menu visibility: <span id="menu-visibility" class="text-text-muted">pending</span></p>
             <p>Before close state: <span id="before-close-state" class="text-text-muted">pending</span></p>
+            <p>Before close first item: <span id="before-close-first-item" class="text-text-muted">pending</span></p>
+            <p>Before close parent: <span id="before-close-parent" class="text-text-muted">pending</span></p>
             <p>Before close cancel: <span id="before-close-cancel" class="text-text-muted">pending</span></p>
+            <p>Before close cancel value: <span id="before-close-cancel-value" class="text-text-muted">pending</span></p>
             <p>Close state: <span id="close-state" class="text-text-muted">pending</span></p>
+            <p>Close first item: <span id="close-first-item" class="text-text-muted">pending</span></p>
+            <p>Close parent: <span id="close-parent" class="text-text-muted">pending</span></p>
             <p>Select state: <span id="select-state" class="text-text-muted">pending</span></p>
             <p>Select text: <span id="select-text" class="text-text-muted">pending</span></p>
             <p>Select id: <span id="select-id" class="text-text-muted">pending</span></p>
             <p>Select url: <span id="select-url" class="text-text-muted">pending</span></p>
+            <p>Select icon CSS: <span id="select-icon-css" class="text-text-muted">pending</span></p>
+            <p>Select separator: <span id="select-separator" class="text-text-muted">pending</span></p>
+            <p>Select first child: <span id="select-first-child" class="text-text-muted">pending</span></p>
         </native-vstack>
     </native-card-body></native-card>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Menu/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Menu/Index.cshtml
@@ -1,0 +1,207 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Menu.FusionMenuModel
+@using System.Collections.Generic
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionMenu";
+
+    const string MenuId = "resident-menu";
+
+    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Menu.FusionMenuModel>();
+    var items = new List<MenuItem>
+    {
+        new() { Id = "dashboard-item", Text = "Dashboard" },
+        new()
+        {
+            Id = "projects-item",
+            Text = "Projects",
+            Items = new List<MenuItem>
+            {
+                new() { Id = "reports-item", Text = "Reports" },
+                new() { Id = "archive-item", Text = "Archive" }
+            }
+        },
+        new() { Id = "help-item", Text = "Help" }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        p.Element("before-item-state").SetText("pending");
+        p.Element("before-item-text").SetText("pending");
+        p.Element("before-item-id").SetText("pending");
+        p.Element("before-open-state").SetText("pending");
+        p.Element("before-open-kind").SetText("pending");
+        p.Element("before-open-top").SetText("pending");
+        p.Element("before-open-left").SetText("pending");
+        p.Element("before-open-parent").SetText("pending");
+        p.Element("before-open-cancel").SetText("pending");
+        p.Element("open-state").SetText("pending");
+        p.Element("open-kind").SetText("pending");
+        p.Element("menu-visibility").SetText("pending");
+        p.Element("before-close-state").SetText("pending");
+        p.Element("before-close-cancel").SetText("pending");
+        p.Element("close-state").SetText("pending");
+        p.Element("select-state").SetText("pending");
+        p.Element("select-text").SetText("pending");
+        p.Element("select-id").SetText("pending");
+        p.Element("select-url").SetText("pending");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionMenu</native-heading>
+    <native-text color="Secondary">
+        Navigation menu slice. Exercises hamburger open and close methods, typed nested item payloads, cancelable open and close guards, item render payloads, and item selection.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Controls</native-heading>
+        <native-vstack gap="Md">
+            <div class="flex flex-wrap gap-4">
+                @{ Html.InputField(plan, m => m.BlockOpen, o => o.Label("Block open"))
+                    .NativeCheckBox(b => b.CssClass("h-4 w-4 rounded border-border text-accent")); }
+                @{ Html.InputField(plan, m => m.BlockClose, o => o.Label("Block close"))
+                    .NativeCheckBox(b => b.CssClass("h-4 w-4 rounded border-border text-accent")); }
+            </div>
+
+            <native-hstack gap="Sm" class="flex-wrap">
+                @(Html.NativeButton("open-menu-btn", "Open menu")
+                    .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                    .Reactive(plan, evt => evt.Click, (_, p) =>
+                    {
+                        var menu = p.Component<FusionMenu>(MenuId);
+                        menu.Open();
+                    }))
+                @(Html.NativeButton("close-menu-btn", "Close menu")
+                    .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                    .Reactive(plan, evt => evt.Click, (_, p) =>
+                    {
+                        var menu = p.Component<FusionMenu>(MenuId);
+                        menu.Close();
+                    }))
+            </native-hstack>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Menu</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            Open the hamburger menu, hover Projects to open the submenu, select an item, and close the menu again.
+        </p>
+
+        @(Html.FusionMenu(plan, MenuId, b =>
+        {
+            b.Items(items);
+            b.HamburgerMode(true);
+            b.Orientation(Orientation.Horizontal);
+            b.ShowItemOnClick(true);
+            b.Title("Resident menu");
+            b.EnableScrolling(false);
+            b.AnimationSettings(new MenuAnimationSettings
+            {
+                Effect = MenuEffect.None,
+                Duration = 0,
+                Easing = "linear"
+            });
+        })
+        .Reactive(evt => evt.BeforeItemRender, (args, p) =>
+        {
+            p.Element("before-item-state").SetText("rendered");
+            p.Element("before-item-text").SetText(args, x => x.Item.Text);
+            p.Element("before-item-id").SetText(args, x => x.Item.Id);
+        })
+        .Reactive(evt => evt.BeforeOpen, (args, p) =>
+        {
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t =>
+                {
+                    t.Element("before-open-kind").SetText("root");
+                    t.Element("before-open-top").SetText(args, x => x.Top);
+                    t.Element("before-open-left").SetText(args, x => x.Left);
+                    t.Element("before-open-parent").SetText("root");
+                })
+                .Else(e =>
+                {
+                    e.Element("before-open-kind").SetText("submenu");
+                    e.Element("before-open-top").SetText(args, x => x.Top);
+                    e.Element("before-open-left").SetText(args, x => x.Left);
+                    e.Element("before-open-parent").SetText(args, x => x.ParentItem!.Text);
+                });
+
+            p.When(p.Component<NativeCheckBox>(m => m.BlockOpen).Value()).Truthy()
+                .Then(t =>
+                {
+                    t.Element("before-open-cancel").SetText("cancelled");
+                    args.PreventOpen(t);
+                })
+                .Else(e => e.Element("before-open-cancel").SetText("allowed"));
+        })
+        .Reactive(evt => evt.Opened, (args, p) =>
+        {
+            p.When(args, x => x.ParentItem).IsNull()
+                .Then(t => t.Element("open-kind").SetText("root"))
+                .Else(e => e.Element("open-kind").SetText("submenu"));
+
+            p.Element("open-state").SetText("opened");
+            p.Element("menu-visibility").SetText("visible");
+        })
+        .Reactive(evt => evt.BeforeClose, (args, p) =>
+        {
+            p.Element("before-close-state").SetText("rendered");
+
+            p.When(p.Component<NativeCheckBox>(m => m.BlockClose).Value()).Truthy()
+                .Then(t =>
+                {
+                    t.Element("before-close-cancel").SetText("cancelled");
+                    args.PreventClose(t);
+                })
+                .Else(e => e.Element("before-close-cancel").SetText("allowed"));
+        })
+        .Reactive(evt => evt.Closed, (args, p) =>
+        {
+            p.Element("close-state").SetText("closed");
+            p.Element("menu-visibility").SetText("hidden");
+        })
+        .Reactive(evt => evt.Select, (args, p) =>
+        {
+            p.Element("select-state").SetText("selected");
+            p.Element("select-text").SetText(args, x => x.Item.Text);
+            p.Element("select-id").SetText(args, x => x.Item.Id);
+            p.Element("select-url").SetText(args, x => x.Item.Url);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Before item state: <span id="before-item-state" class="text-text-muted">pending</span></p>
+            <p>Before item text: <span id="before-item-text" class="text-text-muted">pending</span></p>
+            <p>Before item id: <span id="before-item-id" class="text-text-muted">pending</span></p>
+            <p>Before open state: <span id="before-open-state" class="text-text-muted">pending</span></p>
+            <p>Before open kind: <span id="before-open-kind" class="text-text-muted">pending</span></p>
+            <p>Before open top: <span id="before-open-top" class="text-text-muted">pending</span></p>
+            <p>Before open left: <span id="before-open-left" class="text-text-muted">pending</span></p>
+            <p>Before open parent: <span id="before-open-parent" class="text-text-muted">pending</span></p>
+            <p>Before open cancel: <span id="before-open-cancel" class="text-text-muted">pending</span></p>
+            <p>Open state: <span id="open-state" class="text-text-muted">pending</span></p>
+            <p>Open kind: <span id="open-kind" class="text-text-muted">pending</span></p>
+            <p>Menu visibility: <span id="menu-visibility" class="text-text-muted">pending</span></p>
+            <p>Before close state: <span id="before-close-state" class="text-text-muted">pending</span></p>
+            <p>Before close cancel: <span id="before-close-cancel" class="text-text-muted">pending</span></p>
+            <p>Close state: <span id="close-state" class="text-text-muted">pending</span></p>
+            <p>Select state: <span id="select-state" class="text-text-muted">pending</span></p>
+            <p>Select text: <span id="select-text" class="text-text-muted">pending</span></p>
+            <p>Select id: <span id="select-id" class="text-text-muted">pending</span></p>
+            <p>Select url: <span id="select-url" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/OtpInput/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/OtpInput/Index.cshtml
@@ -1,0 +1,170 @@
+@model OtpInputModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@using Syncfusion.EJ2.Inputs
+@{
+    ViewData["Title"] = "FusionOtpInput";
+
+    var plan = Html.ReactivePlan<OtpInputModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var passcode = p.Component<FusionOtpInput>(m => m.Passcode);
+        passcode.SetValue("1357");
+        p.Element("value-echo").SetText(passcode.Value());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionOtpInput</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Value, Focus, and Events</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.Passcode, o => o.Label("Passcode"))
+                .FusionOtpInput(b => b
+                    .Length(4)
+                    .Value("1234")
+                    .Type(OtpInputType.Text)
+                    .Placeholder("0000")
+                    .Reactive(plan, evt => evt.Input, (args, p) =>
+                    {
+                        p.Element("input-value").SetText(args, x => x.Value);
+                        p.Element("input-previous").SetText(args, x => x.PreviousValue);
+                        p.Element("input-index").SetText(args, x => x.Index);
+                    })
+                    .Reactive(plan, evt => evt.ValueChanged, (args, p) =>
+                    {
+                        p.Element("changed-value").SetText(args, x => x.Value);
+                        p.Element("changed-previous").SetText(args, x => x.PreviousValue);
+                        p.Element("changed-interacted").SetText(args, x => x.IsInteracted);
+                        p.When(args, x => x.Value).Eq("2468")
+                            .Then(t => t.Element("args-condition").SetText("complete"))
+                            .Else(e => e.Element("args-condition").SetText("changed"));
+                    })
+                    .Reactive(plan, evt => evt.Focus, (args, p) =>
+                    {
+                        p.Element("focus-state").SetText("focused");
+                        p.Element("focus-value").SetText(args, x => x.Value);
+                        p.Element("focus-index").SetText(args, x => x.Index);
+                        p.Element("focus-interacted").SetText(args, x => x.IsInteracted);
+                    })
+                    .Reactive(plan, evt => evt.Blur, (args, p) =>
+                    {
+                        p.Element("focus-state").SetText("blurred");
+                        p.Element("blur-value").SetText(args, x => x.Value);
+                        p.Element("blur-index").SetText(args, x => x.Index);
+                        p.Element("blur-interacted").SetText(args, x => x.IsInteracted);
+                    })); }
+        </native-grid>
+
+        <native-hstack gap="Sm" class="mt-4">
+            @(Html.NativeButton("set-code-btn", "Set Code")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var passcode = p.Component<FusionOtpInput>(m => m.Passcode);
+                    passcode.SetValue("9876");
+                    p.Element("value-echo").SetText(passcode.Value());
+                    p.Element("command-state").SetText("code set");
+                }))
+            @(Html.NativeButton("clear-code-btn", "Clear Code")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var passcode = p.Component<FusionOtpInput>(m => m.Passcode);
+                    passcode.SetValue("");
+                    p.Element("value-echo").SetText(passcode.Value());
+                    p.Element("command-state").SetText("code cleared");
+                }))
+            @(Html.NativeButton("focus-code-btn", "Focus Code")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionOtpInput>(m => m.Passcode).FocusIn();
+                    p.Element("command-state").SetText("focus called");
+                }))
+            @(Html.NativeButton("check-code-btn", "Check Code")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var passcode = p.Component<FusionOtpInput>(m => m.Passcode);
+                    p.When(passcode.Value()).Eq("9876")
+                        .Then(t => t.Element("code-state").SetText("verified"))
+                        .Else(e => e.Element("code-state").SetText("pending"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">FocusOut Method</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.AutoBlurCode, o => o.Label("Auto Blur Code"))
+                .FusionOtpInput(b => b
+                    .Length(4)
+                    .Type(OtpInputType.Text)
+                    .Reactive(plan, evt => evt.Focus, (args, p) =>
+                    {
+                        p.Component<FusionOtpInput>(m => m.AutoBlurCode).FocusOut();
+                        p.Element("focusout-method-state").SetText("focusout called");
+                    })
+                    .Reactive(plan, evt => evt.Blur, (args, p) =>
+                    {
+                        p.Element("autoblur-state").SetText("blurred");
+                    })); }
+        </native-grid>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather Code")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var passcode = p.Component<FusionOtpInput>(m => m.Passcode);
+                p.Post("/Sandbox/Components/OtpInput/Echo")
+                    .Gather(g => g.Include(passcode.Value(), "passcode"))
+                    .Response(r => r.OnSuccess<OtpInputEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-code").SetText(json, x => x.Passcode);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">&mdash;</span></p>
+            <p>Value echo: <span id="value-echo" class="text-text-muted">&mdash;</span></p>
+            <p>Input value: <span id="input-value" class="text-text-muted">&mdash;</span></p>
+            <p>Input previous: <span id="input-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Input index: <span id="input-index" class="text-text-muted">&mdash;</span></p>
+            <p>Changed value: <span id="changed-value" class="text-text-muted">&mdash;</span></p>
+            <p>Changed previous: <span id="changed-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Changed interacted: <span id="changed-interacted" class="text-text-muted">&mdash;</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">&mdash;</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">&mdash;</span></p>
+            <p>Focus value: <span id="focus-value" class="text-text-muted">&mdash;</span></p>
+            <p>Focus index: <span id="focus-index" class="text-text-muted">&mdash;</span></p>
+            <p>Focus interacted: <span id="focus-interacted" class="text-text-muted">&mdash;</span></p>
+            <p>Blur value: <span id="blur-value" class="text-text-muted">&mdash;</span></p>
+            <p>Blur index: <span id="blur-index" class="text-text-muted">&mdash;</span></p>
+            <p>Blur interacted: <span id="blur-interacted" class="text-text-muted">&mdash;</span></p>
+            <p>Code state: <span id="code-state" class="text-text-muted">&mdash;</span></p>
+            <p>FocusOut method: <span id="focusout-method-state" class="text-text-muted">&mdash;</span></p>
+            <p>Auto blur state: <span id="autoblur-state" class="text-text-muted">&mdash;</span></p>
+            <p>Gather code: <span id="gather-code" class="text-text-muted">&mdash;</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ProgressButton/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ProgressButton/Index.cshtml
@@ -1,0 +1,221 @@
+@model FusionProgressButtonModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionProgressButton";
+
+    const string buttonId = "resident-progress-button";
+    var plan = Html.ReactivePlan<FusionProgressButtonModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var button = p.Component<FusionProgressButton>(buttonId);
+        button.SetContent("Ready Save");
+        button.SetProgressEnabled(true);
+        p.Element("content-echo").SetText(button.Content());
+        p.Element("progress-enabled-echo").SetText(button.ProgressEnabled());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionProgressButton</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Runtime Progress</native-heading>
+        <native-hstack gap="Base" align="Center">
+            @(Html.FusionProgressButton(plan, buttonId, b => b
+                .Content("Initial Save")
+                .CssClass("care-progress")
+                .Duration(500)
+                .EnableProgress(false))
+                .Reactive(evt => evt.Began, (args, p) =>
+                {
+                    p.Element("begin-percent").SetText(args, x => x.Percent);
+                    p.Element("begin-duration").SetText(args, x => x.CurrentDuration);
+                    p.Element("begin-step").SetText(args, x => x.Step);
+                    p.When(args, x => x.Percent).Eq(0d)
+                        .Then(t => t.Element("begin-condition").SetText("begin zero"))
+                        .Else(e => e.Element("begin-condition").SetText("begin nonzero"));
+                })
+                .Reactive(evt => evt.Progressed, (args, p) =>
+                {
+                    p.Element("progress-percent").SetText(args, x => x.Percent);
+                    p.Element("progress-duration").SetText(args, x => x.CurrentDuration);
+                    p.Element("progress-step").SetText(args, x => x.Step);
+                    p.When(args, x => x.Percent).Gte(60d)
+                        .Then(t => t.Element("progress-condition").SetText("at least sixty"))
+                        .Else(e => e.Element("progress-condition").SetText("below sixty"));
+                })
+                .Reactive(evt => evt.Ended, (args, p) =>
+                {
+                    p.Element("end-percent").SetText(args, x => x.Percent);
+                    p.Element("end-duration").SetText(args, x => x.CurrentDuration);
+                    p.Element("end-step").SetText(args, x => x.Step);
+                    p.When(args, x => x.Percent).Eq(100d)
+                        .Then(t => t.Element("end-condition").SetText("complete"))
+                        .Else(e => e.Element("end-condition").SetText("incomplete"));
+                }))
+        </native-hstack>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-content-btn", "Set Content")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionProgressButton>(buttonId);
+                    button.SetContent("Discharge Save");
+                    p.Element("content-echo").SetText(button.Content());
+                    p.Element("command-state").SetText("content set");
+                }))
+            @(Html.NativeButton("disable-progress-button-btn", "Disable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionProgressButton>(buttonId);
+                    button.SetDisabled(true);
+                    p.Element("disabled-echo").SetText(button.Disabled());
+                    p.Element("command-state").SetText("disabled");
+                }))
+            @(Html.NativeButton("enable-progress-button-btn", "Enable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionProgressButton>(buttonId);
+                    button.SetDisabled(false);
+                    p.Element("disabled-echo").SetText(button.Disabled());
+                    p.Element("command-state").SetText("enabled");
+                }))
+            @(Html.NativeButton("set-css-btn", "Set Css")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionProgressButton>(buttonId);
+                    button.SetCssClass("e-success extra-class");
+                    p.Element("css-echo").SetText(button.CssClass());
+                    p.Element("command-state").SetText("css set");
+                }))
+            @(Html.NativeButton("enable-progress-btn", "Enable Progress")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionProgressButton>(buttonId);
+                    button.SetProgressEnabled(true);
+                    p.Element("progress-enabled-echo").SetText(button.ProgressEnabled());
+                    p.Element("command-state").SetText("progress enabled");
+                }))
+            @(Html.NativeButton("disable-progress-btn", "Disable Progress")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionProgressButton>(buttonId);
+                    button.SetProgressEnabled(false);
+                    p.Element("progress-enabled-echo").SetText(button.ProgressEnabled());
+                    p.Element("command-state").SetText("progress disabled");
+                }))
+            @(Html.NativeButton("start-progress-btn", "Start")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionProgressButton>(buttonId).Start();
+                    p.Element("start-state").SetText("start called");
+                }))
+            @(Html.NativeButton("start-at-progress-btn", "Start At 60")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionProgressButton>(buttonId).StartAt(60d);
+                    p.Element("start-state").SetText("start at 60 called");
+                }))
+            @(Html.NativeButton("complete-progress-btn", "Complete")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionProgressButton>(buttonId).ProgressComplete();
+                    p.Element("complete-state").SetText("complete called");
+                }))
+            @(Html.NativeButton("focus-progress-btn", "Focus")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionProgressButton>(buttonId).FocusIn();
+                    p.Element("focus-state").SetText("focus called");
+                }))
+            @(Html.NativeButton("check-progress-enabled-btn", "Check Progress")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var button = p.Component<FusionProgressButton>(buttonId);
+                    p.When(button.ProgressEnabled()).Truthy()
+                        .Then(t => t.Element("progress-enabled-state").SetText("progress enabled"))
+                        .Else(e => e.Element("progress-enabled-state").SetText("progress disabled"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather ProgressButton")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var button = p.Component<FusionProgressButton>(buttonId);
+                p.Post("/Sandbox/Components/FusionProgressButton/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(button.Content(), "content");
+                        g.Include(button.Disabled(), "disabled");
+                        g.Include(button.CssClass(), "cssClass");
+                        g.Include(button.ProgressEnabled(), "progressEnabled");
+                    })
+                    .Response(r => r.OnSuccess<FusionProgressButtonEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-content").SetText(json, x => x.Content);
+                        s.Element("gather-disabled").SetText(json, x => x.Disabled);
+                        s.Element("gather-css").SetText(json, x => x.CssClass);
+                        s.Element("gather-progress-enabled").SetText(json, x => x.ProgressEnabled);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Content echo: <span id="content-echo" class="text-text-muted">pending</span></p>
+            <p>Disabled echo: <span id="disabled-echo" class="text-text-muted">pending</span></p>
+            <p>Css echo: <span id="css-echo" class="text-text-muted">pending</span></p>
+            <p>Progress enabled echo: <span id="progress-enabled-echo" class="text-text-muted">pending</span></p>
+            <p>Progress enabled state: <span id="progress-enabled-state" class="text-text-muted">pending</span></p>
+            <p>Start state: <span id="start-state" class="text-text-muted">pending</span></p>
+            <p>Complete state: <span id="complete-state" class="text-text-muted">pending</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">pending</span></p>
+            <p>Begin percent: <span id="begin-percent" class="text-text-muted">pending</span></p>
+            <p>Begin duration: <span id="begin-duration" class="text-text-muted">pending</span></p>
+            <p>Begin step: <span id="begin-step" class="text-text-muted">pending</span></p>
+            <p>Begin condition: <span id="begin-condition" class="text-text-muted">pending</span></p>
+            <p>Progress percent: <span id="progress-percent" class="text-text-muted">pending</span></p>
+            <p>Progress duration: <span id="progress-duration" class="text-text-muted">pending</span></p>
+            <p>Progress step: <span id="progress-step" class="text-text-muted">pending</span></p>
+            <p>Progress condition: <span id="progress-condition" class="text-text-muted">pending</span></p>
+            <p>End percent: <span id="end-percent" class="text-text-muted">pending</span></p>
+            <p>End duration: <span id="end-duration" class="text-text-muted">pending</span></p>
+            <p>End step: <span id="end-step" class="text-text-muted">pending</span></p>
+            <p>End condition: <span id="end-condition" class="text-text-muted">pending</span></p>
+            <p>Gather content: <span id="gather-content" class="text-text-muted">pending</span></p>
+            <p>Gather disabled: <span id="gather-disabled" class="text-text-muted">pending</span></p>
+            <p>Gather css: <span id="gather-css" class="text-text-muted">pending</span></p>
+            <p>Gather progress enabled: <span id="gather-progress-enabled" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/RadioButton/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/RadioButton/Index.cshtml
@@ -1,0 +1,178 @@
+@model FusionRadioButtonModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionRadioButton";
+
+    const string privateId = "private-room-radio";
+    const string sharedId = "shared-room-radio";
+    var plan = Html.ReactivePlan<FusionRadioButtonModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var shared = p.Component<FusionRadioButton>(sharedId);
+        shared.SetChecked(true);
+        p.Element("selected-echo").SetText(shared.SelectedValue());
+        p.Element("shared-checked-echo").SetText(shared.Checked());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionRadioButton</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">State and Events</native-heading>
+        <native-vstack gap="Sm">
+            @(Html.FusionRadioButton(plan, privateId, b => b
+                .Name("roomType")
+                .Value("Private")
+                .Label("Private room"))
+                .Reactive(evt => evt.Changed, (args, p) =>
+                {
+                    p.Element("change-value").SetText(args, x => x.Value);
+                    p.When(args, x => x.Value).Eq("Private")
+                        .Then(t => t.Element("args-condition").SetText("private"))
+                        .Else(e => e.Element("args-condition").SetText("not private"));
+                }))
+
+            @(Html.FusionRadioButton(plan, sharedId, b => b
+                .Name("roomType")
+                .Value("Shared")
+                .Label("Shared room"))
+                .Reactive(evt => evt.Changed, (args, p) =>
+                {
+                    p.Element("change-value").SetText(args, x => x.Value);
+                    p.When(args, x => x.Value).Eq("Shared")
+                        .Then(t => t.Element("args-condition").SetText("shared"))
+                        .Else(e => e.Element("args-condition").SetText("not shared"));
+                }))
+        </native-vstack>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-private-btn", "Set Private")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var privateRoom = p.Component<FusionRadioButton>(privateId);
+                    var sharedRoom = p.Component<FusionRadioButton>(sharedId);
+                    privateRoom.SetChecked(true);
+                    p.Element("selected-echo").SetText(privateRoom.SelectedValue());
+                    p.Element("private-checked-echo").SetText(privateRoom.Checked());
+                    p.Element("shared-checked-echo").SetText(sharedRoom.Checked());
+                    p.Element("command-state").SetText("private set");
+                }))
+            @(Html.NativeButton("set-shared-btn", "Set Shared")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var privateRoom = p.Component<FusionRadioButton>(privateId);
+                    var sharedRoom = p.Component<FusionRadioButton>(sharedId);
+                    sharedRoom.SetChecked(true);
+                    p.Element("selected-echo").SetText(sharedRoom.SelectedValue());
+                    p.Element("private-checked-echo").SetText(privateRoom.Checked());
+                    p.Element("shared-checked-echo").SetText(sharedRoom.Checked());
+                    p.Element("command-state").SetText("shared set");
+                }))
+            @(Html.NativeButton("disable-shared-btn", "Disable Shared")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var sharedRoom = p.Component<FusionRadioButton>(sharedId);
+                    sharedRoom.SetDisabled(true);
+                    p.Element("disabled-echo").SetText(sharedRoom.Disabled());
+                    p.Element("command-state").SetText("shared disabled");
+                }))
+            @(Html.NativeButton("enable-shared-btn", "Enable Shared")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var sharedRoom = p.Component<FusionRadioButton>(sharedId);
+                    sharedRoom.SetDisabled(false);
+                    p.Element("disabled-echo").SetText(sharedRoom.Disabled());
+                    p.Element("command-state").SetText("shared enabled");
+                }))
+            @(Html.NativeButton("click-shared-btn", "Click Shared")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var sharedRoom = p.Component<FusionRadioButton>(sharedId);
+                    sharedRoom.Click();
+                    p.Element("selected-echo").SetText(sharedRoom.SelectedValue());
+                    p.Element("click-state").SetText("click called");
+                }))
+            @(Html.NativeButton("focus-private-btn", "Focus Private")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionRadioButton>(privateId).FocusIn();
+                    p.Element("focus-state").SetText("focus called");
+                }))
+            @(Html.NativeButton("check-selected-btn", "Check Selected")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var privateRoom = p.Component<FusionRadioButton>(privateId);
+                    p.When(privateRoom.SelectedValue()).Eq("Private")
+                        .Then(t => t.Element("selected-state").SetText("private selected"))
+                        .Else(e => e.Element("selected-state").SetText("other selected"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather RadioButton")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var privateRoom = p.Component<FusionRadioButton>(privateId);
+                var sharedRoom = p.Component<FusionRadioButton>(sharedId);
+                p.Post("/Sandbox/Components/FusionRadioButton/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(privateRoom.SelectedValue(), "selectedValue");
+                        g.Include(privateRoom.Checked(), "privateChecked");
+                        g.Include(sharedRoom.Checked(), "sharedChecked");
+                        g.Include(sharedRoom.Disabled(), "sharedDisabled");
+                    })
+                    .Response(r => r.OnSuccess<FusionRadioButtonEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-selected").SetText(json, x => x.SelectedValue);
+                        s.Element("gather-private-checked").SetText(json, x => x.PrivateChecked);
+                        s.Element("gather-shared-checked").SetText(json, x => x.SharedChecked);
+                        s.Element("gather-shared-disabled").SetText(json, x => x.SharedDisabled);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Selected echo: <span id="selected-echo" class="text-text-muted">pending</span></p>
+            <p>Private checked: <span id="private-checked-echo" class="text-text-muted">pending</span></p>
+            <p>Shared checked: <span id="shared-checked-echo" class="text-text-muted">pending</span></p>
+            <p>Disabled echo: <span id="disabled-echo" class="text-text-muted">pending</span></p>
+            <p>Change value: <span id="change-value" class="text-text-muted">pending</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">pending</span></p>
+            <p>Click state: <span id="click-state" class="text-text-muted">pending</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">pending</span></p>
+            <p>Selected state: <span id="selected-state" class="text-text-muted">pending</span></p>
+            <p>Gather selected: <span id="gather-selected" class="text-text-muted">pending</span></p>
+            <p>Gather private checked: <span id="gather-private-checked" class="text-text-muted">pending</span></p>
+            <p>Gather shared checked: <span id="gather-shared-checked" class="text-text-muted">pending</span></p>
+            <p>Gather shared disabled: <span id="gather-shared-disabled" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Rating/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Rating/Index.cshtml
@@ -1,0 +1,110 @@
+@model RatingModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionRating";
+
+    var plan = Html.ReactivePlan<RatingModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var rating = p.Component<FusionRating>(m => m.SatisfactionScore);
+        rating.SetValue(3);
+        p.Element("value-echo").SetText(rating.Value());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionRating</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Value, Reset, and Events</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.SatisfactionScore, o => o.Label("Satisfaction Score"))
+                .FusionRating(b => b
+                    .Value(2)
+                    .AllowReset(true)
+                    .ShowLabel(true)
+                    .Reactive(plan, evt => evt.ValueChanged, (args, p) =>
+                    {
+                        p.Element("changed-value").SetText(args, x => x.Value);
+                        p.Element("changed-previous").SetText(args, x => x.PreviousValue);
+                        p.Element("changed-interacted").SetText(args, x => x.IsInteracted);
+                        p.When(args, x => x.Value).Eq(0d)
+                            .Then(t => t.Element("args-condition").SetText("reset"))
+                            .Else(e => e.Element("args-condition").SetText("rated"));
+                    })); }
+        </native-grid>
+
+        <native-hstack gap="Sm" class="mt-4">
+            @(Html.NativeButton("set-rating-btn", "Set Rating")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var rating = p.Component<FusionRating>(m => m.SatisfactionScore);
+                    rating.SetValue(4);
+                    p.Element("value-echo").SetText(rating.Value());
+                    p.Element("command-state").SetText("rating set");
+                }))
+            @(Html.NativeButton("reset-rating-btn", "Reset Rating")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var rating = p.Component<FusionRating>(m => m.SatisfactionScore);
+                    rating.Reset();
+                    p.Element("value-echo").SetText(rating.Value());
+                    p.Element("command-state").SetText("rating reset");
+                }))
+            @(Html.NativeButton("check-rating-btn", "Check Rating")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var rating = p.Component<FusionRating>(m => m.SatisfactionScore);
+                    p.When(rating.Value()).Gte(3d)
+                        .Then(t => t.Element("rating-state").SetText("satisfied"))
+                        .Else(e => e.Element("rating-state").SetText("needs follow-up"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather Rating")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var rating = p.Component<FusionRating>(m => m.SatisfactionScore);
+                p.Post("/Sandbox/Components/Rating/Echo")
+                    .Gather(g => g.Include(rating.Value(), "satisfactionScore"))
+                    .Response(r => r.OnSuccess<RatingEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-score").SetText(json, x => x.SatisfactionScore);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">&mdash;</span></p>
+            <p>Value echo: <span id="value-echo" class="text-text-muted">&mdash;</span></p>
+            <p>Changed value: <span id="changed-value" class="text-text-muted">&mdash;</span></p>
+            <p>Changed previous: <span id="changed-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Changed interacted: <span id="changed-interacted" class="text-text-muted">&mdash;</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">&mdash;</span></p>
+            <p>Rating state: <span id="rating-state" class="text-text-muted">&mdash;</span></p>
+            <p>Gather score: <span id="gather-score" class="text-text-muted">&mdash;</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Sidebar/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Sidebar/Index.cshtml
@@ -2,11 +2,14 @@
 @using Alis.Reactive.Fusion.Components
 @using Alis.Reactive.Native.Components
 @using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Sidebar
 @using Syncfusion.EJ2.Navigations
 @{
     ViewData["Title"] = "FusionSidebar";
 
     const string SidebarId = "resident-sidebar";
+    var openPanelUrl = Url.Action("OpenPanel", "Sidebar", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Sidebar.OpenPanel.");
 
     var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Sidebar.FusionSidebarModel>();
 
@@ -47,6 +50,14 @@
         {
             p.Element("open-state").SetText("opened");
             p.Element("open-interacted").SetText(args, x => x.IsInteracted);
+            p.Post(openPanelUrl)
+                .Gather(g => g.FromEvent(args, x => x.IsInteracted, "isInteracted"))
+                .Response(r => r.OnSuccess<FusionSidebarOpenResponse>((json, s) =>
+                {
+                    s.Element("panel-title").SetText(json, x => x.PanelTitle);
+                    s.Element("panel-load-state").SetText(json, x => x.Message);
+                    s.Element("panel-open-mode").SetText(json, x => x.OpenMode);
+                }));
         })
         .Reactive(evt => evt.Closed, (args, p) =>
         {
@@ -99,6 +110,9 @@
             <p>Close state: <span id="close-state" class="text-text-muted">pending</span></p>
             <p>Close interacted: <span id="close-interacted" class="text-text-muted">pending</span></p>
             <p>Command state: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Panel title: <span id="panel-title" class="text-text-muted">pending</span></p>
+            <p>Panel load state: <span id="panel-load-state" class="text-text-muted">pending</span></p>
+            <p>Panel open mode: <span id="panel-open-mode" class="text-text-muted">pending</span></p>
         </native-vstack>
     </native-card-body></native-card>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Sidebar/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Sidebar/Index.cshtml
@@ -1,0 +1,111 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Sidebar.FusionSidebarModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionSidebar";
+
+    const string SidebarId = "resident-sidebar";
+
+    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Sidebar.FusionSidebarModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var sidebar = p.Component<FusionSidebar>(SidebarId);
+
+        p.Element("is-open-echo").SetText(sidebar.IsOpen());
+        p.Element("open-state").SetText("pending");
+        p.Element("close-state").SetText("pending");
+        p.Element("open-interacted").SetText("pending");
+        p.Element("close-interacted").SetText("pending");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionSidebar</native-heading>
+    <native-text color="Secondary">
+        Navigation component. Exercises open-state reads, show/hide/toggle methods, and cancelable transition events.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Sidebar</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            The sidebar starts closed. Show, hide, and toggle are exposed as typed runtime actions.
+        </p>
+
+        @(Html.FusionSidebar(plan, SidebarId, b =>
+        {
+            b.IsOpen(false);
+            b.Animate(false);
+            b.EnableGestures(false);
+            b.ShowBackdrop(false);
+            b.Type(SidebarType.Over);
+            b.Width("240px");
+        })
+        .Reactive(evt => evt.Opened, (args, p) =>
+        {
+            p.Element("open-state").SetText("opened");
+            p.Element("open-interacted").SetText(args, x => x.IsInteracted);
+        })
+        .Reactive(evt => evt.Closed, (args, p) =>
+        {
+            var sidebar = p.Component<FusionSidebar>(SidebarId);
+            p.Element("close-interacted").SetText(args, x => x.IsInteracted);
+            p.Element("close-state").SetText("closed");
+            p.Element("is-open-echo").SetText(sidebar.IsOpen());
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Commands</native-heading>
+        <native-hstack gap="Sm" class="flex-wrap" style="position: relative; z-index: 2001;">
+            @(Html.NativeButton("show-btn", "Show")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var sidebar = p.Component<FusionSidebar>(SidebarId);
+                    sidebar.Show();
+                    p.Element("command-state").SetText("show");
+                    p.Element("is-open-echo").SetText(sidebar.IsOpen());
+                }))
+            @(Html.NativeButton("hide-btn", "Hide")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var sidebar = p.Component<FusionSidebar>(SidebarId);
+                    sidebar.Hide();
+                    p.Element("command-state").SetText("hide");
+                    p.Element("is-open-echo").SetText(sidebar.IsOpen());
+                }))
+            @(Html.NativeButton("toggle-btn", "Toggle")
+                .CssClass("rounded-md bg-slate-700 px-4 py-2 text-sm font-medium text-white hover:bg-slate-600 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    var sidebar = p.Component<FusionSidebar>(SidebarId);
+                    sidebar.Toggle();
+                    p.Element("command-state").SetText("toggle");
+                    p.Element("is-open-echo").SetText(sidebar.IsOpen());
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Open state: <span id="is-open-echo" class="text-text-muted">pending</span></p>
+            <p>Open state event: <span id="open-state" class="text-text-muted">pending</span></p>
+            <p>Open interacted: <span id="open-interacted" class="text-text-muted">pending</span></p>
+            <p>Close state: <span id="close-state" class="text-text-muted">pending</span></p>
+            <p>Close interacted: <span id="close-interacted" class="text-text-muted">pending</span></p>
+            <p>Command state: <span id="command-state" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Slider/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Slider/Index.cshtml
@@ -1,0 +1,153 @@
+@model SliderModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@using Syncfusion.EJ2.Inputs
+@{
+    ViewData["Title"] = "FusionSlider";
+
+    var plan = Html.ReactivePlan<SliderModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var pain = p.Component<FusionSlider>(m => m.PainScore);
+        pain.SetValue(35);
+        p.Element("value-echo").SetText(pain.Value());
+
+        var range = p.Component<FusionSlider>(m => m.PreferredRange);
+        range.SetRangeValue(15, 75);
+        p.Element("range-echo").SetText(range.RangeValue());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionSlider</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Scalar Value and Events</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.PainScore, o => o.Label("Pain Score"))
+                .FusionSlider(b => b
+                    .Min(0)
+                    .Max(100)
+                    .Step(5)
+                    .Value(25)
+                    .Reactive(plan, evt => evt.Change, (args, p) =>
+                    {
+                        p.Element("change-value").SetText(args, x => x.Value);
+                        p.Element("change-previous").SetText(args, x => x.PreviousValue);
+                        p.Element("change-text").SetText(args, x => x.Text);
+                        p.Element("change-action").SetText(args, x => x.Action);
+                        p.Element("change-interacted").SetText(args, x => x.IsInteracted);
+                    })
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        p.Element("changed-value").SetText(args, x => x.Value);
+                        p.Element("changed-previous").SetText(args, x => x.PreviousValue);
+                        p.Element("changed-text").SetText(args, x => x.Text);
+                        p.Element("changed-action").SetText(args, x => x.Action);
+                        p.When(args, x => x.Value).Gte(50d)
+                            .Then(t => t.Element("args-condition").SetText("at least 50"))
+                            .Else(e => e.Element("args-condition").SetText("below 50"));
+                    })); }
+        </native-grid>
+
+        <native-hstack gap="Sm" class="mt-4">
+            @(Html.NativeButton("set-score-btn", "Set Score")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var pain = p.Component<FusionSlider>(m => m.PainScore);
+                    pain.SetValue(65);
+                    p.Element("value-echo").SetText(pain.Value());
+                    p.Element("command-state").SetText("score set");
+                }))
+            @(Html.NativeButton("check-score-btn", "Check Score")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var pain = p.Component<FusionSlider>(m => m.PainScore);
+                    p.When(pain.Value()).Gte(50d)
+                        .Then(t => t.Element("score-state").SetText("high"))
+                        .Else(e => e.Element("score-state").SetText("low"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Range Value</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.PreferredRange, o => o.Label("Preferred Range"))
+                .FusionSlider(b => b
+                    .Min(0)
+                    .Max(100)
+                    .Step(5)
+                    .Type(SliderType.Range)
+                    .Value(new double[] { 20, 60 })); }
+        </native-grid>
+
+        <native-hstack gap="Sm" class="mt-4">
+            @(Html.NativeButton("set-range-btn", "Set Range")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var range = p.Component<FusionSlider>(m => m.PreferredRange);
+                    range.SetRangeValue(30, 90);
+                    p.Element("range-echo").SetText(range.RangeValue());
+                    p.Element("command-state").SetText("range set");
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather Values")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var pain = p.Component<FusionSlider>(m => m.PainScore);
+                var range = p.Component<FusionSlider>(m => m.PreferredRange);
+                p.Post("/Sandbox/Components/Slider/Echo")
+                    .Gather(g => g
+                        .Include(pain.Value(), "painScore")
+                        .Include(range.RangeValue(), "preferredRange"))
+                    .Response(r => r.OnSuccess<SliderEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-score").SetText(json, x => x.PainScore);
+                        s.Element("gather-range").SetText(json, x => x.PreferredRange);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">&mdash;</span></p>
+            <p>Value echo: <span id="value-echo" class="text-text-muted">&mdash;</span></p>
+            <p>Range echo: <span id="range-echo" class="text-text-muted">&mdash;</span></p>
+            <p>Change value: <span id="change-value" class="text-text-muted">&mdash;</span></p>
+            <p>Change previous: <span id="change-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Change text: <span id="change-text" class="text-text-muted">&mdash;</span></p>
+            <p>Change action: <span id="change-action" class="text-text-muted">&mdash;</span></p>
+            <p>Change interacted: <span id="change-interacted" class="text-text-muted">&mdash;</span></p>
+            <p>Changed value: <span id="changed-value" class="text-text-muted">&mdash;</span></p>
+            <p>Changed previous: <span id="changed-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Changed text: <span id="changed-text" class="text-text-muted">&mdash;</span></p>
+            <p>Changed action: <span id="changed-action" class="text-text-muted">&mdash;</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">&mdash;</span></p>
+            <p>Score state: <span id="score-state" class="text-text-muted">&mdash;</span></p>
+            <p>Gather score: <span id="gather-score" class="text-text-muted">&mdash;</span></p>
+            <p>Gather range: <span id="gather-range" class="text-text-muted">&mdash;</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/SplitButton/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/SplitButton/Index.cshtml
@@ -1,0 +1,181 @@
+@model FusionSplitButtonModel
+@using Alis.Reactive.Builders.Requests
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionSplitButton";
+
+    const string menuId = "resident-split-actions";
+    var plan = Html.ReactivePlan<FusionSplitButtonModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var menu = p.Component<FusionSplitButton>(menuId);
+        menu.SetContent("Ready Review");
+        p.Element("content-echo").SetText(menu.Content());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionSplitButton</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Primary and Secondary Actions</native-heading>
+        <native-hstack gap="Base" align="Center">
+            @(Html.FusionSplitButton(plan, menuId, b => b
+                .Content("Initial Review")
+                .CssClass("care-split-actions")
+                .Items(new[]
+                {
+                    new { id = "assign", text = "Assign nurse", disabled = false },
+                    new { id = "schedule", text = "Schedule visit", disabled = false },
+                    new { id = "hold", text = "Place hold", disabled = true }
+                }))
+                .Reactive(evt => evt.Clicked, (args, p) =>
+                {
+                    p.Element("primary-click-state").SetText("primary clicked");
+                    p.Element("command-state").SetText("primary clicked");
+                })
+                .Reactive(evt => evt.Selected, (args, p) =>
+                {
+                    p.Element("selected-id").SetText(args, x => x.Item.Id);
+                    p.Element("selected-text").SetText(args, x => x.Item.Text);
+                    p.Element("selected-disabled").SetText(args, x => x.Item.Disabled);
+                    p.When(args, x => x.Item.Id).Eq("assign")
+                        .Then(t => t.Element("selected-condition").SetText("assign selected"))
+                        .Else(e => e.Element("selected-condition").SetText("other selected"));
+                }))
+        </native-hstack>
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            @(Html.NativeButton("set-content-btn", "Set Content")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionSplitButton>(menuId);
+                    menu.SetContent("Discharge Review");
+                    p.Element("content-echo").SetText(menu.Content());
+                    p.Element("command-state").SetText("content set");
+                }))
+            @(Html.NativeButton("disable-split-btn", "Disable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionSplitButton>(menuId);
+                    menu.SetDisabled(true);
+                    p.Element("disabled-echo").SetText(menu.Disabled());
+                    p.Element("command-state").SetText("disabled");
+                }))
+            @(Html.NativeButton("enable-split-btn", "Enable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionSplitButton>(menuId);
+                    menu.SetDisabled(false);
+                    p.Element("disabled-echo").SetText(menu.Disabled());
+                    p.Element("command-state").SetText("enabled");
+                }))
+            @(Html.NativeButton("set-css-btn", "Set Css")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionSplitButton>(menuId);
+                    menu.SetCssClass("e-success extra-class");
+                    p.Element("css-echo").SetText(menu.CssClass());
+                    p.Element("command-state").SetText("css set");
+                }))
+            @(Html.NativeButton("toggle-split-btn", "Toggle Menu")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionSplitButton>(menuId).Toggle();
+                    p.Element("toggle-state").SetText("toggle called");
+                }))
+            @(Html.NativeButton("focus-split-btn", "Focus Split")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionSplitButton>(menuId).FocusIn();
+                    p.Element("focus-state").SetText("focus called");
+                }))
+            @(Html.NativeButton("remove-schedule-btn", "Remove Schedule")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionSplitButton>(menuId).RemoveItemsByText("Schedule visit");
+                    p.Element("remove-state").SetText("schedule removed");
+                }))
+            @(Html.NativeButton("remove-hold-btn", "Remove Hold")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionSplitButton>(menuId).RemoveItemsById("hold");
+                    p.Element("remove-state").SetText("hold removed");
+                }))
+            @(Html.NativeButton("check-disabled-btn", "Check Disabled")
+                .CssClass("rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    var menu = p.Component<FusionSplitButton>(menuId);
+                    p.When(menu.Disabled()).Eq(true)
+                        .Then(t => t.Element("disabled-state").SetText("disabled"))
+                        .Else(e => e.Element("disabled-state").SetText("enabled"));
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Gather</native-heading>
+        @(Html.NativeButton("gather-btn", "Gather SplitButton")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var menu = p.Component<FusionSplitButton>(menuId);
+                p.Post("/Sandbox/Components/FusionSplitButton/Echo")
+                    .Gather(g =>
+                    {
+                        g.Include(menu.Content(), "content");
+                        g.Include(menu.Disabled(), "disabled");
+                        g.Include(menu.CssClass(), "cssClass");
+                    })
+                    .Response(r => r.OnSuccess<FusionSplitButtonEchoResponse>((json, s) =>
+                    {
+                        s.Element("gather-content").SetText(json, x => x.Content);
+                        s.Element("gather-disabled").SetText(json, x => x.Disabled);
+                        s.Element("gather-css").SetText(json, x => x.CssClass);
+                        s.Element("gather-summary").SetText(json, x => x.Summary);
+                    }));
+            }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Command: <span id="command-state" class="text-text-muted">pending</span></p>
+            <p>Content echo: <span id="content-echo" class="text-text-muted">pending</span></p>
+            <p>Disabled echo: <span id="disabled-echo" class="text-text-muted">pending</span></p>
+            <p>Css echo: <span id="css-echo" class="text-text-muted">pending</span></p>
+            <p>Toggle state: <span id="toggle-state" class="text-text-muted">pending</span></p>
+            <p>Focus state: <span id="focus-state" class="text-text-muted">pending</span></p>
+            <p>Remove state: <span id="remove-state" class="text-text-muted">pending</span></p>
+            <p>Disabled state: <span id="disabled-state" class="text-text-muted">pending</span></p>
+            <p>Primary click: <span id="primary-click-state" class="text-text-muted">pending</span></p>
+            <p>Selected id: <span id="selected-id" class="text-text-muted">pending</span></p>
+            <p>Selected text: <span id="selected-text" class="text-text-muted">pending</span></p>
+            <p>Selected disabled: <span id="selected-disabled" class="text-text-muted">pending</span></p>
+            <p>Selected condition: <span id="selected-condition" class="text-text-muted">pending</span></p>
+            <p>Gather content: <span id="gather-content" class="text-text-muted">pending</span></p>
+            <p>Gather disabled: <span id="gather-disabled" class="text-text-muted">pending</span></p>
+            <p>Gather css: <span id="gather-css" class="text-text-muted">pending</span></p>
+            <p>Gather summary: <span id="gather-summary" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
@@ -1,0 +1,186 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperModel
+@using System.Collections.Generic
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionStepper";
+
+    const string StepperId = "resident-stepper";
+
+    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperModel>();
+    var steps = new List<Step>
+    {
+        new() { Text = "1", Label = "Intake", Status = StepStatus.InProgress },
+        new() { Text = "2", Label = "Review", Status = StepStatus.NotStarted },
+        new() { Text = "3", Label = "Complete", Status = StepStatus.NotStarted }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var stepper = p.Component<FusionStepper>(StepperId);
+        p.Element("active-step-echo").SetText(stepper.ActiveStep());
+        p.Element("current-step").SetText(stepper.ActiveStep());
+        p.Element("step-changing-state").SetText("pending");
+        p.Element("step-changing-active").SetText("pending");
+        p.Element("step-changing-previous").SetText("pending");
+        p.Element("step-changing-interacted").SetText("pending");
+        p.Element("step-changing-guard").SetText("pending");
+        p.Element("step-click-state").SetText("pending");
+        p.Element("step-click-active").SetText("pending");
+        p.Element("step-click-previous").SetText("pending");
+        p.Element("step-changed-state").SetText("pending");
+        p.Element("step-changed-active").SetText("pending");
+        p.Element("step-changed-previous").SetText("pending");
+        p.Element("step-changed-interacted").SetText("pending");
+        p.Element("progress-state").SetText("pending");
+        p.Element("command-state").SetText("idle");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionStepper</native-heading>
+    <native-text color="Secondary">
+        Progress navigation component. Exercises typed method calls and step payloads.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Stepper</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            The stepper starts on step one. Use the commands or click steps to move through the sequence.
+        </p>
+
+        @(Html.FusionStepper(plan, StepperId, b =>
+        {
+            b.Steps(steps);
+            b.ActiveStep(0);
+            b.CssClass("rounded-md");
+            b.Orientation(StepperOrientation.Horizontal);
+            b.StepType(StepType.Default);
+            b.LabelPosition(StepLabelPosition.Bottom);
+        })
+        .Reactive(evt => evt.StepChanging, (args, p) =>
+        {
+            p.Element("step-changing-state").SetText("observed");
+            p.Element("step-changing-active").SetText(args, x => x.ActiveStep);
+            p.Element("step-changing-previous").SetText(args, x => x.PreviousStep);
+            p.Element("step-changing-interacted").SetText(args, x => x.IsInteracted);
+
+            p.When(args, x => x.ActiveStep).Eq(2)
+                .Then(t =>
+                {
+                    t.When(args, x => x.IsInteracted).Truthy()
+                        .Then(allowed => allowed.Element("step-changing-guard").SetText("allowed"))
+                        .Else(blocked =>
+                        {
+                            blocked.Element("step-changing-guard").SetText("blocked");
+                            args.PreventDefault(blocked);
+                        });
+                })
+                .Else(e => e.Element("step-changing-guard").SetText("allowed"));
+        })
+        .Reactive(evt => evt.StepClick, (args, p) =>
+        {
+            p.Element("active-step-echo").SetText(p.Component<FusionStepper>(StepperId).ActiveStep());
+            p.Element("step-click-state").SetText("clicked");
+            p.Element("step-click-active").SetText(args, x => x.ActiveStep);
+            p.Element("step-click-previous").SetText(args, x => x.PreviousStep);
+        })
+        .Reactive(evt => evt.StepChanged, (args, p) =>
+        {
+            var stepper = p.Component<FusionStepper>(StepperId);
+            p.Element("active-step-echo").SetText(stepper.ActiveStep());
+            p.Element("current-step").SetText(args, x => x.ActiveStep);
+            p.Element("step-changed-state").SetText("changed");
+            p.Element("step-changed-active").SetText(args, x => x.ActiveStep);
+            p.Element("step-changed-previous").SetText(args, x => x.PreviousStep);
+            p.Element("step-changed-interacted").SetText(args, x => x.IsInteracted);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Commands</native-heading>
+        <native-hstack gap="Sm" class="flex-wrap">
+            @(Html.NativeButton("set-review-step-btn", "Set Review")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionStepper>(StepperId).SetActiveStep(1);
+                    p.Element("command-state").SetText("set review");
+                }))
+            @(Html.NativeButton("set-complete-step-btn", "Set Complete")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionStepper>(StepperId).SetActiveStep(2);
+                    p.Element("command-state").SetText("set complete");
+                }))
+            @(Html.NativeButton("set-intake-step-btn", "Set Intake")
+                .CssClass("rounded-md bg-surface px-4 py-2 text-sm font-medium text-text hover:bg-surface-2 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionStepper>(StepperId).SetActiveStep(0);
+                    p.Element("command-state").SetText("set intake");
+                }))
+            @(Html.NativeButton("next-step-btn", "Next")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionStepper>(StepperId).NextStep();
+                    p.Element("command-state").SetText("next");
+                }))
+            @(Html.NativeButton("previous-step-btn", "Previous")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionStepper>(StepperId).PreviousStep();
+                    p.Element("command-state").SetText("previous");
+                }))
+            @(Html.NativeButton("reset-step-btn", "Reset")
+                .CssClass("rounded-md bg-surface px-4 py-2 text-sm font-medium text-text hover:bg-surface-2 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionStepper>(StepperId).Reset();
+                    p.Element("command-state").SetText("reset");
+                }))
+            @(Html.NativeButton("refresh-step-btn", "Refresh")
+                .CssClass("rounded-md bg-surface px-4 py-2 text-sm font-medium text-text hover:bg-surface-2 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionStepper>(StepperId).RefreshProgressbar();
+                    p.Element("progress-state").SetText("refreshed");
+                    p.Element("command-state").SetText("refresh");
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Active step echo: <span id="active-step-echo" class="text-text-muted">pending</span></p>
+            <p>Current step: <span id="current-step" class="text-text-muted">pending</span></p>
+            <p>Step changing state: <span id="step-changing-state" class="text-text-muted">pending</span></p>
+            <p>Step changing active: <span id="step-changing-active" class="text-text-muted">pending</span></p>
+            <p>Step changing previous: <span id="step-changing-previous" class="text-text-muted">pending</span></p>
+            <p>Step changing interacted: <span id="step-changing-interacted" class="text-text-muted">pending</span></p>
+            <p>Step changing guard: <span id="step-changing-guard" class="text-text-muted">pending</span></p>
+            <p>Step click state: <span id="step-click-state" class="text-text-muted">pending</span></p>
+            <p>Step click active: <span id="step-click-active" class="text-text-muted">pending</span></p>
+            <p>Step click previous: <span id="step-click-previous" class="text-text-muted">pending</span></p>
+            <p>Step changed state: <span id="step-changed-state" class="text-text-muted">pending</span></p>
+            <p>Step changed active: <span id="step-changed-active" class="text-text-muted">pending</span></p>
+            <p>Step changed previous: <span id="step-changed-previous" class="text-text-muted">pending</span></p>
+            <p>Step changed interacted: <span id="step-changed-interacted" class="text-text-muted">pending</span></p>
+            <p>Progress state: <span id="progress-state" class="text-text-muted">pending</span></p>
+            <p>Command state: <span id="command-state" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
@@ -8,6 +8,7 @@
     ViewData["Title"] = "FusionStepper";
 
     const string StepperId = "resident-stepper";
+    const string ValidationStepperId = "resident-stepper-validation";
 
     var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperModel>();
     var steps = new List<Step>
@@ -20,6 +21,7 @@
     Html.On(plan, t => t.DomReady(p =>
     {
         var stepper = p.Component<FusionStepper>(StepperId);
+        var validationStepper = p.Component<FusionStepper>(ValidationStepperId);
         p.Element("active-step-echo").SetText(stepper.ActiveStep());
         p.Element("current-step").SetText(stepper.ActiveStep());
         p.Element("step-changing-state").SetText("pending");
@@ -36,7 +38,21 @@
         p.Element("step-changed-interacted").SetText("pending");
         p.Element("progress-state").SetText("pending");
         p.Element("command-state").SetText("idle");
+        p.Element("validation-active-echo").SetText("pending");
+        p.Element("validation-current-step").SetText("pending");
+        p.Element("validation-step-click-state").SetText("pending");
+        p.Element("validation-step-click-active").SetText("pending");
+        p.Element("validation-step-click-previous").SetText("pending");
+        p.Element("validation-active-echo").SetText(validationStepper.ActiveStep());
+        p.Element("validation-current-step").SetText(validationStepper.ActiveStep());
     }));
+
+    var validationSteps = new List<Step>
+    {
+        new() { Text = "1", Label = "Intake", Status = StepStatus.InProgress, IsValid = true, Optional = true },
+        new() { Text = "2", Label = "Review", Status = StepStatus.NotStarted, IsValid = false },
+        new() { Text = "3", Label = "Complete", Status = StepStatus.NotStarted }
+    };
 }
 
 <native-vstack gap="Lg">
@@ -180,6 +196,50 @@
     <native-card><native-card-body>
         <native-heading level="H2">Plan JSON</native-heading>
         <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Validation and Tooltips</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            This variant keeps the stepper linear and shows the built-in validation iconography. The first step is valid, the second is invalid, and the third has no validation state.
+        </p>
+
+        @(Html.FusionStepper(plan, ValidationStepperId, b =>
+        {
+            b.Steps(validationSteps);
+            b.ActiveStep(0);
+            b.CssClass("rounded-md");
+            b.Linear(true);
+            b.ShowTooltip(true);
+            b.Orientation(StepperOrientation.Horizontal);
+            b.StepType(StepType.Default);
+            b.LabelPosition(StepLabelPosition.Bottom);
+        })
+        .Reactive(evt => evt.StepClick, (args, p) =>
+        {
+            p.Element("validation-step-click-state").SetText("clicked");
+            p.Element("validation-step-click-active").SetText(args, x => x.ActiveStep);
+            p.Element("validation-step-click-previous").SetText(args, x => x.PreviousStep);
+        })
+        .Reactive(evt => evt.StepChanged, (args, p) =>
+        {
+            var stepper = p.Component<FusionStepper>(ValidationStepperId);
+            p.Element("validation-active-echo").SetText(stepper.ActiveStep());
+            p.Element("validation-current-step").SetText(args, x => x.ActiveStep);
+        }))
+
+        <native-hstack gap="Sm" class="mt-4 flex-wrap">
+            <span class="text-sm text-text-secondary">Hover a step to prove the tooltip.</span>
+            <span class="text-sm text-text-secondary">Click the steps directly to exercise linear navigation.</span>
+        </native-hstack>
+
+        <div class="mt-4 font-mono text-sm">
+            <p>Validation active step: <span id="validation-active-echo" class="text-text-muted">pending</span></p>
+            <p>Validation current step: <span id="validation-current-step" class="text-text-muted">pending</span></p>
+            <p>Validation click state: <span id="validation-step-click-state" class="text-text-muted">pending</span></p>
+            <p>Validation click active: <span id="validation-step-click-active" class="text-text-muted">pending</span></p>
+            <p>Validation click previous: <span id="validation-step-click-previous" class="text-text-muted">pending</span></p>
+        </div>
     </native-card-body></native-card>
 </native-vstack>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
@@ -61,6 +61,12 @@
     <native-text color="Secondary">
         Progress navigation component. Exercises typed method calls and step payloads.
     </native-text>
+    <native-hstack gap="Sm" class="flex-wrap">
+        <a asp-area="Sandbox" asp-controller="Stepper" asp-action="Wizard"
+           class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors">
+            Open lazy admission wizard
+        </a>
+    </native-hstack>
 
     <native-card><native-card-body>
         <native-heading level="H2">Stepper</native-heading>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Index.cshtml
@@ -28,6 +28,7 @@
         p.Element("step-changing-active").SetText("pending");
         p.Element("step-changing-previous").SetText("pending");
         p.Element("step-changing-interacted").SetText("pending");
+        p.Element("step-changing-cancel").SetText("pending");
         p.Element("step-changing-guard").SetText("pending");
         p.Element("step-click-state").SetText("pending");
         p.Element("step-click-active").SetText("pending");
@@ -82,6 +83,7 @@
             p.Element("step-changing-active").SetText(args, x => x.ActiveStep);
             p.Element("step-changing-previous").SetText(args, x => x.PreviousStep);
             p.Element("step-changing-interacted").SetText(args, x => x.IsInteracted);
+            p.Element("step-changing-cancel").SetText(args, x => x.Cancel);
 
             p.When(args, x => x.ActiveStep).Eq(2)
                 .Then(t =>
@@ -92,6 +94,7 @@
                         {
                             blocked.Element("step-changing-guard").SetText("blocked");
                             args.PreventDefault(blocked);
+                            blocked.Element("step-changing-cancel").SetText(args, x => x.Cancel);
                         });
                 })
                 .Else(e => e.Element("step-changing-guard").SetText("allowed"));
@@ -180,6 +183,7 @@
             <p>Step changing active: <span id="step-changing-active" class="text-text-muted">pending</span></p>
             <p>Step changing previous: <span id="step-changing-previous" class="text-text-muted">pending</span></p>
             <p>Step changing interacted: <span id="step-changing-interacted" class="text-text-muted">pending</span></p>
+            <p>Step changing cancel: <span id="step-changing-cancel" class="text-text-muted">pending</span></p>
             <p>Step changing guard: <span id="step-changing-guard" class="text-text-muted">pending</span></p>
             <p>Step click state: <span id="step-click-state" class="text-text-muted">pending</span></p>
             <p>Step click active: <span id="step-click-active" class="text-text-muted">pending</span></p>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Wizard.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Wizard.cshtml
@@ -1,0 +1,86 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperWizardShellModel
+@using System.Collections.Generic
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionStepper Lazy Wizard";
+
+    const string StepperId = "stepper-wizard";
+    const string StepContainerId = "stepper-wizard-step";
+    var wizardId = Model.WizardId ?? "";
+    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
+
+    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperWizardShellModel>();
+    var steps = new List<Step>
+    {
+        new() { Text = "1", Label = "Intake", Status = StepStatus.InProgress },
+        new() { Text = "2", Label = "Care", Status = StepStatus.NotStarted },
+        new() { Text = "3", Label = "Contacts", Status = StepStatus.NotStarted },
+        new() { Text = "4", Label = "Review", Status = StepStatus.NotStarted }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        p.Post(loadStepUrl, g => g
+                .Static("wizardId", wizardId)
+                .Static("step", 1))
+            .Response(r => r.OnSuccess(s => s.Into(StepContainerId)));
+
+        p.Element("stepper-wizard-current").SetText(p.Component<FusionStepper>(StepperId).ActiveStep());
+        p.Element("stepper-wizard-status").SetText("loaded intake");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
+        <native-vstack gap="Xs">
+            <native-heading level="H1">FusionStepper Lazy Wizard</native-heading>
+            <native-text color="Secondary">
+                Admission workflow with Syncfusion fields, per-step partial loading, framework validation, and server draft recovery.
+            </native-text>
+        </native-vstack>
+        <a asp-area="Sandbox" asp-controller="Stepper" asp-action="Index"
+           class="rounded-md bg-surface px-4 py-2 text-sm font-medium text-text hover:bg-surface-2 transition-colors">
+            Component API
+        </a>
+    </native-hstack>
+
+    <native-card><native-card-body>
+        @(Html.FusionStepper(plan, StepperId, b =>
+        {
+            b.Steps(steps);
+            b.ActiveStep(0);
+            b.CssClass("rounded-md");
+            b.Linear(true);
+            b.ShowTooltip(true);
+            b.Orientation(StepperOrientation.Horizontal);
+            b.StepType(StepType.Default);
+            b.LabelPosition(StepLabelPosition.Bottom);
+        })
+        .Reactive(evt => evt.StepChanged, (args, p) =>
+        {
+            p.Element("stepper-wizard-current").SetText(args, x => x.ActiveStep);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-hstack justify="Between" align="Center" class="mb-4 flex-wrap gap-3">
+            <p class="font-mono text-sm">Active step: <span id="stepper-wizard-current" class="text-text-muted">pending</span></p>
+            <p class="font-mono text-sm">Status: <span id="stepper-wizard-status" class="text-text-muted">pending</span></p>
+        </native-hstack>
+
+        <div id="@StepContainerId">
+            <p class="text-sm text-text-muted p-4">Loading intake step...</p>
+        </div>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="stepper-wizard-plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Wizard.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/Wizard.cshtml
@@ -3,6 +3,7 @@
 @using Alis.Reactive.Fusion.Components
 @using Alis.Reactive.Native.Components
 @using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
 @using Syncfusion.EJ2.Navigations
 @{
     ViewData["Title"] = "FusionStepper Lazy Wizard";
@@ -13,7 +14,7 @@
     var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
         ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
 
-    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperWizardShellModel>();
+    var plan = Html.ReactivePlan<FusionStepperWizardShellModel>();
     var steps = new List<Step>
     {
         new() { Text = "1", Label = "Intake", Status = StepStatus.InProgress },
@@ -35,6 +36,9 @@
 }
 
 <native-vstack gap="Lg">
+    @Html.HiddenFieldFor(plan, m => m.WizardId)
+    @Html.HiddenFieldFor(plan, m => m.MaxUnlockedStep)
+
     <native-hstack justify="Between" align="Center" class="flex-wrap gap-3">
         <native-vstack gap="Xs">
             <native-heading level="H1">FusionStepper Lazy Wizard</native-heading>
@@ -54,15 +58,78 @@
             b.Steps(steps);
             b.ActiveStep(0);
             b.CssClass("rounded-md");
-            b.Linear(true);
+            b.Linear(false);
             b.ShowTooltip(true);
             b.Orientation(StepperOrientation.Horizontal);
             b.StepType(StepType.Default);
             b.LabelPosition(StepLabelPosition.Bottom);
         })
+        .Reactive(evt => evt.StepChanging, (args, p) =>
+        {
+            var maxUnlockedStep = p.Component<NativeHiddenField>(m => m.MaxUnlockedStep).Value();
+
+            p.When(args, x => x.ActiveStep).Eq(1)
+                .And(maxUnlockedStep).Eq("0")
+                .Then(t =>
+                {
+                    args.PreventDefault(t);
+                    t.Element("stepper-wizard-status").SetText("complete intake before opening care");
+                })
+                .ElseIf(args, x => x.ActiveStep).Eq(2)
+                .And(maxUnlockedStep).In("0", "1")
+                .Then(t =>
+                {
+                    args.PreventDefault(t);
+                    t.Element("stepper-wizard-status").SetText("complete care before opening contacts");
+                })
+                .ElseIf(args, x => x.ActiveStep).Eq(3)
+                .And(maxUnlockedStep).In("0", "1", "2")
+                .Then(t =>
+                {
+                    args.PreventDefault(t);
+                    t.Element("stepper-wizard-status").SetText("complete contacts before review");
+                });
+        })
         .Reactive(evt => evt.StepChanged, (args, p) =>
         {
             p.Element("stepper-wizard-current").SetText(args, x => x.ActiveStep);
+
+            p.When(args, x => x.ActiveStep).Eq(0)
+                .Then(t =>
+                {
+                    t.Post(loadStepUrl)
+                        .Gather(g => g
+                            .Include<NativeHiddenField, FusionStepperWizardShellModel>(m => m.WizardId)
+                            .Static("step", 1))
+                        .Response(r => r.OnSuccess(s => s.Into(StepContainerId)));
+                })
+                .ElseIf(args, x => x.ActiveStep).Eq(1)
+                .Then(t =>
+                {
+                    t.Post(loadStepUrl)
+                        .Gather(g => g
+                            .Include<NativeHiddenField, FusionStepperWizardShellModel>(m => m.WizardId)
+                            .Static("step", 2))
+                        .Response(r => r.OnSuccess(s => s.Into(StepContainerId)));
+                })
+                .ElseIf(args, x => x.ActiveStep).Eq(2)
+                .Then(t =>
+                {
+                    t.Post(loadStepUrl)
+                        .Gather(g => g
+                            .Include<NativeHiddenField, FusionStepperWizardShellModel>(m => m.WizardId)
+                            .Static("step", 3))
+                        .Response(r => r.OnSuccess(s => s.Into(StepContainerId)));
+                })
+                .ElseIf(args, x => x.ActiveStep).Eq(3)
+                .Then(t =>
+                {
+                    t.Post(loadStepUrl)
+                        .Gather(g => g
+                            .Include<NativeHiddenField, FusionStepperWizardShellModel>(m => m.WizardId)
+                            .Static("step", 4))
+                        .Response(r => r.OnSuccess(s => s.Into(StepContainerId)));
+                });
         }))
     </native-card-body></native-card>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardCareStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardCareStep.cshtml
@@ -5,12 +5,9 @@
 @using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
 @{
     const string StepperId = "stepper-wizard";
-    const string ContainerId = "stepper-wizard-step";
     const string FormId = "stepper-wizard-care-form";
     var saveUrl = Url.Action("SaveCare", "Stepper", new { area = "Sandbox" })
         ?? throw new InvalidOperationException("Could not resolve Stepper.SaveCare.");
-    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
-        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
 
     var plan = Html.ReactivePlan<FusionStepperWizardCareModel>();
     var careLevels = new[] { "Assisted Living", "Memory Care", "Skilled Nursing" };
@@ -71,11 +68,6 @@
             {
                 p.Component<FusionStepper>(StepperId).SetActiveStep(0);
                 p.Element("stepper-wizard-status").SetText("returned to intake");
-                p.Post(loadStepUrl)
-                    .Gather(g => g
-                        .Include<NativeHiddenField, FusionStepperWizardCareModel>(m => m.WizardId)
-                        .Static("step", 1))
-                    .Response(r => r.OnSuccess(s => s.Into(ContainerId)));
             }))
 
         @(Html.NativeButton("stepper-wizard-next-care", "Next: Contacts")
@@ -88,16 +80,11 @@
                         .OnSuccess<FusionStepperWizardSaveResponse>((json, s) =>
                         {
                             s.Component<NativeHiddenField>(m => m.WizardId).SetValue(json, x => x.WizardId);
+                            s.Component<NativeHiddenField, FusionStepperWizardShellModel>(m => m.MaxUnlockedStep).SetValue("2");
                             s.Component<FusionStepper>(StepperId).SetActiveStep(2);
                             s.Element("stepper-wizard-status").SetText(json, x => x.Message);
                         })
-                        .OnError(400, e => e.ValidationErrors(FormId))
-                        .Chained(c => c
-                            .Post(loadStepUrl)
-                            .Gather(g => g
-                                .Include<NativeHiddenField, FusionStepperWizardCareModel>(m => m.WizardId)
-                                .Static("step", 3))
-                            .Response(r2 => r2.OnSuccess(s2 => s2.Into(ContainerId)))));
+                        .OnError(400, e => e.ValidationErrors(FormId)));
             }))
     </native-hstack>
 </native-card-body></native-card>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardCareStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardCareStep.cshtml
@@ -1,0 +1,106 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperWizardCareModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
+@{
+    const string StepperId = "stepper-wizard";
+    const string ContainerId = "stepper-wizard-step";
+    const string FormId = "stepper-wizard-care-form";
+    var saveUrl = Url.Action("SaveCare", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.SaveCare.");
+    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
+
+    var plan = Html.ReactivePlan<FusionStepperWizardCareModel>();
+    var careLevels = new[] { "Assisted Living", "Memory Care", "Skilled Nursing" };
+    var diagnoses = new[] { "Alzheimer's", "Parkinson's", "Stroke", "Heart Disease", "Diabetes", "Other" };
+}
+
+<native-card><native-card-body id="@FormId">
+    <native-heading level="H2">Step 2: Care Plan</native-heading>
+    <p class="text-sm text-text-secondary mb-4">
+        Memory Care activates a conditional validation rule for the assessment summary.
+    </p>
+
+    @Html.HiddenFieldFor(plan, m => m.WizardId)
+
+    @if (!string.IsNullOrWhiteSpace(Model.ResidentName))
+    {
+        <p class="mb-4 text-sm text-text-secondary">Resident: <span class="font-semibold text-text">@Model.ResidentName</span></p>
+    }
+
+    <native-grid cols="C2" gap="Base" class="mb-4">
+        @{ Html.InputField(plan, m => m.CareLevel, o => o.Required().Label("Care Level"))
+            .FusionDropDownList(b => b
+                .DataSource(careLevels)
+                .Placeholder("Select care level")
+                .Reactive(plan, evt => evt.Changed, (args, p) =>
+                {
+                    p.When(args, x => x.Value).Eq("Memory Care")
+                        .Then(t =>
+                        {
+                            t.Element("memory-assessment-panel").Show();
+                            t.Element("stepper-wizard-status").SetText("memory assessment required");
+                        })
+                        .Else(e =>
+                        {
+                            e.Element("memory-assessment-panel").Hide();
+                            e.Element("stepper-wizard-status").SetText("standard care path");
+                        });
+                })); }
+
+        @{ Html.InputField(plan, m => m.PrimaryDiagnosis, o => o.Required().Label("Primary Diagnosis"))
+            .FusionDropDownList(b => b.DataSource(diagnoses).Placeholder("Select diagnosis")); }
+    </native-grid>
+
+    <native-grid cols="C2" gap="Base" class="mb-4">
+        @{ Html.InputField(plan, m => m.FallRiskScore, o => o.Required().Label("Fall Risk Score"))
+            .FusionNumericTextBox(b => b.Min(0).Max(10).Step(1)); }
+    </native-grid>
+
+    <div id="memory-assessment-panel" @(Model.CareLevel == "Memory Care" ? "" : "hidden")>
+        @{ Html.InputField(plan, m => m.MemoryAssessment, o => o.Label("Memory Assessment"))
+            .FusionTextBox(b => b.Placeholder("Required for Memory Care").ShowClearButton(true)); }
+    </div>
+
+    <native-hstack gap="Sm" justify="Between" class="mt-6 flex-wrap">
+        @(Html.NativeButton("stepper-wizard-back-care", "Back: Intake")
+            .CssClass("rounded-md bg-surface px-5 py-2 text-sm font-medium text-text hover:bg-surface-2 transition-colors")
+            .Reactive(plan, evt => evt.Click, (_, p) =>
+            {
+                p.Component<FusionStepper>(StepperId).SetActiveStep(0);
+                p.Element("stepper-wizard-status").SetText("returned to intake");
+                p.Post(loadStepUrl)
+                    .Gather(g => g
+                        .Include<NativeHiddenField, FusionStepperWizardCareModel>(m => m.WizardId)
+                        .Static("step", 1))
+                    .Response(r => r.OnSuccess(s => s.Into(ContainerId)));
+            }))
+
+        @(Html.NativeButton("stepper-wizard-next-care", "Next: Contacts")
+            .CssClass("rounded-md bg-accent px-5 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (_, p) =>
+            {
+                p.Post(saveUrl, g => g.IncludeAll())
+                    .Validate<FusionStepperWizardCareValidator>(FormId)
+                    .Response(r => r
+                        .OnSuccess<FusionStepperWizardSaveResponse>((json, s) =>
+                        {
+                            s.Component<NativeHiddenField>(m => m.WizardId).SetValue(json, x => x.WizardId);
+                            s.Component<FusionStepper>(StepperId).SetActiveStep(2);
+                            s.Element("stepper-wizard-status").SetText(json, x => x.Message);
+                        })
+                        .OnError(400, e => e.ValidationErrors(FormId))
+                        .Chained(c => c
+                            .Post(loadStepUrl)
+                            .Gather(g => g
+                                .Include<NativeHiddenField, FusionStepperWizardCareModel>(m => m.WizardId)
+                                .Static("step", 3))
+                            .Response(r2 => r2.OnSuccess(s2 => s2.Into(ContainerId)))));
+            }))
+    </native-hstack>
+</native-card-body></native-card>
+
+@Html.EJS().ScriptManager()
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardContactStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardContactStep.cshtml
@@ -5,12 +5,9 @@
 @using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
 @{
     const string StepperId = "stepper-wizard";
-    const string ContainerId = "stepper-wizard-step";
     const string FormId = "stepper-wizard-contact-form";
     var saveUrl = Url.Action("SaveContact", "Stepper", new { area = "Sandbox" })
         ?? throw new InvalidOperationException("Could not resolve Stepper.SaveContact.");
-    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
-        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
 
     var plan = Html.ReactivePlan<FusionStepperWizardContactModel>();
 }
@@ -41,11 +38,6 @@
             {
                 p.Component<FusionStepper>(StepperId).SetActiveStep(1);
                 p.Element("stepper-wizard-status").SetText("returned to care");
-                p.Post(loadStepUrl)
-                    .Gather(g => g
-                        .Include<NativeHiddenField, FusionStepperWizardContactModel>(m => m.WizardId)
-                        .Static("step", 2))
-                    .Response(r => r.OnSuccess(s => s.Into(ContainerId)));
             }))
 
         @(Html.NativeButton("stepper-wizard-next-contact", "Next: Review")
@@ -58,16 +50,11 @@
                         .OnSuccess<FusionStepperWizardSaveResponse>((json, s) =>
                         {
                             s.Component<NativeHiddenField>(m => m.WizardId).SetValue(json, x => x.WizardId);
+                            s.Component<NativeHiddenField, FusionStepperWizardShellModel>(m => m.MaxUnlockedStep).SetValue("3");
                             s.Component<FusionStepper>(StepperId).SetActiveStep(3);
                             s.Element("stepper-wizard-status").SetText(json, x => x.Message);
                         })
-                        .OnError(400, e => e.ValidationErrors(FormId))
-                        .Chained(c => c
-                            .Post(loadStepUrl)
-                            .Gather(g => g
-                                .Include<NativeHiddenField, FusionStepperWizardContactModel>(m => m.WizardId)
-                                .Static("step", 4))
-                            .Response(r2 => r2.OnSuccess(s2 => s2.Into(ContainerId)))));
+                        .OnError(400, e => e.ValidationErrors(FormId)));
             }))
     </native-hstack>
 </native-card-body></native-card>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardContactStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardContactStep.cshtml
@@ -1,0 +1,76 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperWizardContactModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
+@{
+    const string StepperId = "stepper-wizard";
+    const string ContainerId = "stepper-wizard-step";
+    const string FormId = "stepper-wizard-contact-form";
+    var saveUrl = Url.Action("SaveContact", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.SaveContact.");
+    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
+
+    var plan = Html.ReactivePlan<FusionStepperWizardContactModel>();
+}
+
+<native-card><native-card-body id="@FormId">
+    <native-heading level="H2">Step 3: Responsible Party</native-heading>
+    <p class="text-sm text-text-secondary mb-4">
+        Contact fields use Syncfusion textbox primitives and framework regex/email validation.
+    </p>
+
+    @Html.HiddenFieldFor(plan, m => m.WizardId)
+
+    <native-grid cols="C3" gap="Base" class="mb-4">
+        @{ Html.InputField(plan, m => m.ResponsibleParty, o => o.Required().Label("Responsible Party"))
+            .FusionTextBox(b => b.Placeholder("Primary contact").ShowClearButton(true)); }
+
+        @{ Html.InputField(plan, m => m.Phone, o => o.Required().Label("Phone"))
+            .FusionTextBox(b => b.Placeholder("123-456-7890").ShowClearButton(true)); }
+
+        @{ Html.InputField(plan, m => m.Email, o => o.Required().Label("Email"))
+            .FusionTextBox(b => b.Placeholder("contact@example.com").ShowClearButton(true)); }
+    </native-grid>
+
+    <native-hstack gap="Sm" justify="Between" class="mt-6 flex-wrap">
+        @(Html.NativeButton("stepper-wizard-back-contact", "Back: Care")
+            .CssClass("rounded-md bg-surface px-5 py-2 text-sm font-medium text-text hover:bg-surface-2 transition-colors")
+            .Reactive(plan, evt => evt.Click, (_, p) =>
+            {
+                p.Component<FusionStepper>(StepperId).SetActiveStep(1);
+                p.Element("stepper-wizard-status").SetText("returned to care");
+                p.Post(loadStepUrl)
+                    .Gather(g => g
+                        .Include<NativeHiddenField, FusionStepperWizardContactModel>(m => m.WizardId)
+                        .Static("step", 2))
+                    .Response(r => r.OnSuccess(s => s.Into(ContainerId)));
+            }))
+
+        @(Html.NativeButton("stepper-wizard-next-contact", "Next: Review")
+            .CssClass("rounded-md bg-accent px-5 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (_, p) =>
+            {
+                p.Post(saveUrl, g => g.IncludeAll())
+                    .Validate<FusionStepperWizardContactValidator>(FormId)
+                    .Response(r => r
+                        .OnSuccess<FusionStepperWizardSaveResponse>((json, s) =>
+                        {
+                            s.Component<NativeHiddenField>(m => m.WizardId).SetValue(json, x => x.WizardId);
+                            s.Component<FusionStepper>(StepperId).SetActiveStep(3);
+                            s.Element("stepper-wizard-status").SetText(json, x => x.Message);
+                        })
+                        .OnError(400, e => e.ValidationErrors(FormId))
+                        .Chained(c => c
+                            .Post(loadStepUrl)
+                            .Gather(g => g
+                                .Include<NativeHiddenField, FusionStepperWizardContactModel>(m => m.WizardId)
+                                .Static("step", 4))
+                            .Response(r2 => r2.OnSuccess(s2 => s2.Into(ContainerId)))));
+            }))
+    </native-hstack>
+</native-card-body></native-card>
+
+@Html.EJS().ScriptManager()
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardIntakeStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardIntakeStep.cshtml
@@ -5,13 +5,9 @@
 @using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
 @{
     const string StepperId = "stepper-wizard";
-    const string ContainerId = "stepper-wizard-step";
     const string FormId = "stepper-wizard-intake-form";
     var saveUrl = Url.Action("SaveIntake", "Stepper", new { area = "Sandbox" })
         ?? throw new InvalidOperationException("Could not resolve Stepper.SaveIntake.");
-    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
-        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
-
     var plan = Html.ReactivePlan<FusionStepperWizardIntakeModel>();
     var admissionTypes = new[] { "Respite", "Assisted Living", "Memory Care Evaluation", "Skilled Nursing" };
 }
@@ -46,16 +42,11 @@
                         .OnSuccess<FusionStepperWizardSaveResponse>((json, s) =>
                         {
                             s.Component<NativeHiddenField>(m => m.WizardId).SetValue(json, x => x.WizardId);
+                            s.Component<NativeHiddenField, FusionStepperWizardShellModel>(m => m.MaxUnlockedStep).SetValue("1");
                             s.Component<FusionStepper>(StepperId).SetActiveStep(1);
                             s.Element("stepper-wizard-status").SetText(json, x => x.Message);
                         })
-                        .OnError(400, e => e.ValidationErrors(FormId))
-                        .Chained(c => c
-                            .Post(loadStepUrl)
-                            .Gather(g => g
-                                .Include<NativeHiddenField, FusionStepperWizardIntakeModel>(m => m.WizardId)
-                                .Static("step", 2))
-                            .Response(r2 => r2.OnSuccess(s2 => s2.Into(ContainerId)))));
+                        .OnError(400, e => e.ValidationErrors(FormId)));
             }))
     </native-hstack>
 </native-card-body></native-card>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardIntakeStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardIntakeStep.cshtml
@@ -1,0 +1,64 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperWizardIntakeModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
+@{
+    const string StepperId = "stepper-wizard";
+    const string ContainerId = "stepper-wizard-step";
+    const string FormId = "stepper-wizard-intake-form";
+    var saveUrl = Url.Action("SaveIntake", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.SaveIntake.");
+    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
+
+    var plan = Html.ReactivePlan<FusionStepperWizardIntakeModel>();
+    var admissionTypes = new[] { "Respite", "Assisted Living", "Memory Care Evaluation", "Skilled Nursing" };
+}
+
+<native-card><native-card-body id="@FormId">
+    <native-heading level="H2">Step 1: Intake</native-heading>
+    <p class="text-sm text-text-secondary mb-4">
+        This partial is loaded after page boot. Leaving fields empty keeps the stepper on Intake and renders framework validation messages.
+    </p>
+
+    @Html.HiddenFieldFor(plan, m => m.WizardId)
+
+    <native-grid cols="C3" gap="Base" class="mb-4">
+        @{ Html.InputField(plan, m => m.ResidentName, o => o.Required().Label("Resident Name"))
+            .FusionTextBox(b => b.Placeholder("Resident full name").ShowClearButton(true)); }
+
+        @{ Html.InputField(plan, m => m.Age, o => o.Required().Label("Age"))
+            .FusionNumericTextBox(b => b.Min(55).Max(120).Step(1)); }
+
+        @{ Html.InputField(plan, m => m.AdmissionType, o => o.Required().Label("Admission Type"))
+            .FusionDropDownList(b => b.DataSource(admissionTypes).Placeholder("Select admission type")); }
+    </native-grid>
+
+    <native-hstack gap="Sm" justify="End" class="mt-6 flex-wrap">
+        @(Html.NativeButton("stepper-wizard-next-intake", "Next: Care")
+            .CssClass("rounded-md bg-accent px-5 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (_, p) =>
+            {
+                p.Post(saveUrl, g => g.IncludeAll())
+                    .Validate<FusionStepperWizardIntakeValidator>(FormId)
+                    .Response(r => r
+                        .OnSuccess<FusionStepperWizardSaveResponse>((json, s) =>
+                        {
+                            s.Component<NativeHiddenField>(m => m.WizardId).SetValue(json, x => x.WizardId);
+                            s.Component<FusionStepper>(StepperId).SetActiveStep(1);
+                            s.Element("stepper-wizard-status").SetText(json, x => x.Message);
+                        })
+                        .OnError(400, e => e.ValidationErrors(FormId))
+                        .Chained(c => c
+                            .Post(loadStepUrl)
+                            .Gather(g => g
+                                .Include<NativeHiddenField, FusionStepperWizardIntakeModel>(m => m.WizardId)
+                                .Static("step", 2))
+                            .Response(r2 => r2.OnSuccess(s2 => s2.Into(ContainerId)))));
+            }))
+    </native-hstack>
+</native-card-body></native-card>
+
+@Html.EJS().ScriptManager()
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardReviewStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardReviewStep.cshtml
@@ -5,12 +5,9 @@
 @using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
 @{
     const string StepperId = "stepper-wizard";
-    const string ContainerId = "stepper-wizard-step";
     const string FormId = "stepper-wizard-review-form";
     var submitUrl = Url.Action("SubmitWizard", "Stepper", new { area = "Sandbox" })
         ?? throw new InvalidOperationException("Could not resolve Stepper.SubmitWizard.");
-    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
-        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
 
     var plan = Html.ReactivePlan<FusionStepperWizardReviewModel>();
 }
@@ -56,11 +53,6 @@
             {
                 p.Component<FusionStepper>(StepperId).SetActiveStep(2);
                 p.Element("stepper-wizard-status").SetText("returned to contacts");
-                p.Post(loadStepUrl)
-                    .Gather(g => g
-                        .Include<NativeHiddenField, FusionStepperWizardReviewModel>(m => m.WizardId)
-                        .Static("step", 3))
-                    .Response(r => r.OnSuccess(s => s.Into(ContainerId)));
             }))
 
         @(Html.NativeButton("stepper-wizard-submit", "Submit Admission")

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardReviewStep.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Stepper/_WizardReviewStep.cshtml
@@ -1,0 +1,84 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper.FusionStepperWizardReviewModel
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper
+@{
+    const string StepperId = "stepper-wizard";
+    const string ContainerId = "stepper-wizard-step";
+    const string FormId = "stepper-wizard-review-form";
+    var submitUrl = Url.Action("SubmitWizard", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.SubmitWizard.");
+    var loadStepUrl = Url.Action("LoadWizardStep", "Stepper", new { area = "Sandbox" })
+        ?? throw new InvalidOperationException("Could not resolve Stepper.LoadWizardStep.");
+
+    var plan = Html.ReactivePlan<FusionStepperWizardReviewModel>();
+}
+
+<native-card><native-card-body id="@FormId">
+    <native-heading level="H2">Step 4: Review</native-heading>
+    <p class="text-sm text-text-secondary mb-4">
+        The summary is rebuilt from server drafts saved by the previous lazy steps.
+    </p>
+
+    @Html.HiddenFieldFor(plan, m => m.WizardId)
+
+    <native-grid cols="C2" gap="Base" class="mb-4">
+        <div class="rounded-md border border-border/60 p-4">
+            <p class="text-xs uppercase tracking-wide text-text-muted">Resident</p>
+            <p id="stepper-wizard-summary-resident" class="text-sm font-semibold text-text">@Model.ResidentName</p>
+            <p class="text-sm text-text-secondary">@Model.AdmissionType</p>
+        </div>
+        <div class="rounded-md border border-border/60 p-4">
+            <p class="text-xs uppercase tracking-wide text-text-muted">Care</p>
+            <p id="stepper-wizard-summary-care" class="text-sm font-semibold text-text">@Model.CareLevel</p>
+            <p class="text-sm text-text-secondary">@Model.PrimaryDiagnosis</p>
+        </div>
+        <div class="rounded-md border border-border/60 p-4">
+            <p class="text-xs uppercase tracking-wide text-text-muted">Responsible Party</p>
+            <p id="stepper-wizard-summary-contact" class="text-sm font-semibold text-text">@Model.ResponsibleParty</p>
+            <p class="text-sm text-text-secondary">@Model.Phone</p>
+        </div>
+        <div>
+            @{ Html.InputField(plan, m => m.AdmissionCoordinator, o => o.Required().Label("Admission Coordinator"))
+                .FusionTextBox(b => b.Placeholder("Coordinator name").ShowClearButton(true)); }
+        </div>
+    </native-grid>
+
+    <div id="stepper-wizard-submit-result" class="mt-4 rounded-md border border-border/60 bg-surface p-4 text-sm text-text-secondary">
+        Waiting for submission.
+    </div>
+
+    <native-hstack gap="Sm" justify="Between" class="mt-6 flex-wrap">
+        @(Html.NativeButton("stepper-wizard-back-review", "Back: Contacts")
+            .CssClass("rounded-md bg-surface px-5 py-2 text-sm font-medium text-text hover:bg-surface-2 transition-colors")
+            .Reactive(plan, evt => evt.Click, (_, p) =>
+            {
+                p.Component<FusionStepper>(StepperId).SetActiveStep(2);
+                p.Element("stepper-wizard-status").SetText("returned to contacts");
+                p.Post(loadStepUrl)
+                    .Gather(g => g
+                        .Include<NativeHiddenField, FusionStepperWizardReviewModel>(m => m.WizardId)
+                        .Static("step", 3))
+                    .Response(r => r.OnSuccess(s => s.Into(ContainerId)));
+            }))
+
+        @(Html.NativeButton("stepper-wizard-submit", "Submit Admission")
+            .CssClass("rounded-md bg-accent px-5 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (_, p) =>
+            {
+                p.Post(submitUrl, g => g.IncludeAll())
+                    .Validate<FusionStepperWizardReviewValidator>(FormId)
+                    .Response(r => r
+                        .OnSuccess<FusionStepperWizardSubmitResponse>((json, s) =>
+                        {
+                            s.Element("stepper-wizard-status").SetText("submitted");
+                            s.Element("stepper-wizard-submit-result").SetText(json, x => x.Message);
+                        })
+                        .OnError(400, e => e.ValidationErrors(FormId)));
+            }))
+    </native-hstack>
+</native-card-body></native-card>
+
+@Html.EJS().ScriptManager()
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/TextArea/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/TextArea/Index.cshtml
@@ -1,0 +1,130 @@
+@model TextAreaModel
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionTextArea";
+
+    var plan = Html.ReactivePlan<TextAreaModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var note = p.Component<FusionTextArea>(m => m.CareNote);
+        note.SetValue("Resident prefers morning medication rounds.");
+        p.Element("value-echo").SetText(note.Value());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionTextArea</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Runtime Value and Events</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.CareNote, o => o.Label("Care Note"))
+                .FusionTextArea(b => b
+                    .Placeholder("Care note")
+                    .Rows(4)
+                    .ShowClearButton(true)
+                    .Reactive(plan, evt => evt.Input, (args, p) =>
+                    {
+                        p.Element("input-value").SetText(args, x => x.Value);
+                        p.Element("input-previous").SetText(args, x => x.PreviousValue);
+                    })
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        p.Element("change-value").SetText(args, x => x.Value);
+                        p.Element("change-previous").SetText(args, x => x.PreviousValue);
+                        p.Element("change-interacted").SetText(args, x => x.IsInteracted);
+                        p.When(args, x => x.Value).NotEmpty()
+                            .Then(t => t.Element("args-condition").SetText("note entered"))
+                            .Else(e => e.Element("args-condition").SetText("no note"));
+                    })
+                    .Reactive(plan, evt => evt.Focus, (args, p) =>
+                    {
+                        p.Element("focus-state").SetText("focused");
+                        p.Element("focus-value").SetText(args, x => x.Value);
+                    })
+                    .Reactive(plan, evt => evt.Blur, (args, p) =>
+                    {
+                        p.Element("focus-state").SetText("blurred");
+                        p.Element("blur-value").SetText(args, x => x.Value);
+                    })); }
+        </native-grid>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Value Source</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>DomReady value echo: <span id="value-echo" class="text-text-muted">&mdash;</span></p>
+            <p>Input value: <span id="input-value" class="text-text-muted">&mdash;</span></p>
+            <p>Input previous: <span id="input-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Change value: <span id="change-value" class="text-text-muted">&mdash;</span></p>
+            <p>Change previous: <span id="change-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Change interacted: <span id="change-interacted" class="text-text-muted">&mdash;</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Focus Methods</native-heading>
+        <native-hstack gap="Sm">
+            @(Html.NativeButton("focus-in-btn", "Focus Care Note")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionTextArea>(m => m.CareNote).FocusIn();
+                }))
+        </native-hstack>
+        <native-vstack gap="Xs" class="font-mono text-sm mt-3">
+            <p>Focus state: <span id="focus-state" class="text-text-muted">&mdash;</span></p>
+            <p>Focus value: <span id="focus-value" class="text-text-muted">&mdash;</span></p>
+            <p>Blur value: <span id="blur-value" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">FocusOut Method</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.AutoBlurNote, o => o.Label("Auto Blur Note"))
+                .FusionTextArea(b => b
+                    .Placeholder("Click here to trigger FocusOut")
+                    .Rows(3)
+                    .Value("FocusOut proof")
+                    .Reactive(plan, evt => evt.Focus, (args, p) =>
+                    {
+                        p.Component<FusionTextArea>(m => m.AutoBlurNote).FocusOut();
+                        p.Element("focusout-method-state").SetText("focusout called");
+                    })
+                    .Reactive(plan, evt => evt.Blur, (args, p) =>
+                    {
+                        p.Element("autoblur-state").SetText("blurred");
+                    })); }
+        </native-grid>
+        <native-vstack gap="Xs" class="font-mono text-sm mt-3">
+            <p>FocusOut method: <span id="focusout-method-state" class="text-text-muted">&mdash;</span></p>
+            <p>Auto blur state: <span id="autoblur-state" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Component Condition</native-heading>
+        @(Html.NativeButton("check-note-btn", "Check Care Note")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var note = p.Component<FusionTextArea>(m => m.CareNote);
+                p.When(note.Value()).NotEmpty()
+                    .Then(t => t.Element("note-warning").SetText("care note set"))
+                    .Else(e => e.Element("note-warning").SetText("care note required"));
+            }))
+        <p class="font-mono text-sm mt-2">Warning: <span id="note-warning" class="text-text-muted">&mdash;</span></p>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/TextBox/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/TextBox/Index.cshtml
@@ -1,0 +1,129 @@
+@model TextBoxModel
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@{
+    ViewData["Title"] = "FusionTextBox";
+
+    var plan = Html.ReactivePlan<TextBoxModel>();
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        var name = p.Component<FusionTextBox>(m => m.ResidentName);
+        name.SetValue("Amina Patel");
+        name.AddAppendIcon("e-icons e-search");
+        p.Element("value-echo").SetText(name.Value());
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionTextBox</native-heading>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Runtime Value, Icon, and Events</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.ResidentName, o => o.Label("Resident Name"))
+                .FusionTextBox(b => b
+                    .Placeholder("Resident name")
+                    .ShowClearButton(true)
+                    .Reactive(plan, evt => evt.Input, (args, p) =>
+                    {
+                        p.Element("input-value").SetText(args, x => x.Value);
+                        p.Element("input-previous").SetText(args, x => x.PreviousValue);
+                    })
+                    .Reactive(plan, evt => evt.Changed, (args, p) =>
+                    {
+                        p.Element("change-value").SetText(args, x => x.Value);
+                        p.Element("change-previous").SetText(args, x => x.PreviousValue);
+                        p.Element("change-interacted").SetText(args, x => x.IsInteracted);
+                        p.When(args, x => x.Value).NotEmpty()
+                            .Then(t => t.Element("args-condition").SetText("name entered"))
+                            .Else(e => e.Element("args-condition").SetText("no name"));
+                    })
+                    .Reactive(plan, evt => evt.Focus, (args, p) =>
+                    {
+                        p.Element("focus-state").SetText("focused");
+                        p.Element("focus-value").SetText(args, x => x.Value);
+                    })
+                    .Reactive(plan, evt => evt.Blur, (args, p) =>
+                    {
+                        p.Element("focus-state").SetText("blurred");
+                        p.Element("blur-value").SetText(args, x => x.Value);
+                    })); }
+        </native-grid>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Value Source</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>DomReady value echo: <span id="value-echo" class="text-text-muted">&mdash;</span></p>
+            <p>Input value: <span id="input-value" class="text-text-muted">&mdash;</span></p>
+            <p>Input previous: <span id="input-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Change value: <span id="change-value" class="text-text-muted">&mdash;</span></p>
+            <p>Change previous: <span id="change-previous" class="text-text-muted">&mdash;</span></p>
+            <p>Change interacted: <span id="change-interacted" class="text-text-muted">&mdash;</span></p>
+            <p>Args condition: <span id="args-condition" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Focus Methods</native-heading>
+        <native-hstack gap="Sm">
+            @(Html.NativeButton("focus-in-btn", "Focus Resident Name")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (args, p) =>
+                {
+                    p.Component<FusionTextBox>(m => m.ResidentName).FocusIn();
+                }))
+        </native-hstack>
+        <native-vstack gap="Xs" class="font-mono text-sm mt-3">
+            <p>Focus state: <span id="focus-state" class="text-text-muted">&mdash;</span></p>
+            <p>Focus value: <span id="focus-value" class="text-text-muted">&mdash;</span></p>
+            <p>Blur value: <span id="blur-value" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">FocusOut Method</native-heading>
+        <native-grid cols="C2" gap="Base">
+            @{ Html.InputField(plan, m => m.AutoBlurNote, o => o.Label("Auto Blur Note"))
+                .FusionTextBox(b => b
+                    .Placeholder("Click here to trigger FocusOut")
+                    .Value("FocusOut proof")
+                    .Reactive(plan, evt => evt.Focus, (args, p) =>
+                    {
+                        p.Component<FusionTextBox>(m => m.AutoBlurNote).FocusOut();
+                        p.Element("focusout-method-state").SetText("focusout called");
+                    })
+                    .Reactive(plan, evt => evt.Blur, (args, p) =>
+                    {
+                        p.Element("autoblur-state").SetText("blurred");
+                    })); }
+        </native-grid>
+        <native-vstack gap="Xs" class="font-mono text-sm mt-3">
+            <p>FocusOut method: <span id="focusout-method-state" class="text-text-muted">&mdash;</span></p>
+            <p>Auto blur state: <span id="autoblur-state" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Component Condition</native-heading>
+        @(Html.NativeButton("check-name-btn", "Check Resident Name")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+            .Reactive(plan, evt => evt.Click, (args, p) =>
+            {
+                var name = p.Component<FusionTextBox>(m => m.ResidentName);
+                p.When(name.Value()).NotEmpty()
+                    .Then(t => t.Element("name-warning").SetText("resident name set"))
+                    .Else(e => e.Element("name-warning").SetText("resident name required"));
+            }))
+        <p class="font-mono text-sm mt-2">Warning: <span id="name-warning" class="text-text-muted">&mdash;</span></p>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre class="rounded-md bg-slate-900 text-emerald-400 p-4 font-mono text-xs overflow-x-auto max-h-96"><code id="plan-json">@Html.Raw(plan.RenderFormatted())</code></pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Toolbar/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/Toolbar/Index.cshtml
@@ -1,0 +1,96 @@
+@model Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Toolbar.FusionToolbarModel
+@using System.Collections.Generic
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Native.Extensions
+@using Syncfusion.EJ2.Navigations
+@{
+    ViewData["Title"] = "FusionToolbar";
+
+    const string ToolbarId = "resident-toolbar";
+
+    var plan = Html.ReactivePlan<Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Toolbar.FusionToolbarModel>();
+    var items = new List<ToolbarItem>
+    {
+        new() { Id = "toolbar-save", Text = "Save", Type = ItemType.Button },
+        new() { Id = "toolbar-delete", Text = "Delete", Type = ItemType.Button }
+    };
+
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        p.Element("toolbar-disabled").SetText("false");
+        p.Element("clicked-state").SetText("pending");
+        p.Element("clicked-id").SetText("pending");
+        p.Element("clicked-text").SetText("pending");
+        p.Element("clicked-disabled").SetText("pending");
+    }));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">FusionToolbar</native-heading>
+    <native-text color="Secondary">
+        Navigation component. Exercises disable/enable behavior and clicked item metadata.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Toolbar</native-heading>
+        <p class="text-sm text-text-secondary mb-4">
+            The toolbar starts enabled. Clicking an item records its typed payload fields.
+        </p>
+
+        @(Html.FusionToolbar(plan, ToolbarId, b =>
+        {
+            b.Items(items);
+            b.CssClass("rounded-md");
+            b.Width("360px");
+        })
+        .Reactive(evt => evt.Clicked, (args, p) =>
+        {
+            p.Element("clicked-state").SetText("clicked");
+            p.Element("clicked-id").SetText(args, x => x.Item.Id);
+            p.Element("clicked-text").SetText(args, x => x.Item.Text);
+            p.Element("clicked-disabled").SetText(args, x => x.Item.Disabled);
+        }))
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Commands</native-heading>
+        <native-hstack gap="Sm" class="flex-wrap">
+            @(Html.NativeButton("disable-toolbar-btn", "Disable")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionToolbar>(ToolbarId).Disable(true);
+                    p.Element("toolbar-disabled").SetText("true");
+                    p.Element("command-state").SetText("disabled");
+                }))
+            @(Html.NativeButton("enable-toolbar-btn", "Enable")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors")
+                .Reactive(plan, evt => evt.Click, (_, p) =>
+                {
+                    p.Component<FusionToolbar>(ToolbarId).Disable(false);
+                    p.Element("toolbar-disabled").SetText("false");
+                    p.Element("command-state").SetText("enabled");
+                }))
+        </native-hstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Trace</native-heading>
+        <native-vstack gap="Xs" class="font-mono text-sm">
+            <p>Toolbar disabled: <span id="toolbar-disabled" class="text-text-muted">pending</span></p>
+            <p>Clicked state: <span id="clicked-state" class="text-text-muted">pending</span></p>
+            <p>Clicked id: <span id="clicked-id" class="text-text-muted">pending</span></p>
+            <p>Clicked text: <span id="clicked-text" class="text-text-muted">pending</span></p>
+            <p>Clicked disabled: <span id="clicked-disabled" class="text-text-muted">pending</span></p>
+            <p>Command state: <span id="command-state" class="text-text-muted">pending</span></p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Plan JSON</native-heading>
+        <pre id="plan-json" class="text-xs overflow-auto max-h-96">@Html.Raw(plan.RenderFormatted())</pre>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -190,6 +190,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="OtpInput" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    OtpInput
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                One-time code entry with typed value reads, writes, focus methods, and input/change payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="NumericTextBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -138,6 +138,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="FusionCheckBox" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    FusionCheckBox
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion checkbox with typed checked, indeterminate, disabled, click, focus, and change behavior
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -190,6 +190,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="ProgressButton" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    ProgressButton
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion progress button with typed progress filler, start, completion, focus, and numeric progress payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -151,6 +151,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="RadioButton" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    RadioButton
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion radio button with typed checked, disabled, selected value, click, focus, and change behavior
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -138,6 +138,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="TextBox" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    TextBox
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Short text entry with typed value reads, writes, focus methods, icons, and input/change payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="NumericTextBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -151,6 +151,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="TextArea" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    TextArea
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Long-form notes with typed value reads, writes, focus methods, and input/change payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="NumericTextBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -541,6 +541,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Operations"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Operations
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Runtime column personalization, current-view handoff, keyed row updates, and typed template actions
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="Schedule" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -151,6 +151,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="ContextMenu" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    ContextMenu
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion context menu with typed open and close methods, nested item payloads, cancelable guards, and selection events
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="BulletChart" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">
@@ -590,6 +603,149 @@
             </native-hstack>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
                 Care task board with remote data, typed templates, method-return sources, and CRUD event payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Breadcrumb" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Breadcrumb
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Breadcrumb navigation with typed active item reads and item click payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Carousel" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Carousel
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Image and content carousel with typed active index, navigation methods, and slide lifecycle events
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="ComboBox" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    ComboBox
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Typed dropdown combo box with value reads, focus, selection, and filtering payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="DropDownTree" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    DropDownTree
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Hierarchical dropdown tree with typed value reads, expansion, and selection payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="ListBox" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    ListBox
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Typed list box with selection and bulk value methods, and value-only change payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="ListView" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    ListView
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                List view with typed item selection, template rendering, and click payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Sidebar" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Sidebar
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Collapsible sidebar with typed open state, show/hide/toggle methods, and open/close events
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="SmartComponents" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    SmartPasteButton
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                AI-assisted paste action button with typed click, focus, and disabled state
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="SmartComponents" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    SmartTextArea
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                AI-assisted textarea with typed value reads, writes, focus, and suggestion payloads
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Stepper" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Stepper
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Multi-step workflow with typed navigation methods, active step reads, validation states, and guarded transition events
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Toolbar" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Toolbar
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Typed toolbar button state, content, click payloads, and enabled/disabled control
             </p>
         </a>
     </div>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -164,6 +164,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="Slider" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Slider
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Numeric scalar and range sliders with typed value reads, writes, and change payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="NumericTextBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -177,6 +177,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="Rating" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Rating
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Numeric rating control with typed value reads, writes, reset, and value-changed payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="NumericTextBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -138,6 +138,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="Menu" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Menu
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion menu with typed hamburger open and close methods, nested item payloads, cancelable guards, and selection events
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="BulletChart" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -502,58 +502,6 @@
             </p>
         </a>
 
-        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Index"
-           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
-            <native-hstack justify="Between" align="Start">
-                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
-                    Grid
-                </h3>
-                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
-            </native-hstack>
-            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Data grid with server binding, paging, sorting, filtering, grouping, selection, and editing workflows
-            </p>
-        </a>
-
-        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
-           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
-            <native-hstack justify="Between" align="Start">
-                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
-                    Grid Directory
-                </h3>
-                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
-            </native-hstack>
-            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Server-bound resident directory with public Grid methods, grouped data, virtual scrolling, and typed row events
-            </p>
-        </a>
-
-        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Editing"
-           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
-            <native-hstack justify="Between" align="Start">
-                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
-                    Grid Editing
-                </h3>
-                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
-            </native-hstack>
-            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Inline, batch, and dialog-template editing with typed method calls, batch changes, and validation-backed updates
-            </p>
-        </a>
-
-        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Operations"
-           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
-            <native-hstack justify="Between" align="Start">
-                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
-                    Grid Operations
-                </h3>
-                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
-            </native-hstack>
-            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Runtime column personalization, current-view handoff, keyed row updates, and typed template actions
-            </p>
-        </a>
-
         <a asp-area="Sandbox" asp-controller="Schedule" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">
@@ -804,6 +752,92 @@
 </section>
 
 <!-- Navigation / Container -->
+<section class="mb-10">
+    <div class="flex items-center gap-3 mb-4">
+        <span class="w-1 h-6 rounded-full bg-info"></span>
+        <h2 class="text-lg font-semibold text-text-primary">Fusion Grid</h2>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Data grid with server binding, paging, sorting, filtering, grouping, selection, and editing workflows
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Directory
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Server-bound resident directory with public Grid methods, grouped data, virtual scrolling, and typed row events
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Editing"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Editing
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Inline, batch, and dialog-template editing with typed method calls, batch changes, and validation-backed updates
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Operations"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Operations
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Runtime column personalization, current-view handoff, keyed row updates, and typed template actions
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Billing"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Billing
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Month-end billing board: bulk batch charge edits, server rate increases, templated-dialog admits, and roster export
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="CareOps"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Care Operations
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Chip fast-filters, checkbox selection, typed templated cell editors, frozen columns, sticky header, and NativeActionLink discharge
+            </p>
+        </a>
+    </div>
+</section>
+
 <section class="mb-10">
     <div class="flex items-center gap-3 mb-4">
         <span class="w-1 h-6 rounded-full bg-[#8B5CF6]"></span>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -177,6 +177,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="SplitButton" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    SplitButton
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion split button with typed primary click, content, disabled state, CSS, popup toggle, focus, item removal, and selection payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -164,6 +164,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="DropDownButton" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    DropDownButton
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion dropdown button with typed content, disabled state, CSS, popup toggle, focus, item removal, and selection payloads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -138,6 +138,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="BulletChart" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    BulletChart
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion bullet chart with typed load, render, legend, tooltip mutation, click payloads, and wrapped index reads
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="FusionCheckBox" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -511,7 +511,33 @@
                 <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
             </native-hstack>
             <p class="mt-2 text-sm text-text-secondary leading-relaxed">
-                Data grid with inline editing, sorting, and filtering — see row mutations gathered for batch operations
+                Data grid with server binding, paging, sorting, filtering, grouping, selection, and editing workflows
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Directory"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Directory
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Server-bound resident directory with public Grid methods, grouped data, virtual scrolling, and typed row events
+            </p>
+        </a>
+
+        <a asp-area="Sandbox" asp-controller="Grid" asp-action="Editing"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Grid Editing
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Inline, batch, and dialog-template editing with typed method calls, batch changes, and validation-backed updates
             </p>
         </a>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -125,6 +125,19 @@
         <h2 class="text-lg font-semibold text-text-primary">Fusion</h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        <a asp-area="Sandbox" asp-controller="Button" asp-action="Index"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Button
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Syncfusion button with typed content, disabled state, styling, focus, and click methods
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="DropDownList" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Index.cshtml
@@ -736,6 +736,19 @@
             </p>
         </a>
 
+        <a asp-area="Sandbox" asp-controller="Stepper" asp-action="Wizard"
+           class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
+            <native-hstack justify="Between" align="Start">
+                <h3 class="text-[15px] font-semibold text-text-primary group-hover:text-primary transition-colors">
+                    Stepper Lazy Wizard
+                </h3>
+                <span class="text-text-muted group-hover:text-primary transition-colors text-sm">&rarr;</span>
+            </native-hstack>
+            <p class="mt-2 text-sm text-text-secondary leading-relaxed">
+                Real admission form with lazy-loaded steps, Syncfusion inputs, draft recovery, and framework validation
+            </p>
+        </a>
+
         <a asp-area="Sandbox" asp-controller="Toolbar" asp-action="Index"
            class="group relative block rounded-2xl border border-border/60 bg-white p-6 shadow-sm ring-1 ring-black/[0.03] hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5 transition-all duration-200">
             <native-hstack justify="Between" align="Start">

--- a/Alis.Reactive.SandboxApp/Program.cs
+++ b/Alis.Reactive.SandboxApp/Program.cs
@@ -22,6 +22,10 @@ if (!string.IsNullOrEmpty(sfLicense))
 
 builder.Services.AddControllersWithViews();
 builder.Services.AddSignalR();
+// Per-session in-memory state so sandbox grid edits persist across saves and page
+// refreshes within a browser session, while each browser/test context stays isolated.
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession(options => options.IdleTimeout = TimeSpan.FromHours(2));
 builder.Services.AddReactiveFluentValidation(validation =>
     validation.AddFromAssemblyContaining<Program>());
 
@@ -82,6 +86,7 @@ app.UseStaticFiles(new StaticFileOptions
 
 app.UseStaticFiles();
 app.UseRouting();
+app.UseSession();
 app.UseAuthorization();
 
 app.MapHub<NotificationHub>("/hubs/notifications");

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-breadcrumb-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-breadcrumb-probe.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Breadcrumb API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Breadcrumb API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <div id="breadcrumb"></div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("breadcrumb");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        const ej2 = new ej.navigations.Breadcrumb({
+            // Add real component options and event handlers here while tracing.
+            // Example:
+            // filtering: args => probe.event("filtering", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "breadcrumb",
+            namespace: "ej.navigations",
+            className: "Breadcrumb",
+            id: "breadcrumb"
+        });
+        proposal({
+            candidate: "replace this row",
+            kind: "method | prop-read | prop-write | event | payload-read | bridge",
+            builder: "covered | not covered | static-only",
+            args: "exact args and order",
+            returnOrPayload: "shape proven by trace",
+            proof: "visible behavior or trace label",
+            csharp: "typed Fusion API",
+            outcome: "implement | bridge-needed | exclude | needs-proof"
+        });
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-bullet-chart-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-bullet-chart-probe.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF BulletChart API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF BulletChart API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <div id="bullet-chart"></div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("bullet-chart");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        const ej2 = new ej.charts.BulletChart({
+            width: '100%',
+            height: '280px',
+            title: 'Resident readiness',
+            subtitle: 'Probe load, tooltip, click, and method reads',
+            minimum: 0,
+            maximum: 100,
+            interval: 20,
+            categoryField: 'category',
+            valueField: 'value',
+            targetField: 'target',
+            dataSource: [
+                { category: 'North Wing', value: 72, target: 80 },
+                { category: 'South Wing', value: 54, target: 68 },
+                { category: 'Rehab', value: 88, target: 92 }
+            ],
+            ranges: [
+                { end: 40, name: 'Poor', color: '#ef4444' },
+                { end: 70, name: 'Average', color: '#f59e0b' },
+                { end: 100, name: 'Good', color: '#10b981' }
+            ],
+            tooltip: {
+                enable: true
+            },
+            load: args => probe.event('load', args),
+            loaded: args => probe.event('loaded', args),
+            tooltipRender: args => {
+                args.text = 'Bullet tooltip rewritten';
+                probe.event('tooltipRender', args);
+            },
+            bulletChartMouseClick: args => probe.event('bulletChartMouseClick', args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        record('method actualIndex -1', ej2.getActualIndex(-1, 3));
+        record('method actualIndex 3', ej2.getActualIndex(3, 3));
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "bullet-chart",
+            namespace: "ej.charts",
+            className: "BulletChart",
+            id: "bullet-chart"
+        });
+        proposal({
+            candidate: "replace this row",
+            kind: "method | prop-read | prop-write | event | payload-read | bridge",
+            builder: "covered | not covered | static-only",
+            args: "exact args and order",
+            returnOrPayload: "shape proven by trace",
+            proof: "visible behavior or trace label",
+            csharp: "typed Fusion API",
+            outcome: "implement | bridge-needed | exclude | needs-proof"
+        });
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-button-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-button-probe.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Button API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Button API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <button id="fusion-button-probe" type="button">Initial</button>
+        <button id="outside-button" type="button">Outside focus target</button>
+        <p>Native click count: <span id="native-click-count">0</span></p>
+        <p>Syncfusion click count: <span id="fusion-click-count">0</span></p>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("fusion-button-probe");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        let nativeClickCount = 0;
+        let fusionClickCount = 0;
+
+        function snapshot(label) {
+            record(label, {
+                content: ej2.content,
+                disabled: ej2.disabled,
+                iconCss: ej2.iconCss,
+                iconPosition: ej2.iconPosition,
+                isPrimary: ej2.isPrimary,
+                cssClass: ej2.cssClass,
+                isToggle: ej2.isToggle,
+                text: target.textContent.trim(),
+                html: target.innerHTML,
+                disabledAttribute: target.hasAttribute("disabled"),
+                className: target.className,
+                iconClass: target.querySelector(".e-btn-icon")?.className || null,
+                active: target.classList.contains("e-active"),
+                focused: document.activeElement === target
+            });
+        }
+
+        target.addEventListener("click", event => {
+            nativeClickCount += 1;
+            document.getElementById("native-click-count").textContent = String(nativeClickCount);
+            record("native click", {
+                count: nativeClickCount,
+                disabled: target.disabled,
+                active: target.classList.contains("e-active"),
+                eventType: event.type
+            });
+        });
+
+        const ej2 = new ej.buttons.Button({
+            content: "Initial",
+            iconCss: "e-icons e-search",
+            iconPosition: "Left",
+            isToggle: true,
+            created: args => probe.event("created", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        ej2.addEventListener("click", args => {
+            fusionClickCount += 1;
+            document.getElementById("fusion-click-count").textContent = String(fusionClickCount);
+            probe.event("fusion addEventListener click", args || {});
+        });
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "button",
+            namespace: "ej.buttons",
+            className: "Button",
+            id: "fusion-button-probe"
+        });
+        snapshot("initial");
+
+        function runValueTrace() {
+            ej2.content = "Queued";
+            ej2.disabled = true;
+            ej2.iconCss = "e-icons e-edit";
+            ej2.iconPosition = "Right";
+            ej2.cssClass = "e-success extra-class";
+            ej2.isPrimary = true;
+            snapshot("direct set before dataBind");
+
+            const dataBindResult = ej2.dataBind();
+            record("dataBind return", dataBindResult);
+            snapshot("direct set after dataBind");
+
+            const disabledClickResult = ej2.click();
+            record("click while disabled return", disabledClickResult);
+            snapshot("after disabled click");
+
+            ej2.disabled = false;
+            ej2.dataBind();
+            const clickResult = ej2.click();
+            record("click return", clickResult);
+            snapshot("after click");
+
+            document.getElementById("outside-button").focus();
+            const focusResult = ej2.focusIn();
+            record("focusIn return", focusResult);
+            snapshot("after focusIn");
+
+            ej2.isToggle = false;
+            ej2.dataBind();
+            target.click();
+            snapshot("after isToggle false native click");
+
+            document.getElementById("active-element").textContent =
+                document.activeElement?.id || "";
+        }
+
+        proposal({
+            candidate: "content + dataBind()",
+            kind: "prop-read/write + public flush method",
+            builder: "Content() covers initial render",
+            args: "string",
+            returnOrPayload: "string; visible text updates after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetContent(string), Content()",
+            outcome: "implement if trace is stable"
+        });
+        proposal({
+            candidate: "disabled + dataBind()",
+            kind: "prop-read/write + public flush method",
+            builder: "Disabled() covers initial render",
+            args: "bool",
+            returnOrPayload: "bool; disabled attribute updates after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetDisabled(bool), Disabled()",
+            outcome: "implement if trace is stable"
+        });
+        proposal({
+            candidate: "iconCss/iconPosition/cssClass/isPrimary + dataBind()",
+            kind: "prop-write + public flush method",
+            builder: "IconCss/IconPosition/CssClass/IsPrimary cover initial render",
+            args: "typed strings/bool",
+            returnOrPayload: "void; visible classes update after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetIcon(...), SetCssClass(...), SetPrimary(bool)",
+            outcome: "implement only narrow proven members"
+        });
+        proposal({
+            candidate: "click()",
+            kind: "method",
+            builder: "Click(string) is static event hook, not method",
+            args: "none",
+            returnOrPayload: "void; invokes native button click when enabled",
+            proof: "click return, native click",
+            csharp: "Click()",
+            outcome: "implement if trace is stable"
+        });
+        proposal({
+            candidate: "focusIn()",
+            kind: "method",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "void; button receives focus",
+            proof: "after focusIn",
+            csharp: "FocusIn()",
+            outcome: "implement if trace is stable"
+        });
+        proposal({
+            candidate: "click event channel",
+            kind: "event payload-read",
+            builder: "Click(string) covers static hook",
+            args: "none",
+            returnOrPayload: "unknown until trace",
+            proof: "fusion addEventListener click",
+            csharp: "Click event only if root event channel fires",
+            outcome: "needs-proof"
+        });
+
+        if (new URLSearchParams(location.search).has("autorun")) {
+            setTimeout(runValueTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-carousel-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-carousel-probe.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Carousel API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Carousel API Probe</h1>
+    <p>Trace the runtime surface before promoting it into typed Fusion API.</p>
+
+    <div id="host">
+        <div id="carousel"></div>
+    </div>
+
+    <h2>Trace Matrix</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Proof</th>
+                <th>Typed Fusion API</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const rows = [];
+        const target = document.getElementById("carousel");
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return { ownKeys: own, properties };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            document.getElementById("trace").textContent = JSON.stringify(trace, null, 2);
+        }
+
+        function addRow(row) {
+            rows.push(row);
+            const tr = document.createElement("tr");
+            [row.candidate, row.kind, row.builder, row.proof, row.csharp, row.outcome].forEach(value => {
+                const td = document.createElement("td");
+                td.textContent = value;
+                tr.appendChild(td);
+            });
+            document.getElementById("proposal-body").appendChild(tr);
+        }
+
+        const ej2 = new ej.navigations.Carousel({
+            items: [
+                { template: "<div class='carousel-slide carousel-slide-one'>One</div>" },
+                { template: "<div class='carousel-slide carousel-slide-two'>Two</div>" },
+                { template: "<div class='carousel-slide carousel-slide-three'>Three</div>" }
+            ],
+            selectedIndex: 1,
+            animationEffect: "None",
+            autoPlay: false,
+            buttonsVisibility: "Hidden",
+            showIndicators: false,
+            showPlayButton: false,
+            allowKeyboardInteraction: false,
+            enableTouchSwipe: false,
+            loop: false,
+            slideChanging: args => {
+                record("slideChanging", describePayload(args));
+                if (args.nextIndex === 0) {
+                    args.cancel = true;
+                    record("slideChanging.cancel", { nextIndex: args.nextIndex, cancel: args.cancel });
+                }
+            },
+            slideChanged: args => {
+                record("slideChanged", describePayload(args));
+                record("selectedIndex.read", ej2.selectedIndex);
+            }
+        });
+
+        ej2.appendTo(target);
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            record("prototype methods", Object.getOwnPropertyNames(Object.getPrototypeOf(ej2)).sort());
+            record("selectedIndex.read", ej2.selectedIndex);
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            document.getElementById("trace").textContent = "";
+        });
+
+        addRow({
+            candidate: "selectedIndex read",
+            kind: "prop-read",
+            builder: "static-only",
+            proof: "load trace and dump trace show selectedIndex is readable at runtime",
+            csharp: "SelectedIndex()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "next()",
+            kind: "method",
+            builder: "runtime",
+            proof: "clicking Next moves from Two to Three",
+            csharp: "Next()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "prev()",
+            kind: "method",
+            builder: "runtime",
+            proof: "clicking Previous moves from Three to Two",
+            csharp: "Previous()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "slideChanging.cancel",
+            kind: "payload-write",
+            builder: "runtime",
+            proof: "setting cancel=true blocks the final move to the first slide",
+            csharp: "PreventTransition()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "slideChanged payload",
+            kind: "payload-read",
+            builder: "runtime",
+            proof: "trace shows currentIndex, previousIndex, isSwiped, slideDirection",
+            csharp: "FusionCarouselSlideChangedArgs",
+            outcome: "implement"
+        });
+
+        record("ready", {
+            component: "carousel",
+            namespace: "ej.navigations",
+            className: "Carousel",
+            id: "carousel"
+        });
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-check-box-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-check-box-probe.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF CheckBox API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF CheckBox API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <input id="fusion-checkbox-probe" type="checkbox" />
+        <button id="outside-button" type="button">Outside focus target</button>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("fusion-checkbox-probe");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        function wrapper() {
+            return target.closest(".e-checkbox-wrapper");
+        }
+
+        function frame() {
+            return wrapper()?.querySelector(".e-frame");
+        }
+
+        function snapshot(label) {
+            record(label, {
+                checked: ej2.checked,
+                indeterminate: ej2.indeterminate,
+                disabled: ej2.disabled,
+                label: ej2.label,
+                cssClass: ej2.cssClass,
+                inputChecked: target.checked,
+                inputIndeterminate: target.indeterminate,
+                disabledAttribute: target.hasAttribute("disabled"),
+                wrapperClass: wrapper()?.className || null,
+                wrapperAriaDisabled: wrapper()?.getAttribute("aria-disabled") || null,
+                frameClass: frame()?.className || null,
+                focused: document.activeElement === target
+            });
+        }
+
+        const ej2 = new ej.buttons.CheckBox({
+            label: "Accept",
+            checked: false,
+            change: args => probe.event("change", args),
+            created: args => probe.event("created", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "check-box",
+            namespace: "ej.buttons",
+            className: "CheckBox",
+            id: "fusion-checkbox-probe"
+        });
+        snapshot("initial");
+
+        function runValueTrace() {
+            ej2.checked = true;
+            ej2.indeterminate = true;
+            ej2.disabled = true;
+            snapshot("direct set before dataBind");
+
+            const dataBindResult = ej2.dataBind();
+            record("dataBind return", dataBindResult);
+            snapshot("direct set after dataBind");
+
+            const disabledClickResult = ej2.click();
+            record("click while disabled return", disabledClickResult);
+            snapshot("after disabled click");
+
+            ej2.disabled = false;
+            ej2.indeterminate = false;
+            ej2.checked = false;
+            ej2.dataBind();
+            snapshot("reset after dataBind");
+
+            const clickResult = ej2.click();
+            record("click return", clickResult);
+            snapshot("after click");
+
+            document.getElementById("outside-button").focus();
+            const focusResult = ej2.focusIn();
+            record("focusIn return", focusResult);
+            snapshot("after focusIn");
+
+            document.getElementById("active-element").textContent =
+                document.activeElement?.id || "";
+        }
+
+        proposal({
+            candidate: "checked + dataBind()",
+            kind: "prop-read/write + public flush method",
+            builder: "For()/Checked covers initial render",
+            args: "bool",
+            returnOrPayload: "bool; input checked/frame class update after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetChecked(bool), Checked()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "indeterminate + dataBind()",
+            kind: "prop-read/write + public flush method",
+            builder: "Indeterminate() covers initial render",
+            args: "bool",
+            returnOrPayload: "bool; input indeterminate/frame class update after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetIndeterminate(bool), Indeterminate()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "disabled + dataBind()",
+            kind: "prop-read/write + public flush method",
+            builder: "Disabled() covers initial render",
+            args: "bool",
+            returnOrPayload: "bool; disabled attribute/wrapper aria update after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetDisabled(bool), Disabled()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "click()",
+            kind: "method",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "void; toggles checked and fires change when enabled",
+            proof: "click return, after click, change",
+            csharp: "Click()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "focusIn()",
+            kind: "method",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "void; input receives focus",
+            proof: "after focusIn",
+            csharp: "FocusIn()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "change.checked",
+            kind: "event payload-read",
+            builder: "Change(string) only wires a static handler",
+            args: "ChangeEventArgs",
+            returnOrPayload: "checked bool; event object excluded",
+            proof: "change",
+            csharp: "Changed with FusionCheckBoxChangeArgs.Checked",
+            outcome: "implement if stable"
+        });
+
+        if (new URLSearchParams(location.search).has("autorun")) {
+            setTimeout(runValueTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-combo-box-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-combo-box-probe.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF ComboBox API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF ComboBox API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <input id="combo-box-probe" />
+        <button id="outside-button" type="button">Outside focus target</button>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="run-proof">Run Proof</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("combo-box-probe");
+        const dataSource = [
+            { id: "AL", name: "Alice" },
+            { id: "BE", name: "Bennett" },
+            { id: "CA", name: "Carey" },
+            { id: "DA", name: "Dawson" }
+        ];
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args))
+        };
+
+        window.__sfProbe = probe;
+
+        function delay(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
+        function inputElement() {
+            return document.getElementById("combo-box-probe");
+        }
+
+        function hiddenElement() {
+            return document.querySelector("select[name='combo-box-probe']");
+        }
+
+        function popupElement() {
+            return document.querySelector(".e-ddl.e-popup") || document.querySelector(".e-popup.e-popup-open");
+        }
+
+        function snapshot(label) {
+            const input = inputElement();
+            const hidden = hiddenElement();
+            const popup = popupElement();
+            record(label, {
+                value: ej2.value,
+                text: ej2.text,
+                index: ej2.index,
+                enabled: ej2.enabled,
+                readonly: ej2.readonly,
+                inputValue: input?.value || null,
+                hiddenValue: hidden?.value || null,
+                activeElementId: document.activeElement?.id || null,
+                activeElementClass: document.activeElement?.className || null,
+                popupOpen: !!popup && popup.classList.contains("e-popup-open"),
+                popupDisplay: popup?.style.display || null,
+                listItemCount: ej2.getItems().length
+            });
+        }
+
+        const ej2 = new ej.dropdowns.ComboBox({
+            dataSource,
+            fields: { text: "name", value: "id" },
+            value: "AL",
+            placeholder: "Select resident",
+            allowCustom: true,
+            allowFiltering: false,
+            popupHeight: "160px",
+            change: args => probe.event("change", args),
+            focus: args => probe.event("focus", args),
+            blur: args => probe.event("blur", args),
+            open: args => probe.event("open", args),
+            close: args => probe.event("close", args),
+            filtering: args => probe.event("filtering", args),
+            customValueSpecifier: args => probe.event("customValueSpecifier", args),
+            created: args => probe.event("created", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("prototype-functions", functionNames(ej2));
+            record("own-keys", Object.keys(ej2).sort());
+            snapshot("dump-snapshot");
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        document.addEventListener("focusin", () => {
+            document.getElementById("active-element").textContent =
+                document.activeElement?.id || document.activeElement?.tagName || "";
+        });
+
+        async function runProof() {
+            snapshot("initial");
+
+            proposal({
+                candidate: "value",
+                kind: "property read/write",
+                builder: "ComboBoxBuilder.Value",
+                args: "string",
+                returnOrPayload: "string|null",
+                proof: "Set value to BE, call dataBind, DOM/input text updates.",
+                csharp: "SetValue(string?) / Value()",
+                outcome: "proven"
+            });
+            ej2.value = "BE";
+            ej2.dataBind();
+            await delay(50);
+            snapshot("after-set-value");
+
+            proposal({
+                candidate: "text",
+                kind: "property read/write",
+                builder: "ComboBoxBuilder.Text",
+                args: "string",
+                returnOrPayload: "string|null",
+                proof: "Set text to Carey, call dataBind, value follows mapped item.",
+                csharp: "SetText(string?) / Text()",
+                outcome: "proven"
+            });
+            ej2.text = "Carey";
+            ej2.dataBind();
+            await delay(50);
+            snapshot("after-set-text");
+
+            proposal({
+                candidate: "index",
+                kind: "property read/write",
+                builder: "ComboBoxBuilder.Index",
+                args: "number",
+                returnOrPayload: "number|null",
+                proof: "Set index to 3, call dataBind, value/text update.",
+                csharp: "SetIndex(int) / Index()",
+                outcome: "proven"
+            });
+            ej2.index = 3;
+            ej2.dataBind();
+            await delay(50);
+            snapshot("after-set-index");
+
+            proposal({
+                candidate: "showPopup/hidePopup",
+                kind: "method call",
+                builder: "static popup configuration only",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "showPopup opens list, hidePopup closes it.",
+                csharp: "ShowPopup() / HidePopup()",
+                outcome: "proven"
+            });
+            ej2.showPopup();
+            await delay(100);
+            snapshot("after-show-popup");
+            ej2.hidePopup();
+            await delay(100);
+            snapshot("after-hide-popup");
+
+            proposal({
+                candidate: "focusIn/focusOut",
+                kind: "method call",
+                builder: "none",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "focusIn moves active element to ComboBox input, focusOut blurs it.",
+                csharp: "FocusIn() / FocusOut()",
+                outcome: "proven"
+            });
+            ej2.focusIn();
+            await delay(100);
+            snapshot("after-focus-in");
+            ej2.focusOut();
+            await delay(100);
+            snapshot("after-focus-out");
+
+            proposal({
+                candidate: "clear",
+                kind: "method call",
+                builder: "ComboBoxBuilder.ShowClearButton controls static button",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "clear resets value/text/index after dataBind.",
+                csharp: "Clear()",
+                outcome: "proven"
+            });
+            ej2.clear();
+            ej2.dataBind();
+            await delay(50);
+            snapshot("after-clear");
+
+            inputElement().value = "Dawson";
+            inputElement().dispatchEvent(new Event("input", { bubbles: true }));
+            inputElement().dispatchEvent(new KeyboardEvent("keyup", { key: "n", bubbles: true }));
+            ej2.hidePopup();
+            await delay(100);
+            snapshot("after-typed-change");
+
+            record("proof-complete", true);
+            return {
+                trace,
+                proposalRows
+            };
+        }
+
+        window.runComboBoxProof = runProof;
+        document.getElementById("run-proof").addEventListener("click", runProof);
+        snapshot("created");
+
+        if (new URLSearchParams(window.location.search).has("autorun")) {
+            setTimeout(() => {
+                runProof()
+                    .then(() => {
+                        document.body.dataset.proofComplete = "true";
+                    })
+                    .catch(error => {
+                        record("proof-error", {
+                            name: error?.name || null,
+                            message: error?.message || String(error)
+                        });
+                        document.body.dataset.proofComplete = "false";
+                    });
+            }, 0);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-context-menu-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-context-menu-probe.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF ContextMenu API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        #context-target { border: 1px dashed #94a3b8; background: #f8fafc; min-height: 112px; padding: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; margin-bottom: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF ContextMenu API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+
+    <div id="host">
+        <div id="context-target">Right-click here or use the buttons below.</div>
+        <ul id="context-menu"></ul>
+    </div>
+
+    <div>
+        <button id="open">Open at 96,168</button>
+        <button id="open-with-target">Open with target</button>
+        <button id="close">Close</button>
+        <button id="dump">Dump Keys</button>
+        <button id="clear">Clear Trace</button>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("context-target");
+
+        const items = [
+            { id: "dashboard-item", text: "Dashboard" },
+            {
+                id: "projects-item",
+                text: "Projects",
+                items: [
+                    { id: "reports-item", text: "Reports" },
+                    { id: "archive-item", text: "Archive" }
+                ]
+            },
+            { id: "help-item", text: "Help" }
+        ];
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return `[Element#${value.id || value.tagName}]`;
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent = JSON.stringify(trace, null, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        const ej2 = new ej.navigations.ContextMenu({
+            target: "#context-target",
+            items,
+            enableScrolling: false,
+            animationSettings: {
+                effect: "None",
+                duration: 0,
+                easing: "linear"
+            },
+            beforeItemRender: args => probe.event("beforeItemRender", args),
+            beforeOpen: args => probe.event("beforeOpen", args),
+            onOpen: args => probe.event("onOpen", args),
+            beforeClose: args => probe.event("beforeClose", args),
+            onClose: args => probe.event("onClose", args),
+            select: args => probe.event("select", args)
+        });
+        ej2.appendTo(document.getElementById("context-menu"));
+        probe.ej2 = ej2;
+
+        document.getElementById("open").addEventListener("click", () => {
+            record("open()", ej2.open(96, 168));
+        });
+
+        document.getElementById("open-with-target").addEventListener("click", () => {
+            record("open(top,left,target)", ej2.open(96, 168, target));
+        });
+
+        document.getElementById("close").addEventListener("click", () => {
+            record("close()", ej2.close());
+        });
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "context-menu",
+            namespace: "ej.navigations",
+            className: "ContextMenu",
+            id: "context-menu"
+        });
+
+        proposal({
+            candidate: "open(top,left,target?)",
+            kind: "method",
+            builder: "static-only",
+            args: "number, number, optional HTMLElement",
+            returnOrPayload: "void",
+            proof: "open buttons, open-with-target button, and right-click target",
+            csharp: "Open(top, left)",
+            outcome: "exclude target bridge"
+        });
+        proposal({
+            candidate: "close()",
+            kind: "method",
+            builder: "static-only",
+            args: "none",
+            returnOrPayload: "void",
+            proof: "close button",
+            csharp: "Close()",
+            outcome: "implement"
+        });
+        proposal({
+            candidate: "beforeItemRender",
+            kind: "event",
+            builder: "static-only",
+            args: "MenuEventArgs",
+            returnOrPayload: "element, item, event",
+            proof: "beforeItemRender trace",
+            csharp: "BeforeItemRender",
+            outcome: "implement"
+        });
+        proposal({
+            candidate: "beforeOpen / onOpen / beforeClose / onClose",
+            kind: "events",
+            builder: "static-only",
+            args: "menu event args",
+            returnOrPayload: "element, items, parentItem, cancel, top, left",
+            proof: "open and close traces",
+            csharp: "BeforeOpen / Opened / BeforeClose / Closed",
+            outcome: "implement"
+        });
+        proposal({
+            candidate: "select",
+            kind: "event",
+            builder: "static-only",
+            args: "MenuEventArgs",
+            returnOrPayload: "element, item, event",
+            proof: "select trace",
+            csharp: "Select",
+            outcome: "implement"
+        });
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-drop-down-button-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-drop-down-button-probe.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF DropDownButton API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF DropDownButton API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <button id="drop-down-button-probe" type="button">Initial Actions</button>
+        <button id="outside-button" type="button">Outside focus target</button>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("drop-down-button-probe");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args))
+        };
+
+        window.__sfProbe = probe;
+
+        function popup() {
+            return document.getElementById(target.id + "-popup");
+        }
+
+        function isOpen() {
+            return popup()?.classList.contains("e-popup-open") || false;
+        }
+
+        function ensureOpen() {
+            if (!isOpen()) {
+                ej2.toggle();
+            }
+        }
+
+        function ensureClosed() {
+            if (isOpen()) {
+                ej2.toggle();
+            }
+        }
+
+        function items() {
+            return Array.from(popup()?.querySelectorAll("li.e-item") || []).map(li => ({
+                id: li.id,
+                text: li.textContent.trim(),
+                disabled: li.classList.contains("e-disabled"),
+                className: li.className
+            }));
+        }
+
+        function itemTexts() {
+            return ej2.items.map(item => item.text);
+        }
+
+        function snapshot(label) {
+            const popupElement = popup();
+            record(label, {
+                content: ej2.content,
+                disabled: ej2.disabled,
+                cssClass: ej2.cssClass,
+                items: ej2.items.map(item => ({
+                    id: item.id,
+                    text: item.text,
+                    disabled: item.disabled,
+                    separator: item.separator
+                })),
+                text: target.textContent.trim(),
+                html: target.innerHTML,
+                disabledAttribute: target.hasAttribute("disabled"),
+                className: target.className,
+                popupClass: popupElement?.className || null,
+                popupOpen: popupElement?.classList.contains("e-popup-open") || false,
+                popupClose: popupElement?.classList.contains("e-popup-close") || false,
+                popupItems: items(),
+                ariaExpanded: target.getAttribute("aria-expanded"),
+                focused: document.activeElement === target
+            });
+        }
+
+        const ej2 = new ej.splitbuttons.DropDownButton({
+            content: "Initial Actions",
+            cssClass: "care-actions",
+            animationSettings: { effect: "None" },
+            items: [
+                { id: "view", text: "View profile" },
+                { id: "assign", text: "Assign nurse" },
+                { id: "hold", text: "Place hold", disabled: true }
+            ],
+            beforeItemRender: args => probe.event("beforeItemRender", args),
+            beforeOpen: args => probe.event("beforeOpen", args),
+            open: args => probe.event("open", args),
+            beforeClose: args => probe.event("beforeClose", args),
+            close: args => probe.event("close", args),
+            select: args => probe.event("select", args),
+            created: args => probe.event("created", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+            record("host instance", {
+                hasEj2Instances: Array.isArray(target.ej2_instances),
+                firstInstanceIsDropDownButton: target.ej2_instances && target.ej2_instances[0] === ej2
+            });
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "drop-down-button",
+            namespace: "ej.splitbuttons",
+            className: "DropDownButton",
+            id: "drop-down-button-probe"
+        });
+        snapshot("initial");
+
+        function runValueTrace() {
+            ej2.content = "Queued Actions";
+            ej2.disabled = true;
+            ej2.cssClass = "e-success extra-class";
+            snapshot("direct set before dataBind");
+
+            const dataBindResult = ej2.dataBind();
+            record("dataBind return", dataBindResult);
+            snapshot("direct set after dataBind");
+
+            ej2.disabled = false;
+            ej2.dataBind();
+            snapshot("enabled after dataBind");
+
+            ensureClosed();
+            const openResult = ej2.toggle();
+            record("toggle open return", openResult);
+            snapshot("after toggle open");
+
+            const closeResult = ej2.toggle();
+            record("toggle close return", closeResult);
+            snapshot("after toggle close");
+
+            const focusResult = ej2.focusIn();
+            record("focusIn return", focusResult);
+            snapshot("after focusIn");
+
+            const removeTextResult = ej2.removeItems(["Assign nurse"], false);
+            record("removeItems by text return", removeTextResult);
+            ensureOpen();
+            snapshot("after removeItems by text and open");
+            ensureClosed();
+            snapshot("after close post text removal");
+
+            const removeIdResult = ej2.removeItems(["hold"], true);
+            record("removeItems by id return", removeIdResult);
+            ensureOpen();
+            snapshot("after removeItems by id and open");
+
+            const selectTarget = Array.from(popup().querySelectorAll("li.e-item"))
+                .find(li => li.textContent.trim() === "View profile");
+            selectTarget.click();
+            snapshot("after item click");
+
+            document.getElementById("outside-button").focus();
+            snapshot("after outside focus");
+
+            record("summary", {
+                finalContent: ej2.content,
+                finalDisabled: ej2.disabled,
+                finalCssClass: ej2.cssClass,
+                finalItemTexts: itemTexts(),
+                selectedEventCount: trace.filter(entry => entry.label === "select").length,
+                hostInstanceStored: target.ej2_instances && target.ej2_instances[0] === ej2
+            });
+        }
+
+        proposal({
+            candidate: "ej2.content",
+            kind: "property read/write",
+            builder: "Content",
+            args: "string + dataBind()",
+            returnOrPayload: "string",
+            proof: "Trace compares DOM text before and after dataBind.",
+            csharp: "Content(), SetContent(string)",
+            outcome: "onboard if browser trace updates visible text"
+        });
+        proposal({
+            candidate: "ej2.disabled",
+            kind: "property read/write",
+            builder: "Disabled",
+            args: "bool + dataBind()",
+            returnOrPayload: "bool",
+            proof: "Trace compares button disabled attribute before and after dataBind.",
+            csharp: "Disabled(), SetDisabled(bool)",
+            outcome: "onboard if browser trace updates native disabled state"
+        });
+        proposal({
+            candidate: "ej2.cssClass",
+            kind: "property read/write",
+            builder: "CssClass",
+            args: "string + dataBind()",
+            returnOrPayload: "string",
+            proof: "Trace compares button and popup classes before and after dataBind.",
+            csharp: "CssClass(), SetCssClass(string)",
+            outcome: "onboard if browser trace updates rendered classes"
+        });
+        proposal({
+            candidate: "ej2.toggle()",
+            kind: "method",
+            builder: "-",
+            args: "none",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies popup open/close class and aria-expanded changes.",
+            csharp: "Toggle()",
+            outcome: "onboard if browser trace toggles popup"
+        });
+        proposal({
+            candidate: "ej2.focusIn()",
+            kind: "method",
+            builder: "-",
+            args: "none",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies document.activeElement is the button.",
+            csharp: "FocusIn()",
+            outcome: "onboard if browser trace focuses host"
+        });
+        proposal({
+            candidate: "ej2.removeItems(string[], false)",
+            kind: "method",
+            builder: "-",
+            args: "string[]",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies named item is absent from the next popup render.",
+            csharp: "RemoveItemsByText(params string[])",
+            outcome: "onboard if browser trace removes by text"
+        });
+        proposal({
+            candidate: "ej2.removeItems(string[], true)",
+            kind: "method",
+            builder: "-",
+            args: "string[]",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies id item is absent from the next popup render.",
+            csharp: "RemoveItemsById(params string[])",
+            outcome: "onboard if browser trace removes by id"
+        });
+        proposal({
+            candidate: "select",
+            kind: "event",
+            builder: "Select",
+            args: "MenuEventArgs",
+            returnOrPayload: "item.id, item.text, item.disabled",
+            proof: "Trace captures select payload after a real item click.",
+            csharp: "Selected(FusionDropDownButtonSelectArgs)",
+            outcome: "onboard only typed item fields, not HTMLElement/Event"
+        });
+
+        if (new URLSearchParams(window.location.search).has("autorun")) {
+            window.addEventListener("load", () => {
+                setTimeout(runValueTrace, 250);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-drop-down-tree-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-drop-down-tree-probe.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF DropDownTree API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF DropDownTree API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <input id="drop-down-tree-probe" />
+        <button id="outside-button" type="button">Outside focus target</button>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="run-proof">Run Proof</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("drop-down-tree-probe");
+        const dataSource = [
+            { id: "floor-a", name: "Floor A", hasChild: true, expanded: true },
+            { id: "alice", pid: "floor-a", name: "Alice" },
+            { id: "bennett", pid: "floor-a", name: "Bennett" },
+            { id: "floor-b", name: "Floor B", hasChild: true, expanded: true },
+            { id: "carey", pid: "floor-b", name: "Carey" },
+            { id: "dawson", pid: "floor-b", name: "Dawson" }
+        ];
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args))
+        };
+
+        window.__sfProbe = probe;
+
+        function delay(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
+        function inputElement() {
+            return document.getElementById("drop-down-tree-probe");
+        }
+
+        function hiddenValues() {
+            return Array.from(document.querySelectorAll("select[name='drop-down-tree-probe'] option"))
+                .map(option => option.value);
+        }
+
+        function popupElement() {
+            return document.getElementById("drop-down-tree-probe_options");
+        }
+
+        function visibleItem(text) {
+            return Array.from(document.querySelectorAll("#drop-down-tree-probe_tree .e-list-item"))
+                .find(item => item.textContent.trim() === text);
+        }
+
+        function snapshot(label) {
+            const input = inputElement();
+            const popup = popupElement();
+            record(label, {
+                value: ej2.value ? ej2.value.slice() : ej2.value,
+                text: ej2.text,
+                inputValue: input?.value || null,
+                hiddenValues: hiddenValues(),
+                readonly: ej2.readonly,
+                enabled: ej2.enabled,
+                popupOpen: !!popup && popup.classList.contains("e-popup-open"),
+                popupDisplay: popup?.style.display || null,
+                selectedLis: Array.from(document.querySelectorAll("#drop-down-tree-probe_tree .e-active"))
+                    .map(item => item.textContent.trim()),
+                activeElementId: document.activeElement?.id || null,
+                activeElementClass: document.activeElement?.className || null
+            });
+        }
+
+        const ej2 = new ej.dropdowns.DropDownTree({
+            fields: {
+                dataSource,
+                value: "id",
+                text: "name",
+                parentValue: "pid",
+                hasChildren: "hasChild",
+                expanded: "expanded"
+            },
+            value: ["alice"],
+            changeOnBlur: false,
+            popupHeight: "180px",
+            placeholder: "Select resident",
+            change: args => probe.event("change", args),
+            select: args => probe.event("select", args),
+            focus: args => probe.event("focus", args),
+            blur: args => probe.event("blur", args),
+            open: args => probe.event("open", args),
+            close: args => probe.event("close", args),
+            created: args => probe.event("created", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("prototype-functions", functionNames(ej2));
+            record("own-keys", Object.keys(ej2).sort());
+            snapshot("dump-snapshot");
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        async function runProof() {
+            snapshot("initial");
+
+            proposal({
+                candidate: "value",
+                kind: "property read/write",
+                builder: "DropDownTreeBuilder.Value",
+                args: "string[]",
+                returnOrPayload: "string[]|null",
+                proof: "Set value to [bennett], call dataBind, text/input update.",
+                csharp: "SetValue(params string[]) / Value()",
+                outcome: "proven"
+            });
+            ej2.value = ["bennett"];
+            ej2.dataBind();
+            await delay(100);
+            snapshot("after-set-value");
+
+            proposal({
+                candidate: "text",
+                kind: "property read/write",
+                builder: "DropDownTreeBuilder.Text",
+                args: "string|null",
+                returnOrPayload: "string|null",
+                proof: "Set text to Carey, call dataBind, value follows mapped item.",
+                csharp: "SetText(string?) / Text()",
+                outcome: "proven"
+            });
+            ej2.text = "Carey";
+            ej2.dataBind();
+            await delay(100);
+            snapshot("after-set-text");
+
+            proposal({
+                candidate: "showPopup/hidePopup",
+                kind: "method call",
+                builder: "static popup configuration only",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "showPopup opens tree popup, hidePopup closes it.",
+                csharp: "ShowPopup() / HidePopup()",
+                outcome: "proven"
+            });
+            ej2.showPopup();
+            await delay(150);
+            snapshot("after-show-popup");
+            ej2.hidePopup();
+            await delay(150);
+            snapshot("after-hide-popup");
+
+            proposal({
+                candidate: "clear",
+                kind: "method call",
+                builder: "DropDownTreeBuilder.ShowClearButton controls static button",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "clear resets value to [] and text/input to null.",
+                csharp: "Clear()",
+                outcome: "proven"
+            });
+            ej2.clear();
+            await delay(100);
+            snapshot("after-clear");
+
+            ej2.showPopup();
+            await delay(150);
+            const dawson = visibleItem("Dawson");
+            if (dawson) {
+                dawson.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
+                dawson.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
+                dawson.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+            }
+            await delay(150);
+            snapshot("after-click-dawson");
+
+            record("proof-complete", true);
+            return {
+                trace,
+                proposalRows
+            };
+        }
+
+        window.runDropDownTreeProof = runProof;
+        document.getElementById("run-proof").addEventListener("click", runProof);
+        snapshot("created");
+
+        if (new URLSearchParams(window.location.search).has("autorun")) {
+            setTimeout(() => {
+                runProof()
+                    .then(() => {
+                        document.body.dataset.proofComplete = "true";
+                    })
+                    .catch(error => {
+                        record("proof-error", {
+                            name: error?.name || null,
+                            message: error?.message || String(error)
+                        });
+                        document.body.dataset.proofComplete = "false";
+                    });
+            }, 0);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-grid-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-grid-probe.html
@@ -49,7 +49,15 @@
     <button id="method-group">groupColumn("careLevel")</button>
     <button id="method-clear-group">clearGrouping()</button>
     <button id="method-select">selectRow(1)</button>
+    <button id="method-select-range">selectRowsByRange(0, 2)</button>
     <button id="method-clear-selection">clearSelection()</button>
+    <button id="method-hide-risk">hideColumns("risk")</button>
+    <button id="method-show-risk">showColumns("risk")</button>
+    <button id="method-reorder-risk">reorderColumns("risk", "residentName")</button>
+    <button id="method-current-view">getCurrentViewRecords()</button>
+    <button id="method-row-index">getRowIndexByPrimaryKey(103)</button>
+    <button id="method-set-cell">setCellValue(103, "risk", "Critical")</button>
+    <button id="method-set-row">setRowData(104, row)</button>
     <button id="clear">Clear Trace</button>
     <pre id="trace"></pre>
 
@@ -335,12 +343,61 @@
             });
         });
 
+        document.getElementById("method-select-range").addEventListener("click", () => {
+            ej2.selectRowsByRange(0, 2);
+            record("call selectRowsByRange after", {
+                indexes: ej2.getSelectedRowIndexes(),
+                records: ej2.getSelectedRecords()
+            });
+        });
+
         document.getElementById("method-clear-selection").addEventListener("click", () => {
             ej2.clearSelection();
             record("call clearSelection after", {
                 indexes: ej2.getSelectedRowIndexes(),
                 records: ej2.getSelectedRecords()
             });
+        });
+
+        document.getElementById("method-hide-risk").addEventListener("click", () => {
+            ej2.hideColumns("risk", "field");
+            record("call hideColumns after", ej2.getHiddenColumns().map(col => col.field));
+        });
+
+        document.getElementById("method-show-risk").addEventListener("click", () => {
+            ej2.showColumns("risk", "field");
+            record("call showColumns after", ej2.getHiddenColumns().map(col => col.field));
+        });
+
+        document.getElementById("method-reorder-risk").addEventListener("click", () => {
+            ej2.reorderColumns("risk", "residentName");
+            record("call reorderColumns after", ej2.getColumns().map(col => col.field || col.headerText));
+        });
+
+        document.getElementById("method-current-view").addEventListener("click", () => {
+            record("call getCurrentViewRecords result", ej2.getCurrentViewRecords());
+        });
+
+        document.getElementById("method-row-index").addEventListener("click", () => {
+            record("call getRowIndexByPrimaryKey result", ej2.getRowIndexByPrimaryKey(103));
+        });
+
+        document.getElementById("method-set-cell").addEventListener("click", () => {
+            ej2.setCellValue(103, "risk", "Critical");
+            record("call setCellValue after", ej2.getCurrentViewRecords().find(row => row.residentId === 103));
+        });
+
+        document.getElementById("method-set-row").addEventListener("click", () => {
+            ej2.setRowData(104, {
+                residentId: 104,
+                residentName: "Irene Runtime",
+                age: 88,
+                careLevel: "Skilled Nursing",
+                wing: "South",
+                suite: "S-312",
+                risk: "Critical"
+            });
+            record("call setRowData after", ej2.getCurrentViewRecords().find(row => row.residentId === 104));
         });
 
         document.getElementById("clear").addEventListener("click", () => {
@@ -424,6 +481,76 @@
                 proof: "method button + rowSelected trace",
                 csharp: "SelectRow(int rowIndex), ClearSelection()",
                 outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "selectRowsByRange(startIndex, endIndex)",
+                kind: "method",
+                builder: "selectionSettings owns selection mode",
+                args: "int startIndex, int endIndex",
+                returnOrPayload: "void; selected records update",
+                proof: "method button + getSelectedRecords trace",
+                csharp: "SelectRowsByRange(int startIndex, int endIndex)",
+                outcome: "onboarded; covered by operations Playwright"
+            },
+            {
+                candidate: "showColumns(keys, showBy) / hideColumns(keys, hideBy)",
+                kind: "method",
+                builder: "columns own initial render",
+                args: "typed row field expression; showBy/hideBy fixed to field",
+                returnOrPayload: "void; header/cell visibility changes",
+                proof: "method button + hidden columns trace",
+                csharp: "ShowColumn<TRow, TField>(field), HideColumn<TRow, TField>(field)",
+                outcome: "onboarded; covered by operations Playwright"
+            },
+            {
+                candidate: "reorderColumns(fromFName, toFName)",
+                kind: "method",
+                builder: "allowReordering owns static enablement",
+                args: "typed source field and typed target field expressions",
+                returnOrPayload: "void; column order changes",
+                proof: "method button + getColumns trace",
+                csharp: "ReorderColumnBefore<TRow, TFromField, TToField>(from, before)",
+                outcome: "onboarded; covered by operations Playwright"
+            },
+            {
+                candidate: "getCurrentViewRecords()",
+                kind: "method-return source",
+                builder: "not static initial render",
+                args: "none",
+                returnOrPayload: "current rendered row array",
+                proof: "method button + row array trace",
+                csharp: "CurrentViewRecords<TRow>()",
+                outcome: "onboarded; covered by operations Playwright"
+            },
+            {
+                candidate: "getRowIndexByPrimaryKey(value)",
+                kind: "method-return source",
+                builder: "primary key column owns key field",
+                args: "int primary key",
+                returnOrPayload: "visible row index or -1",
+                proof: "method button + numeric index trace",
+                csharp: "RowIndexByPrimaryKey(int primaryKey)",
+                outcome: "onboarded; covered by operations Playwright"
+            },
+            {
+                candidate: "setCellValue(key, field, value)",
+                kind: "method",
+                builder: "primary key column owns key field",
+                args: "int key, typed row field expression, typed value",
+                returnOrPayload: "void; visible cell and current view record update",
+                proof: "method button + visible cell/current view trace",
+                csharp: "SetCellValue(int primaryKey, Expression<Func<TRow, TValue>> field, TValue value)",
+                outcome: "onboarded; covered by operations Playwright"
+            },
+            {
+                candidate: "setRowData(key, rowData)",
+                kind: "method",
+                builder: "primary key column owns key field",
+                args: "int key, typed row or response-body row selector",
+                returnOrPayload: "void; visible row updates",
+                proof: "method button + current view trace",
+                csharp: "SetRowData<TRow>(int primaryKey, TRow row)",
+                outcome: "onboarded; covered by operations Playwright"
             },
             {
                 candidate: "startEdit/endEdit/closeEdit/addRecord/deleteRecord/updateRow",

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-grid-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-grid-probe.html
@@ -1,0 +1,461 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Grid API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Grid API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <div id="grid-probe"></div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="method-page">goToPage(2)</button>
+    <button id="method-sort">sortColumn("residentName")</button>
+    <button id="method-search">search("Memory")</button>
+    <button id="method-filter">filterByColumn("wing")</button>
+    <button id="method-clear-filter">clearFiltering()</button>
+    <button id="method-group">groupColumn("careLevel")</button>
+    <button id="method-clear-group">clearGrouping()</button>
+    <button id="method-select">selectRow(1)</button>
+    <button id="method-clear-selection">clearSelection()</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("grid-probe");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        const residents = [
+            { residentId: 101, residentName: "Amina Patel", age: 82, careLevel: "Assisted Living", wing: "North", suite: "N-104", risk: "Moderate" },
+            { residentId: 102, residentName: "Grace Bennett", age: 91, careLevel: "Memory Care", wing: "East", suite: "E-211", risk: "High" },
+            { residentId: 103, residentName: "Henry Liu", age: 77, careLevel: "Independent", wing: "West", suite: "W-018", risk: "Low" },
+            { residentId: 104, residentName: "Irene Morgan", age: 88, careLevel: "Skilled Nursing", wing: "South", suite: "S-312", risk: "High" },
+            { residentId: 105, residentName: "Jonah Reed", age: 74, careLevel: "Assisted Living", wing: "North", suite: "N-112", risk: "Low" },
+            { residentId: 106, residentName: "Katherine Ortiz", age: 86, careLevel: "Memory Care", wing: "East", suite: "E-118", risk: "Moderate" },
+            { residentId: 107, residentName: "Leo Simmons", age: 93, careLevel: "Skilled Nursing", wing: "South", suite: "S-109", risk: "High" },
+            { residentId: 108, residentName: "Mara Thompson", age: 79, careLevel: "Independent", wing: "West", suite: "W-205", risk: "Low" },
+            { residentId: 109, residentName: "Noah Walsh", age: 84, careLevel: "Assisted Living", wing: "North", suite: "N-206", risk: "Moderate" },
+            { residentId: 110, residentName: "Priya Shah", age: 90, careLevel: "Memory Care", wing: "East", suite: "E-301", risk: "High" },
+            { residentId: 111, residentName: "Ruth Carter", age: 81, careLevel: "Independent", wing: "West", suite: "W-117", risk: "Low" },
+            { residentId: 112, residentName: "Samuel Diaz", age: 95, careLevel: "Skilled Nursing", wing: "South", suite: "S-201", risk: "High" }
+        ];
+
+        function sortRows(rows, sorted) {
+            if (!Array.isArray(sorted) || sorted.length === 0) return rows;
+            return rows.slice().sort((left, right) => {
+                for (const sort of sorted) {
+                    const field = sort.name;
+                    const direction = sort.direction === "descending" ? -1 : 1;
+                    const a = left[field];
+                    const b = right[field];
+                    if (a < b) return -1 * direction;
+                    if (a > b) return 1 * direction;
+                }
+                return 0;
+            });
+        }
+
+        function filterRows(rows, where) {
+            if (!Array.isArray(where) || where.length === 0) return rows;
+            return rows.filter(row => where.every(predicate => {
+                const field = predicate.field;
+                const value = predicate.value;
+                if (!field || value === undefined || value === null || value === "") return true;
+                const actual = row[field];
+                if (predicate.operator === "contains") {
+                    return String(actual).toLowerCase().includes(String(value).toLowerCase());
+                }
+                if (predicate.operator === "equal") {
+                    return String(actual).toLowerCase() === String(value).toLowerCase();
+                }
+                return String(actual).toLowerCase().includes(String(value).toLowerCase());
+            }));
+        }
+
+        function searchRows(rows, search) {
+            if (!Array.isArray(search) || search.length === 0) return rows;
+            const active = search.find(item => item && item.key);
+            if (!active) return rows;
+            const key = String(active.key).toLowerCase();
+            const fields = Array.isArray(active.fields) && active.fields.length
+                ? active.fields
+                : ["residentName", "careLevel", "wing", "suite", "risk"];
+            return rows.filter(row => fields.some(field =>
+                String(row[field] ?? "").toLowerCase().includes(key)));
+        }
+
+        function pageRows(rows, skip, take) {
+            const start = Number.isFinite(skip) ? skip : 0;
+            const length = Number.isFinite(take) && take > 0 ? take : 5;
+            return rows.slice(start, start + length);
+        }
+
+        function applyState(state) {
+            let rows = residents.slice();
+            rows = filterRows(rows, state.where);
+            rows = searchRows(rows, state.search);
+            rows = sortRows(rows, state.sorted);
+            const result = pageRows(rows, state.skip, state.take);
+            return { result, count: rows.length };
+        }
+
+        const initialState = { skip: 0, take: 5 };
+        const ej2 = new ej.grids.Grid({
+            dataSource: applyState(initialState),
+            allowPaging: true,
+            allowSorting: true,
+            allowMultiSorting: true,
+            allowGrouping: true,
+            allowSelection: true,
+            allowFiltering: true,
+            toolbar: ["Search"],
+            pageSettings: { pageSize: 5 },
+            searchSettings: { fields: ["residentName", "careLevel", "wing", "suite", "risk"] },
+            filterSettings: { type: "FilterBar" },
+            groupSettings: { showDropArea: true },
+            columns: [
+                { field: "residentId", headerText: "ID", isPrimaryKey: true, width: 80, textAlign: "Right" },
+                { field: "residentName", headerText: "Resident", width: 180 },
+                { field: "age", headerText: "Age", width: 90, textAlign: "Right" },
+                { field: "careLevel", headerText: "Care Level", width: 160 },
+                { field: "wing", headerText: "Wing", width: 110 },
+                { field: "suite", headerText: "Suite", width: 110 },
+                { field: "risk", headerText: "Risk", width: 120 }
+            ],
+            dataStateChange: args => {
+                probe.event("dataStateChange", args);
+                ej2.dataSource = applyState(args);
+            },
+            actionBegin: args => probe.event("actionBegin", args),
+            actionComplete: args => probe.event("actionComplete", args),
+            recordClick: args => probe.event("recordClick", args),
+            rowSelected: args => probe.event("rowSelected", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("method-page").addEventListener("click", () => {
+            record("call goToPage before", { currentPage: ej2.pageSettings.currentPage });
+            ej2.goToPage(2);
+            record("call goToPage after", { currentPage: ej2.pageSettings.currentPage });
+        });
+
+        document.getElementById("method-sort").addEventListener("click", () => {
+            ej2.sortColumn("residentName", "Ascending", false);
+            record("call sortColumn after", ej2.sortSettings.columns);
+        });
+
+        document.getElementById("method-search").addEventListener("click", () => {
+            ej2.search("Memory");
+            record("call search after", ej2.searchSettings);
+        });
+
+        document.getElementById("method-filter").addEventListener("click", () => {
+            ej2.filterByColumn("wing", "equal", "North");
+            record("call filterByColumn after", ej2.filterSettings.columns);
+        });
+
+        document.getElementById("method-clear-filter").addEventListener("click", () => {
+            ej2.clearFiltering();
+            record("call clearFiltering after", ej2.filterSettings.columns);
+        });
+
+        document.getElementById("method-group").addEventListener("click", () => {
+            ej2.groupColumn("careLevel");
+            record("call groupColumn after", ej2.groupSettings.columns);
+        });
+
+        document.getElementById("method-clear-group").addEventListener("click", () => {
+            ej2.clearGrouping();
+            record("call clearGrouping after", ej2.groupSettings.columns);
+        });
+
+        document.getElementById("method-select").addEventListener("click", () => {
+            ej2.selectRow(1);
+            record("call selectRow after", {
+                indexes: ej2.getSelectedRowIndexes(),
+                records: ej2.getSelectedRecords()
+            });
+        });
+
+        document.getElementById("method-clear-selection").addEventListener("click", () => {
+            ej2.clearSelection();
+            record("call clearSelection after", {
+                indexes: ej2.getSelectedRowIndexes(),
+                records: ej2.getSelectedRecords()
+            });
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "grid",
+            namespace: "ej.grids",
+            className: "Grid",
+            id: "grid-probe"
+        });
+        [
+            {
+                candidate: "dataStateChange.group",
+                kind: "event payload read",
+                builder: "event wiring only",
+                args: "grouping/search/filter/sort/page gestures",
+                returnOrPayload: "skip, take, where[], search[], sorted[], group[], action",
+                proof: "dataStateChange trace rows",
+                csharp: "FusionGridDataStateChangeArgs.Group/Search/Where",
+                outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "goToPage(pageNo)",
+                kind: "method",
+                builder: "not static initial render",
+                args: "int pageNo",
+                returnOrPayload: "void; updates pageSettings.currentPage and dataStateChange",
+                proof: "method button + pager DOM",
+                csharp: "GoToPage(int pageNumber)",
+                outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "sortColumn(columnName, direction, isMultiSort)",
+                kind: "method",
+                builder: "not static initial render",
+                args: "typed row field expression, enum direction, bool multiSort",
+                returnOrPayload: "void; updates sorted state",
+                proof: "method button + dataStateChange.sorted",
+                csharp: "SortBy<TRow, TField>(Expression<Func<TRow, TField>> field, FusionGridSortDirection direction, bool keepExistingSorts = false)",
+                outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "search(searchString)",
+                kind: "method",
+                builder: "not static initial render",
+                args: "string searchString",
+                returnOrPayload: "void; updates searchSettings.key and dataStateChange.search[]",
+                proof: "method button + visible Memory Care rows",
+                csharp: "Search(string searchText)",
+                outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "filterByColumn(columnName, operator, value) / clearFiltering()",
+                kind: "method",
+                builder: "not static initial render",
+                args: "typed row field expression, enum text operator, string value",
+                returnOrPayload: "void; updates filterSettings.columns and dataStateChange.where[]",
+                proof: "method button + visible North Wing rows",
+                csharp: "FilterTextBy<TRow, TField>(Expression<Func<TRow, TField>> field, FusionGridTextFilterOperator op, string value), ClearFiltering()",
+                outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "groupColumn(columnName) / clearGrouping()",
+                kind: "method",
+                builder: "not static initial render",
+                args: "typed row field expression",
+                returnOrPayload: "void; updates groupSettings.columns and dataStateChange.group[]",
+                proof: "method button + grouped DOM",
+                csharp: "GroupBy<TRow, TField>(Expression<Func<TRow, TField>> field), ClearGrouping()",
+                outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "selectRow(index) / clearSelection()",
+                kind: "method",
+                builder: "not static initial render",
+                args: "int rowIndex",
+                returnOrPayload: "void; selected index/records update; rowSelected payload",
+                proof: "method button + rowSelected trace",
+                csharp: "SelectRow(int rowIndex), ClearSelection()",
+                outcome: "onboarded; covered by directory Playwright"
+            },
+            {
+                candidate: "startEdit/endEdit/closeEdit/addRecord/deleteRecord/updateRow",
+                kind: "method",
+                builder: "editSettings owns static editing mode",
+                args: "typed row values or response-body row selector",
+                returnOrPayload: "void; edit DOM/events/dataSource mutate",
+                proof: "editing sandbox inline grid",
+                csharp: "StartEdit(), EndEdit(), CloseEdit(), AddRecord<TRow>(), DeleteSelectedRecord(), UpdateRow<TRow>()",
+                outcome: "onboarded; covered by editing Playwright"
+            },
+            {
+                candidate: "editCell/saveCell/updateCell/getBatchChanges",
+                kind: "method and method-return source",
+                builder: "editSettings mode Batch owns static editing mode",
+                args: "typed row field expressions and typed cell values",
+                returnOrPayload: "void or FusionGridBatchChanges<TRow>",
+                proof: "editing sandbox batch grid",
+                csharp: "EditCell<TRow, TField>(), SaveCell(), UpdateCell(...), BatchChanges<TRow>()",
+                outcome: "onboarded; covered by editing Playwright"
+            },
+            {
+                candidate: "beginEdit/actionBegin/actionComplete/cellSave/cellSaved/beforeBatchSave",
+                kind: "event payload read and payload mutation",
+                builder: "event wiring only",
+                args: "typed row/event payloads",
+                returnOrPayload: "typed args; cancel mutation on editable events",
+                proof: "editing sandbox inline, batch, and dialog grids",
+                csharp: "BeginEdit<TRow>(), ActionBegin<TRow>(), ActionComplete<TRow>(), CellSave<TRow, TValue>(), CellSaved<TRow, TValue>(), BeforeBatchSave<TRow>()",
+                outcome: "onboarded; covered by editing Playwright"
+            }
+        ].forEach(proposal);
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-list-box-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-list-box-probe.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF ListBox API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+        .panel { border: 1px solid #d0d7de; padding: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; max-height: 620px; }
+        button { margin: 4px 8px 4px 0; }
+    </style>
+</head>
+<body>
+    <h1>SF ListBox API Probe</h1>
+    <p>Temporary probe for source-grounded ListBox onboarding. Only rows proven here can become typed Fusion API.</p>
+
+    <div class="grid">
+        <div class="panel">
+            <h2>String Data Source</h2>
+            <input id="list-box-probe" />
+        </div>
+        <div class="panel">
+            <h2>Value/Text Data Source</h2>
+            <input id="list-box-value-probe" />
+        </div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump" type="button">Dump Keys</button>
+    <button id="run-proof" type="button">Run Proof</button>
+    <button id="clear" type="button">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 30).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return { ownKeys: [], functions: [], properties: {} };
+            }
+
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent = JSON.stringify(trace, null, 2);
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            const tr = document.createElement("tr");
+            [
+                row.candidate,
+                row.kind,
+                row.builder,
+                row.args,
+                row.returnOrPayload,
+                row.proof,
+                row.csharp,
+                row.outcome
+            ].forEach(value => {
+                const td = document.createElement("td");
+                td.textContent = value || "";
+                tr.appendChild(td);
+            });
+            document.getElementById("proposal-body").appendChild(tr);
+        }
+
+        function itemTexts(list, selector) {
+            return Array.from((list.list || document).querySelectorAll(selector))
+                .map(item => item.textContent.trim());
+        }
+
+        function selectValues(list) {
+            return Array.from((list.list || document).querySelectorAll("select.e-hidden-select option:checked"))
+                .map(option => option.value);
+        }
+
+        function snapshot(list) {
+            const items = Array.from((list.list || document).querySelectorAll(".e-list-item"));
+            return {
+                value: list.value ? list.value.slice() : list.value,
+                listExists: !!list.list,
+                itemCount: items.length,
+                selectedValues: selectValues(list),
+                selectedByClass: itemTexts(list, ".e-list-item.e-active, .e-list-item.e-selected"),
+                selectedByAria: items
+                    .filter(item => item.getAttribute("aria-selected") === "true")
+                    .map(item => item.textContent.trim()),
+                classNames: items.map(item => ({
+                    text: item.textContent.trim(),
+                    value: item.getAttribute("data-value"),
+                    className: item.className,
+                    ariaSelected: item.getAttribute("aria-selected")
+                })),
+                disabled: itemTexts(list, ".e-list-item.e-disabled"),
+                checked: itemTexts(list, ".e-list-item .e-check").map(() => "[frame]")
+            };
+        }
+
+        const stringList = new ej.dropdowns.ListBox({
+            dataSource: ["Alice", "Bennett", "Carey", "Dawson"],
+            selectionSettings: { mode: "Multiple" },
+            change: args => record("string.change", describePayload(args))
+        });
+        stringList.appendTo("#list-box-probe");
+
+        const valueList = new ej.dropdowns.ListBox({
+            dataSource: [
+                { id: "a", name: "Alice" },
+                { id: "b", name: "Bennett" },
+                { id: "c", name: "Carey" },
+                { id: "d", name: "Dawson" }
+            ],
+            fields: { value: "id", text: "name" },
+            selectionSettings: { mode: "Multiple" },
+            change: args => record("value.change", describePayload(args))
+        });
+        valueList.appendTo("#list-box-value-probe");
+
+        window.__sfListBoxProbe = {
+            trace,
+            proposalRows,
+            stringList,
+            valueList,
+            record,
+            snapshot: () => ({
+                string: snapshot(stringList),
+                value: snapshot(valueList)
+            })
+        };
+
+        proposal({
+            candidate: "value property read/write + dataBind()",
+            kind: "property + method",
+            builder: "Value is builder-covered for initial render",
+            args: "string[]; empty array clears selection",
+            returnOrPayload: "string[] value after dataBind",
+            proof: "runProof sets value to Bennett/Dawson, then clears with []",
+            csharp: "SetValue(string[]), DataBind(), Value()",
+            outcome: "accept"
+        });
+        proposal({
+            candidate: "selectItems(items, state, isValue)",
+            kind: "method",
+            builder: "not builder-covered runtime method",
+            args: "string[] values, bool state, isValue: true",
+            returnOrPayload: "void; emits change.value",
+            proof: "runProof selects/unselects primitive and field-mapped values",
+            csharp: "SelectValues(string[]), UnselectValues(string[])",
+            outcome: "accept"
+        });
+        proposal({
+            candidate: "selectAll(state)",
+            kind: "method",
+            builder: "not builder-covered runtime method",
+            args: "bool state",
+            returnOrPayload: "void; emits change.value",
+            proof: "runProof selects and clears all string items",
+            csharp: "SelectAll(), UnselectAll()",
+            outcome: "accept"
+        });
+        proposal({
+            candidate: "enableItems(items, enable, isValue)",
+            kind: "method",
+            builder: "not builder-covered runtime method",
+            args: "string[] values, bool enable, isValue: true",
+            returnOrPayload: "void",
+            proof: "runProof disables/enables primitive and field-mapped values",
+            csharp: "DisableValues(string[]), EnableValues(string[])",
+            outcome: "accept"
+        });
+        proposal({
+            candidate: "selectItems/enableItems text mode",
+            kind: "method overload",
+            builder: "not builder-covered runtime method",
+            args: "string[] text, isValue: false",
+            returnOrPayload: "void",
+            proof: "source maps text through getValueByText",
+            csharp: "",
+            outcome: "reject: text is not a stable key when display text duplicates"
+        });
+        proposal({
+            candidate: "change event",
+            kind: "event",
+            builder: "Change builder-covered as callback hook only",
+            args: "ListBoxChangeEventArgs",
+            returnOrPayload: "value: string[]; elements/items/event are DOM/object",
+            proof: "runProof records event payload shape",
+            csharp: "Changed.Value only",
+            outcome: "accept value only; reject elements/items/event"
+        });
+        proposal({
+            candidate: "addItems/removeItems/drag/drop data APIs",
+            kind: "method/event",
+            builder: "mixed static/runtime",
+            args: "object item shapes and DOM events",
+            returnOrPayload: "loose object[]/Element payloads",
+            proof: "d.ts and source expose broad object/DOM shapes",
+            csharp: "",
+            outcome: "reject: violates typed public API invariant"
+        });
+
+        function dumpKeys() {
+            record("keys", {
+                namespace: !!ej.dropdowns,
+                ctor: typeof ej.dropdowns.ListBox,
+                stringFunctions: functionNames(stringList),
+                ownKeys: Object.keys(stringList).sort()
+            });
+        }
+
+        async function runProof() {
+            trace.length = 0;
+            dumpKeys();
+            record("initial", window.__sfListBoxProbe.snapshot());
+
+            stringList.value = ["Bennett", "Dawson"];
+            stringList.dataBind();
+            record("after.value.write", window.__sfListBoxProbe.snapshot());
+
+            stringList.value = [];
+            stringList.dataBind();
+            record("after.value.clear", window.__sfListBoxProbe.snapshot());
+
+            stringList.selectItems(["Alice", "Carey"], true, true);
+            record("after.select.string.values", window.__sfListBoxProbe.snapshot());
+
+            stringList.selectItems(["Carey"], false, true);
+            record("after.unselect.string.values", window.__sfListBoxProbe.snapshot());
+
+            stringList.selectAll(true);
+            record("after.select.all", window.__sfListBoxProbe.snapshot());
+
+            stringList.selectAll(false);
+            record("after.unselect.all", window.__sfListBoxProbe.snapshot());
+
+            stringList.enableItems(["Dawson"], false, true);
+            record("after.disable.string.values", window.__sfListBoxProbe.snapshot());
+
+            stringList.enableItems(["Dawson"], true, true);
+            record("after.enable.string.values", window.__sfListBoxProbe.snapshot());
+
+            valueList.selectItems(["b", "d"], true, true);
+            record("after.select.values", window.__sfListBoxProbe.snapshot());
+
+            valueList.selectItems(["d"], false, true);
+            record("after.unselect.values", window.__sfListBoxProbe.snapshot());
+
+            valueList.enableItems(["c"], false, true);
+            record("after.disable.values", window.__sfListBoxProbe.snapshot());
+
+            valueList.enableItems(["c"], true, true);
+            record("after.enable.values", window.__sfListBoxProbe.snapshot());
+        }
+
+        document.getElementById("dump").addEventListener("click", dumpKeys);
+        document.getElementById("run-proof").addEventListener("click", () => runProof().catch(error => record("error", {
+            message: error.message,
+            stack: error.stack
+        })));
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        if (new URLSearchParams(window.location.search).get("autorun") === "1") {
+            setTimeout(() => runProof().catch(error => record("error", {
+                message: error.message,
+                stack: error.stack
+            })), 300);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-list-view-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-list-view-probe.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF ListView API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+        .panel { border: 1px solid #d0d7de; padding: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; max-height: 540px; }
+        button { margin: 4px 8px 4px 0; }
+    </style>
+</head>
+<body>
+    <h1>SF ListView API Probe</h1>
+    <p>Temporary probe for source-grounded ListView onboarding. Only rows proven here can become typed Fusion API.</p>
+
+    <div class="grid">
+        <div class="panel">
+            <h2>Selection List</h2>
+            <div id="list-view-probe"></div>
+        </div>
+        <div class="panel">
+            <h2>Checkbox List</h2>
+            <div id="list-view-check-probe"></div>
+        </div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump" type="button">Dump Keys</button>
+    <button id="run-proof" type="button">Run Proof</button>
+    <button id="clear" type="button">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 30).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return { ownKeys: [], functions: [], properties: {} };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent = JSON.stringify(trace, null, 2);
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            const tr = document.createElement("tr");
+            [
+                row.candidate,
+                row.kind,
+                row.builder,
+                row.args,
+                row.returnOrPayload,
+                row.proof,
+                row.csharp,
+                row.outcome
+            ].forEach(value => {
+                const td = document.createElement("td");
+                td.textContent = value || "";
+                tr.appendChild(td);
+            });
+            document.getElementById("proposal-body").appendChild(tr);
+        }
+
+        function item(listId, text) {
+            return Array.from(document.querySelectorAll("#" + listId + " .e-list-item"))
+                .find(li => li.innerText.trim() === text);
+        }
+
+        function clickItem(listId, text) {
+            const li = item(listId, text);
+            if (!li) throw new Error("Missing item " + text + " in " + listId);
+            li.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+        }
+
+        function listSnapshot(listId, list) {
+            const items = Array.from(document.querySelectorAll("#" + listId + " .e-list-item"));
+            return {
+                selected: items.filter(li => li.classList.contains("e-active")).map(li => li.innerText.trim()),
+                checked: items
+                    .filter(li => li.querySelector(".e-check"))
+                    .map(li => li.innerText.trim()),
+                disabled: items.filter(li => li.classList.contains("e-disabled")).map(li => li.innerText.trim()),
+                hidden: items.filter(li => li.style.display === "none").map(li => li.innerText.trim()),
+                selectedItems: list.getSelectedItems()
+            };
+        }
+
+        let cancelCarey = false;
+
+        const selectionList = new ej.lists.ListView({
+            dataSource: ["Alice", "Bennett", "Carey", "Dawson"],
+            select: args => {
+                record("selection.select", describePayload(args));
+                if (args.text === "Carey" && cancelCarey) {
+                    args.cancel = true;
+                    record("selection.cancelled", { text: args.text, cancel: args.cancel });
+                }
+            }
+        });
+        selectionList.appendTo("#list-view-probe");
+
+        const checkboxList = new ej.lists.ListView({
+            dataSource: ["Hydration", "Mobility", "Dining"],
+            showCheckBox: true,
+            select: args => record("checkbox.select", describePayload(args))
+        });
+        checkboxList.appendTo("#list-view-check-probe");
+
+        window.__sfListViewProbe = {
+            trace,
+            proposalRows,
+            selectionList,
+            checkboxList,
+            record,
+            snapshot: () => ({
+                selection: listSnapshot("list-view-probe", selectionList),
+                checkbox: listSnapshot("list-view-check-probe", checkboxList)
+            })
+        };
+
+        proposal({
+            candidate: "selectItem(text)",
+            kind: "method",
+            builder: "not builder-covered runtime method",
+            args: "string text, primitive string dataSource",
+            returnOrPayload: "void",
+            proof: "runProof snapshots selected Bennett",
+            csharp: "SelectText(string text)",
+            outcome: "accept"
+        });
+        proposal({
+            candidate: "unselectItem(text)",
+            kind: "method",
+            builder: "not builder-covered runtime method",
+            args: "string text, primitive string dataSource",
+            returnOrPayload: "void",
+            proof: "runProof removes Bennett selection",
+            csharp: "UnselectText(string text)",
+            outcome: "accept"
+        });
+        proposal({
+            candidate: "checkItem/uncheckItem(text), checkAllItems/uncheckAllItems",
+            kind: "method",
+            builder: "ShowCheckBox is static builder config",
+            args: "string text for item methods; no args for all methods",
+            returnOrPayload: "void",
+            proof: "checkItem/uncheckItem text args throw; checkAllItems/uncheckAllItems toggle all",
+            csharp: "CheckAllItems/UncheckAllItems",
+            outcome: "accept all-item methods only; reject text item methods"
+        });
+        proposal({
+            candidate: "enableItem/disableItem/showItem/hideItem(text)",
+            kind: "method",
+            builder: "item initial state can be builder data",
+            args: "string text, primitive string dataSource",
+            returnOrPayload: "void",
+            proof: "source calls getItemData directly; raw proof with text argument stops",
+            csharp: "",
+            outcome: "reject: text argument is not stable; object/element overloads are loose"
+        });
+        proposal({
+            candidate: "select event",
+            kind: "event",
+            builder: "Select event builder-covered for initial wiring only",
+            args: "payload",
+            returnOrPayload: "text/index/isInteracted/isChecked/cancel proven; item/event/data omitted",
+            proof: "runProof user click and cancel snapshots",
+            csharp: "FusionListViewSelectArgs",
+            outcome: "accept narrowed scalar payload"
+        });
+        proposal({
+            candidate: "getSelectedItems/findItem/addItem/removeItem/object item overloads",
+            kind: "method",
+            builder: "not static config",
+            args: "loose object or HTMLElement",
+            returnOrPayload: "DOM/data object or {[key:string]: object}",
+            proof: "d.ts/source show loose object/element contracts",
+            csharp: "",
+            outcome: "reject: loose public shape"
+        });
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("selection.functions", functionNames(selectionList));
+            record("checkbox.functions", functionNames(checkboxList));
+            record("snapshot", window.__sfListViewProbe.snapshot());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        document.getElementById("run-proof").addEventListener("click", runProof);
+
+        function step(label, action) {
+            try {
+                action();
+            } catch (error) {
+                record(label + " error", {
+                    message: error && error.message ? error.message : String(error)
+                });
+            }
+        }
+
+        async function runProof() {
+            record("initial", window.__sfListViewProbe.snapshot());
+
+            step("selectItem Bennett", () => {
+                selectionList.selectItem("Bennett");
+                record("after selectItem Bennett", listSnapshot("list-view-probe", selectionList));
+            });
+
+            step("unselectItem Bennett", () => {
+                selectionList.unselectItem("Bennett");
+                record("after unselectItem Bennett", listSnapshot("list-view-probe", selectionList));
+            });
+
+            step("user click Alice", () => {
+                clickItem("list-view-probe", "Alice");
+                record("after user click Alice", listSnapshot("list-view-probe", selectionList));
+            });
+
+            step("cancelled user click Carey", () => {
+                cancelCarey = true;
+                clickItem("list-view-probe", "Carey");
+                cancelCarey = false;
+                record("after cancelled user click Carey", listSnapshot("list-view-probe", selectionList));
+            });
+
+            step("checkItem Hydration", () => {
+                checkboxList.checkItem("Hydration");
+                record("after checkItem Hydration", listSnapshot("list-view-check-probe", checkboxList));
+            });
+
+            step("uncheckItem Hydration", () => {
+                checkboxList.uncheckItem("Hydration");
+                record("after uncheckItem Hydration", listSnapshot("list-view-check-probe", checkboxList));
+            });
+
+            step("checkAllItems", () => {
+                checkboxList.checkAllItems();
+                record("after checkAllItems", listSnapshot("list-view-check-probe", checkboxList));
+            });
+
+            step("uncheckAllItems", () => {
+                checkboxList.uncheckAllItems();
+                record("after uncheckAllItems", listSnapshot("list-view-check-probe", checkboxList));
+            });
+        }
+
+        if (new URLSearchParams(window.location.search).get("autorun") === "1") {
+            setTimeout(runProof, 0);
+        }
+
+        renderTrace();
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-menu-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-menu-probe.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Menu API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+        label { margin-right: 12px; }
+    </style>
+</head>
+<body>
+    <h1>SF Menu API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <ul id="menu"></ul>
+    </div>
+
+    <div style="margin-bottom:12px;">
+        <label><input id="block-open" type="checkbox" /> Block open</label>
+        <label><input id="block-close" type="checkbox" /> Block close</label>
+        <button id="open-menu">Open</button>
+        <button id="close-menu">Close</button>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("menu");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return { ownKeys: own, properties };
+        }
+
+        function record(label, value) {
+            trace.push({ at: new Date().toISOString(), label, value: clean(value, new WeakSet(), 0) });
+            document.getElementById("trace").textContent = JSON.stringify(trace, safeJson, 2);
+        }
+
+        const items = [
+            { id: "dashboard-item", text: "Dashboard" },
+            { id: "projects-item", text: "Projects", items: [{ id: "reports-item", text: "Reports" }, { id: "archive-item", text: "Archive" }] },
+            { id: "help-item", text: "Help" }
+        ];
+
+        const menu = new ej.navigations.Menu({
+            items,
+            hamburgerMode: true,
+            orientation: "Horizontal",
+            showItemOnClick: true,
+            title: "Resident menu",
+            animationSettings: { effect: "None", duration: 0, easing: "linear" },
+            beforeItemRender: args => record("beforeItemRender", describePayload(args)),
+            beforeOpen: args => {
+                record("beforeOpen", describePayload(args));
+                if (document.getElementById("block-open").checked) {
+                    args.cancel = true;
+                    record("beforeOpen.cancel", { cancel: args.cancel });
+                }
+            },
+            onOpen: args => record("onOpen", describePayload(args)),
+            beforeClose: args => {
+                record("beforeClose", describePayload(args));
+                if (document.getElementById("block-close").checked) {
+                    args.cancel = true;
+                    record("beforeClose.cancel", { cancel: args.cancel });
+                }
+            },
+            onClose: args => record("onClose", describePayload(args)),
+            select: args => record("select", describePayload(args))
+        });
+        menu.appendTo(target);
+        window.__sfProbe = { menu, trace, record };
+
+        document.getElementById("open-menu").addEventListener("click", () => menu.open());
+        document.getElementById("close-menu").addEventListener("click", () => menu.close());
+
+        record("ready", {
+            component: "menu",
+            namespace: "ej.navigations",
+            className: "Menu",
+            id: "menu"
+        });
+        record("own keys", Object.keys(menu).sort());
+        record("prototype methods", Object.getOwnPropertyNames(Object.getPrototypeOf(menu)).sort());
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-otp-input-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-otp-input-probe.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF OtpInput API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF OtpInput API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <div id="otp-input"></div>
+        <p>Hidden value: <span id="hidden-value"></span></p>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("otp-input");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        function inputs() {
+            return Array.from(target.querySelectorAll("input.e-otp-input-field"));
+        }
+
+        function hiddenInput() {
+            return target.querySelector("input[type='hidden']");
+        }
+
+        function snapshot(label) {
+            record(label, {
+                value: ej2.value,
+                hidden: hiddenInput()?.value || null,
+                inputs: inputs().map((input, index) => ({
+                    index,
+                    value: input.value,
+                    focused: document.activeElement === input,
+                    ariaLabel: input.getAttribute("aria-label")
+                }))
+            });
+        }
+
+        const ej2 = new ej.inputs.OtpInput({
+            length: 4,
+            value: "1234",
+            type: "text",
+            placeholder: "0000",
+            focus: args => probe.event("focus", args),
+            blur: args => probe.event("blur", args),
+            input: args => probe.event("input", args),
+            valueChanged: args => probe.event("valueChanged", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "otp-input",
+            namespace: "ej.inputs",
+            className: "OtpInput",
+            id: "otp-input"
+        });
+
+        function runValueTrace() {
+            snapshot("initial");
+
+            ej2.value = "9876";
+            snapshot("direct set before dataBind");
+            ej2.dataBind();
+            snapshot("direct set after dataBind");
+
+            const focusInResult = ej2.focusIn();
+            record("focusIn return", focusInResult);
+            snapshot("after focusIn");
+
+            const focusOutResult = ej2.focusOut();
+            record("focusOut return", focusOutResult);
+            snapshot("after focusOut");
+
+            ej2.value = "";
+            ej2.dataBind();
+            const first = inputs()[0];
+            first.focus();
+            first.value = "4";
+            first.dispatchEvent(new Event("input", { bubbles: true }));
+            const second = inputs()[1];
+            second.value = "5";
+            second.dispatchEvent(new Event("input", { bubbles: true }));
+            const third = inputs()[2];
+            third.value = "6";
+            third.dispatchEvent(new Event("input", { bubbles: true }));
+            const fourth = inputs()[3];
+            fourth.value = "7";
+            fourth.dispatchEvent(new Event("input", { bubbles: true }));
+            fourth.blur();
+            snapshot("after browser input events");
+
+            document.getElementById("hidden-value").textContent = hiddenInput()?.value || "";
+            document.getElementById("active-element").textContent =
+                document.activeElement?.className || "";
+        }
+
+        proposal({
+            candidate: "value",
+            kind: "prop-read",
+            builder: "Value() covers initial render",
+            args: "none",
+            returnOrPayload: "string when configured with string value",
+            proof: "initial",
+            csharp: "Value()",
+            outcome: "implement as string"
+        });
+        proposal({
+            candidate: "value + dataBind()",
+            kind: "prop-write + public flush method",
+            builder: "Value() covers initial render",
+            args: "string",
+            returnOrPayload: "void; hidden/input values update after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetValue(string?)",
+            outcome: "implement as string"
+        });
+        proposal({
+            candidate: "focusIn / focusOut",
+            kind: "method",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "void; browser focus changes",
+            proof: "after focusIn, after focusOut",
+            csharp: "FocusIn(), FocusOut()",
+            outcome: "implement"
+        });
+        proposal({
+            candidate: "input, valueChanged, focus, blur",
+            kind: "event payload-read",
+            builder: "builder event string hook only",
+            args: "OtpInputEventArgs / OtpChangedEventArgs / OtpFocusEventArgs",
+            returnOrPayload: "value, previousValue, index, isInteracted where present",
+            proof: "input, valueChanged, focus, blur",
+            csharp: "Input, ValueChanged, Focus, Blur",
+            outcome: "implement typed string payloads"
+        });
+
+        if (new URLSearchParams(location.search).has("autorun")) {
+            setTimeout(runValueTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-progress-button-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-progress-button-probe.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF ProgressButton API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF ProgressButton API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <button id="progress-button-probe" type="button">Initial Save</button>
+        <button id="outside-button" type="button">Outside focus target</button>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("progress-button-probe");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args))
+        };
+
+        window.__sfProbe = probe;
+
+        function delay(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
+        function progressElement() {
+            return target.querySelector(".e-progress");
+        }
+
+        function spinnerPane() {
+            return target.querySelector(".e-spinner-pane");
+        }
+
+        function snapshot(label) {
+            const progress = progressElement();
+            const spinner = spinnerPane();
+            record(label, {
+                content: ej2.content,
+                disabled: ej2.disabled,
+                cssClass: ej2.cssClass,
+                enableProgress: ej2.enableProgress,
+                duration: ej2.duration,
+                percent: ej2.percent,
+                progressTime: ej2.progressTime,
+                text: target.textContent.trim(),
+                html: target.innerHTML,
+                disabledAttribute: target.hasAttribute("disabled"),
+                className: target.className,
+                progressExists: !!progress,
+                progressWidth: progress?.style.width || null,
+                spinnerClass: spinner?.className || null,
+                active: target.classList.contains("e-progress-active"),
+                ariaValueNow: target.getAttribute("aria-valuenow"),
+                focused: document.activeElement === target
+            });
+        }
+
+        const ej2 = new ej.splitbuttons.ProgressButton({
+            content: "Initial Save",
+            cssClass: "care-progress",
+            duration: 300,
+            enableProgress: false,
+            animationSettings: { effect: "None" },
+            begin: args => probe.event("begin", args),
+            progress: args => probe.event("progress", args),
+            end: args => probe.event("end", args),
+            fail: args => probe.event("fail", args),
+            created: args => probe.event("created", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+            record("host instance", {
+                hasEj2Instances: Array.isArray(target.ej2_instances),
+                firstInstanceIsProgressButton: target.ej2_instances && target.ej2_instances[0] === ej2
+            });
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "progress-button",
+            namespace: "ej.splitbuttons",
+            className: "ProgressButton",
+            id: "progress-button-probe"
+        });
+        snapshot("initial");
+
+        async function runValueTrace() {
+            record("host instance", {
+                hasEj2Instances: Array.isArray(target.ej2_instances),
+                firstInstanceIsProgressButton: target.ej2_instances && target.ej2_instances[0] === ej2
+            });
+
+            ej2.content = "Queued Save";
+            ej2.disabled = true;
+            ej2.cssClass = "e-success extra-class";
+            ej2.enableProgress = true;
+            snapshot("direct set before dataBind");
+
+            const dataBindResult = ej2.dataBind();
+            record("dataBind return", dataBindResult);
+            snapshot("direct set after dataBind");
+
+            ej2.disabled = false;
+            ej2.dataBind();
+            snapshot("enabled after dataBind");
+
+            const startAtResult = ej2.start(60);
+            record("start at 60 return", startAtResult);
+            await delay(80);
+            snapshot("after start at 60");
+
+            const completeAfterStartAtResult = ej2.progressComplete();
+            record("progressComplete after start at 60 return", completeAfterStartAtResult);
+            await delay(80);
+            snapshot("after progressComplete from start at 60");
+
+            const startResult = ej2.start();
+            record("start return", startResult);
+            await delay(80);
+            snapshot("after start");
+
+            const completeResult = ej2.progressComplete();
+            record("progressComplete return", completeResult);
+            await delay(80);
+            snapshot("after progressComplete");
+
+            const focusResult = ej2.focusIn();
+            record("focusIn return", focusResult);
+            snapshot("after focusIn");
+
+            document.getElementById("outside-button").focus();
+            snapshot("after outside focus");
+
+            record("summary", {
+                finalContent: ej2.content,
+                finalDisabled: ej2.disabled,
+                finalCssClass: ej2.cssClass,
+                finalEnableProgress: ej2.enableProgress,
+                beginEventCount: trace.filter(entry => entry.label === "begin").length,
+                progressEventCount: trace.filter(entry => entry.label === "progress").length,
+                endEventCount: trace.filter(entry => entry.label === "end").length,
+                hostInstanceStored: target.ej2_instances && target.ej2_instances[0] === ej2
+            });
+        }
+
+        proposal({
+            candidate: "ej2.content",
+            kind: "property read/write",
+            builder: "Content",
+            args: "string + dataBind()",
+            returnOrPayload: "string",
+            proof: "Trace compares content span text before and after dataBind.",
+            csharp: "Content(), SetContent(string)",
+            outcome: "onboard if browser trace updates visible text"
+        });
+        proposal({
+            candidate: "ej2.disabled",
+            kind: "property read/write",
+            builder: "Disabled",
+            args: "bool + dataBind()",
+            returnOrPayload: "bool",
+            proof: "Trace compares disabled attribute before and after dataBind.",
+            csharp: "Disabled(), SetDisabled(bool)",
+            outcome: "onboard if browser trace updates native disabled state"
+        });
+        proposal({
+            candidate: "ej2.cssClass",
+            kind: "property read/write",
+            builder: "CssClass",
+            args: "string + dataBind()",
+            returnOrPayload: "string",
+            proof: "Trace compares button classes before and after dataBind.",
+            csharp: "CssClass(), SetCssClass(string)",
+            outcome: "onboard if browser trace updates rendered classes"
+        });
+        proposal({
+            candidate: "ej2.enableProgress",
+            kind: "property read/write",
+            builder: "EnableProgress",
+            args: "bool + dataBind()",
+            returnOrPayload: "bool",
+            proof: "Trace verifies progress span creation after dataBind.",
+            csharp: "ProgressEnabled(), SetProgressEnabled(bool)",
+            outcome: "onboard if browser trace creates progress filler"
+        });
+        proposal({
+            candidate: "ej2.start()",
+            kind: "method",
+            builder: "-",
+            args: "none",
+            returnOrPayload: "undefined; begin/progress events and progress-active class",
+            proof: "Trace captures begin event and active state after start.",
+            csharp: "Start()",
+            outcome: "onboard if browser trace starts progress"
+        });
+        proposal({
+            candidate: "ej2.start(60)",
+            kind: "method",
+            builder: "-",
+            args: "number",
+            returnOrPayload: "undefined; progress event starts from provided percent",
+            proof: "Trace captures progress event with percent near 60.",
+            csharp: "StartAt(double percent)",
+            outcome: "onboard as mapped overload if browser trace starts at percent"
+        });
+        proposal({
+            candidate: "ej2.progressComplete()",
+            kind: "method",
+            builder: "-",
+            args: "none",
+            returnOrPayload: "undefined; end event percent 100",
+            proof: "Trace captures end event and inactive state after completion.",
+            csharp: "ProgressComplete()",
+            outcome: "onboard if browser trace completes progress"
+        });
+        proposal({
+            candidate: "ej2.focusIn()",
+            kind: "method",
+            builder: "-",
+            args: "none",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies document.activeElement is the button.",
+            csharp: "FocusIn()",
+            outcome: "onboard if browser trace focuses host"
+        });
+        proposal({
+            candidate: "begin/progress/end",
+            kind: "events",
+            builder: "Begin/Progress/End",
+            args: "ProgressEventArgs",
+            returnOrPayload: "percent, currentDuration, step",
+            proof: "Trace captures event payloads during start/startAt/progressComplete.",
+            csharp: "Began/Progressed/Ended(FusionProgressButtonProgressArgs)",
+            outcome: "onboard only typed numeric payload fields"
+        });
+
+        if (new URLSearchParams(window.location.search).has("autorun")) {
+            window.addEventListener("load", () => {
+                setTimeout(() => runValueTrace(), 250);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-radio-button-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-radio-button-probe.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF RadioButton API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF RadioButton API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <input id="radio-button-a" type="radio" />
+        <input id="radio-button-b" type="radio" />
+        <button id="outside-button" type="button">Outside focus target</button>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("radio-button-a");
+        const secondTarget = document.getElementById("radio-button-b");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        function wrapper(input) {
+            return input.closest(".e-radio-wrapper");
+        }
+
+        function label(input) {
+            return wrapper(input)?.querySelector("label");
+        }
+
+        function snapshot(labelText) {
+            record(labelText, {
+                first: {
+                    checked: first.checked,
+                    disabled: first.disabled,
+                    value: first.value,
+                    selectedValue: first.getSelectedValue(),
+                    inputChecked: target.checked,
+                    inputDisabled: target.disabled,
+                    inputValue: target.value,
+                    wrapperClass: wrapper(target)?.className || null,
+                    focused: document.activeElement === target
+                },
+                second: {
+                    checked: second.checked,
+                    disabled: second.disabled,
+                    value: second.value,
+                    selectedValue: second.getSelectedValue(),
+                    inputChecked: secondTarget.checked,
+                    inputDisabled: secondTarget.disabled,
+                    inputValue: secondTarget.value,
+                    wrapperClass: wrapper(secondTarget)?.className || null,
+                    focused: document.activeElement === secondTarget
+                }
+            });
+        }
+
+        const first = new ej.buttons.RadioButton({
+            label: "Private room",
+            name: "roomType",
+            value: "Private",
+            checked: false,
+            change: args => probe.event("first change", args),
+            created: args => probe.event("first created", args)
+        });
+        first.appendTo(target);
+
+        const second = new ej.buttons.RadioButton({
+            label: "Shared room",
+            name: "roomType",
+            value: "Shared",
+            checked: false,
+            change: args => probe.event("second change", args),
+            created: args => probe.event("second created", args)
+        });
+        second.appendTo(secondTarget);
+
+        probe.ej2 = first;
+        probe.first = first;
+        probe.second = second;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(first).sort());
+            const proto = Object.getPrototypeOf(first);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "radio-button",
+            namespace: "ej.buttons",
+            className: "RadioButton",
+            id: "radio-button-a"
+        });
+        snapshot("initial");
+
+        function runValueTrace() {
+            first.checked = true;
+            first.disabled = true;
+            snapshot("direct set before dataBind");
+
+            const dataBindResult = first.dataBind();
+            record("first dataBind return", dataBindResult);
+            snapshot("direct set after dataBind");
+
+            const disabledClickResult = first.click();
+            record("first click while disabled return", disabledClickResult);
+            snapshot("after disabled click");
+
+            first.disabled = false;
+            first.checked = false;
+            first.dataBind();
+            snapshot("reset after dataBind");
+
+            const secondClickResult = second.click();
+            record("second click return", secondClickResult);
+            snapshot("after second click");
+
+            const firstClickResult = first.click();
+            record("first click return", firstClickResult);
+            snapshot("after first click");
+
+            document.getElementById("outside-button").focus();
+            const focusResult = first.focusIn();
+            record("first focusIn return", focusResult);
+            snapshot("after focusIn");
+
+            document.getElementById("active-element").textContent =
+                document.activeElement?.id || "";
+        }
+
+        proposal({
+            candidate: "checked + dataBind()",
+            kind: "prop-read/write + public flush method",
+            builder: "checked covers initial render",
+            args: "bool",
+            returnOrPayload: "bool; input checked update and group uncheck after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetChecked(bool), Checked()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "disabled + dataBind()",
+            kind: "prop-read/write + public flush method",
+            builder: "Disabled() covers initial render",
+            args: "bool",
+            returnOrPayload: "bool; disabled attribute updates after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetDisabled(bool), Disabled()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "getSelectedValue()",
+            kind: "method-return source",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "string selected value for radio group",
+            proof: "after second click, after first click",
+            csharp: "SelectedValue()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "click()",
+            kind: "method",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "void; selects radio and fires change when enabled",
+            proof: "first click return, after first click, first change",
+            csharp: "Click()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "focusIn()",
+            kind: "method",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "void; input receives focus",
+            proof: "after focusIn",
+            csharp: "FocusIn()",
+            outcome: "implement if stable"
+        });
+        proposal({
+            candidate: "change.value",
+            kind: "event payload-read",
+            builder: "Change(string) wires a static handler",
+            args: "ChangeArgs",
+            returnOrPayload: "value string; event object excluded",
+            proof: "first change, second change",
+            csharp: "Changed with FusionRadioButtonChangeArgs.Value",
+            outcome: "implement if stable"
+        });
+
+        if (new URLSearchParams(location.search).has("autorun")) {
+            setTimeout(runValueTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-rating-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-rating-probe.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Rating API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Rating API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <input id="rating" />
+        <p>Element value: <span id="element-value"></span></p>
+        <p>ARIA value: <span id="aria-value"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("rating");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        function snapshot(label) {
+            const itemList = document.querySelector(".e-rating-item-list");
+            const valueItems = Array.from(document.querySelectorAll(".e-rating-item-container")).map(item => ({
+                value: item.getAttribute("data-value"),
+                selected: item.classList.contains("e-selected-value"),
+                styleValue: item.querySelector(".e-rating-item")?.style.getPropertyValue("--rating-value") || null
+            }));
+            record(label, {
+                value: ej2.value,
+                currentValue: ej2.currentValue,
+                elementValue: target.getAttribute("value"),
+                ariaValue: itemList ? itemList.getAttribute("aria-valuenow") : null,
+                items: valueItems
+            });
+        }
+
+        const ej2 = new ej.inputs.Rating({
+            value: 2,
+            allowReset: true,
+            showLabel: true,
+            valueChanged: args => probe.event("valueChanged", args),
+            onItemHover: args => probe.event("onItemHover", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "rating",
+            namespace: "ej.inputs",
+            className: "Rating",
+            id: "rating"
+        });
+
+        function runValueTrace() {
+            snapshot("initial");
+
+            ej2.value = 4;
+            snapshot("direct set before dataBind");
+            ej2.dataBind();
+            snapshot("direct set after dataBind");
+
+            ej2.value = 3;
+            ej2.dataBind();
+            snapshot("second set after dataBind");
+
+            const resetResult = ej2.reset();
+            record("reset return", resetResult);
+            snapshot("after reset");
+
+            document.getElementById("element-value").textContent = target.getAttribute("value");
+            document.getElementById("aria-value").textContent =
+                document.querySelector(".e-rating-item-list")?.getAttribute("aria-valuenow") || "";
+        }
+
+        proposal({
+            candidate: "value",
+            kind: "prop-read",
+            builder: "Value() covers initial render",
+            args: "none",
+            returnOrPayload: "number",
+            proof: "initial",
+            csharp: "Value()",
+            outcome: "implement"
+        });
+        proposal({
+            candidate: "value + dataBind()",
+            kind: "prop-write + public flush method",
+            builder: "Value() covers initial render",
+            args: "number",
+            returnOrPayload: "void; element value and ARIA update after dataBind",
+            proof: "direct set after dataBind",
+            csharp: "SetValue(double)",
+            outcome: "implement"
+        });
+        proposal({
+            candidate: "reset()",
+            kind: "method",
+            builder: "not covered",
+            args: "none",
+            returnOrPayload: "void; value resets to min",
+            proof: "reset return, after reset",
+            csharp: "Reset()",
+            outcome: "implement"
+        });
+        proposal({
+            candidate: "valueChanged",
+            kind: "event payload-read",
+            builder: "builder event string hook only",
+            args: "RatingChangedEventArgs",
+            returnOrPayload: "value, previousValue, isInteracted",
+            proof: "valueChanged",
+            csharp: "ValueChanged",
+            outcome: "implement"
+        });
+
+        if (new URLSearchParams(location.search).has("autorun")) {
+            setTimeout(runValueTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-sidebar-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-sidebar-probe.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Sidebar API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { position: relative; width: 560px; min-height: 240px; border: 1px solid #d0d7de; margin-bottom: 16px; overflow: hidden; }
+        #content { padding: 16px; min-height: 240px; background: #f8fafc; }
+        #sidebar { background: #111827; color: #fff; height: 240px; padding: 16px; box-sizing: border-box; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Sidebar API Probe</h1>
+    <p>Trace the runtime surface before onboarding typed Fusion API.</p>
+
+    <div id="host">
+        <aside id="sidebar">
+            <h2>Sidebar</h2>
+            <p>Probe content.</p>
+        </aside>
+        <main id="content">Main content</main>
+    </div>
+
+    <div>
+        <button id="show">Show</button>
+        <button id="hide">Hide</button>
+        <button id="toggle">Toggle</button>
+        <button id="cancel-next-close">Cancel next close</button>
+        <button id="clear">Clear Trace</button>
+    </div>
+
+    <h2>Trace Matrix</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Proof</th>
+                <th>Typed Fusion API</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const rows = [];
+        const target = document.getElementById("sidebar");
+        let cancelNextClose = false;
+        let sidebar;
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return { ownKeys: own, properties };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            document.getElementById("trace").textContent = JSON.stringify(trace, null, 2);
+        }
+
+        window.__sfProbe = {
+            trace,
+            record,
+            event: (label, args) => record(label, describePayload(args)),
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke())
+        };
+
+        function addRow(row) {
+            rows.push(row);
+            const tr = document.createElement("tr");
+            [row.candidate, row.kind, row.builder, row.proof, row.csharp, row.outcome].forEach(value => {
+                const td = document.createElement("td");
+                td.textContent = value;
+                tr.appendChild(td);
+            });
+            document.getElementById("proposal-body").appendChild(tr);
+        }
+
+        sidebar = new ej.navigations.Sidebar({
+            isOpen: false,
+            animate: false,
+            enableGestures: false,
+            showBackdrop: false,
+            type: "Over",
+            width: "240px",
+            open: args => {
+                record("open", describePayload(args));
+                record("isOpen.read", sidebar.isOpen);
+            },
+            close: args => {
+                record("close", describePayload(args));
+                if (cancelNextClose) {
+                    args.cancel = true;
+                    cancelNextClose = false;
+                    record("close.cancelled", {
+                        cancel: args.cancel,
+                        isOpen: sidebar.isOpen
+                    });
+                }
+                record("isOpen.read", sidebar.isOpen);
+            }
+        });
+
+        sidebar.appendTo(target);
+        record("ready", {
+            component: "sidebar",
+            namespace: "ej.navigations",
+            className: "Sidebar",
+            id: "sidebar",
+            isOpen: sidebar.isOpen,
+            methods: Object.getOwnPropertyNames(Object.getPrototypeOf(sidebar)).sort()
+        });
+
+        document.getElementById("show").addEventListener("click", () => {
+            sidebar.show();
+            record("after-show-call", {
+                isOpen: sidebar.isOpen,
+                className: target.className,
+                classes: Array.from(target.classList).sort()
+            });
+        });
+
+        document.getElementById("hide").addEventListener("click", () => {
+            sidebar.hide();
+            record("after-hide-call", {
+                isOpen: sidebar.isOpen,
+                className: target.className,
+                classes: Array.from(target.classList).sort()
+            });
+        });
+
+        document.getElementById("toggle").addEventListener("click", () => {
+            sidebar.toggle();
+            record("after-toggle-call", {
+                isOpen: sidebar.isOpen,
+                className: target.className,
+                classes: Array.from(target.classList).sort()
+            });
+        });
+
+        document.getElementById("cancel-next-close").addEventListener("click", () => {
+            cancelNextClose = true;
+            record("cancel-next-close", { cancelNextClose });
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            document.getElementById("trace").textContent = "";
+        });
+
+        addRow({
+            candidate: "isOpen read",
+            kind: "prop-read",
+            builder: "static-only",
+            proof: "sidebar.isOpen changes with show/hide/toggle",
+            csharp: "IsOpen()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "show()",
+            kind: "method",
+            builder: "runtime",
+            proof: "Show button opens the sidebar and fires open",
+            csharp: "Show()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "hide()",
+            kind: "method",
+            builder: "runtime",
+            proof: "Hide button closes the sidebar and fires close",
+            csharp: "Hide()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "toggle()",
+            kind: "method",
+            builder: "runtime",
+            proof: "Toggle button alternates open and closed state",
+            csharp: "Toggle()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "close.cancel",
+            kind: "payload-write",
+            builder: "runtime",
+            proof: "Cancel next close keeps isOpen true after hide()",
+            csharp: "PreventTransition()",
+            outcome: "implement"
+        });
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-slider-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-slider-probe.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Slider API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Slider API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <h2>Default scalar slider</h2>
+        <div id="slider"></div>
+        <p>Scalar hidden value: <span id="scalar-hidden"></span></p>
+        <p>Scalar handle aria: <span id="scalar-aria"></span></p>
+
+        <h2>Range slider</h2>
+        <div id="range-slider"></div>
+        <p>Range hidden value: <span id="range-hidden"></span></p>
+        <p>Range handle aria: <span id="range-aria"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("slider");
+        const rangeTarget = document.getElementById("range-slider");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        function hiddenValue(host) {
+            const input = host.parentElement.querySelector("input.e-slider-input");
+            return input ? input.value : null;
+        }
+
+        function handleAria(host) {
+            return Array.from(host.querySelectorAll(".e-handle")).map(handle => ({
+                valueNow: handle.getAttribute("aria-valuenow"),
+                valueText: handle.getAttribute("aria-valuetext")
+            }));
+        }
+
+        function snapshot(label, instance, host) {
+            const value = Array.isArray(instance.value) ? instance.value.slice() : instance.value;
+            record(label, {
+                value,
+                hidden: hiddenValue(host),
+                aria: handleAria(host),
+                firstHandleLeft: host.querySelector(".e-handle")?.style.left || null,
+                rangeBarLeft: host.querySelector(".e-range")?.style.left || null,
+                rangeBarWidth: host.querySelector(".e-range")?.style.width || null
+            });
+            return value;
+        }
+
+        const ej2 = new ej.inputs.Slider({
+            min: 0,
+            max: 100,
+            step: 5,
+            value: 25,
+            change: args => probe.event("scalar change", args),
+            changed: args => probe.event("scalar changed", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        const rangeEj2 = new ej.inputs.Slider({
+            min: 0,
+            max: 100,
+            step: 5,
+            type: "Range",
+            value: [20, 60],
+            change: args => probe.event("range change", args),
+            changed: args => probe.event("range changed", args)
+        });
+        rangeEj2.appendTo(rangeTarget);
+        probe.rangeEj2 = rangeEj2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "slider",
+            namespace: "ej.inputs",
+            className: "Slider",
+            id: "slider"
+        });
+
+        function runValueTrace() {
+            snapshot("scalar initial", ej2, target);
+
+            ej2.value = 40;
+            snapshot("scalar direct set before dataBind", ej2, target);
+            ej2.dataBind();
+            snapshot("scalar direct set after dataBind", ej2, target);
+
+            ej2.value = 55;
+            ej2.dataBind();
+            snapshot("scalar second set after dataBind", ej2, target);
+
+            snapshot("range initial", rangeEj2, rangeTarget);
+
+            rangeEj2.value = [15, 75];
+            snapshot("range direct set before dataBind", rangeEj2, rangeTarget);
+            rangeEj2.dataBind();
+            snapshot("range direct set after dataBind", rangeEj2, rangeTarget);
+
+            rangeEj2.value = [30, 90];
+            rangeEj2.dataBind();
+            snapshot("range second set after dataBind", rangeEj2, rangeTarget);
+
+            document.getElementById("scalar-hidden").textContent = hiddenValue(target);
+            document.getElementById("scalar-aria").textContent = JSON.stringify(handleAria(target));
+            document.getElementById("range-hidden").textContent = hiddenValue(rangeTarget);
+            document.getElementById("range-aria").textContent = JSON.stringify(handleAria(rangeTarget));
+        }
+
+        proposal({
+            candidate: "value",
+            kind: "prop-read",
+            builder: "Value() covers initial render",
+            args: "none",
+            returnOrPayload: "number for Default/MinRange, number[] for Range",
+            proof: "scalar initial, range initial",
+            csharp: "Value(), RangeValue()",
+            outcome: "implement with separate typed APIs"
+        });
+        proposal({
+            candidate: "value + dataBind()",
+            kind: "prop-write + public flush method",
+            builder: "Value() covers initial render",
+            args: "number or number[]",
+            returnOrPayload: "void; hidden input and handle aria update after dataBind",
+            proof: "scalar direct set after dataBind, range direct set after dataBind",
+            csharp: "SetValue(double), SetRangeValue(double, double)",
+            outcome: "implement with separate typed APIs"
+        });
+        proposal({
+            candidate: "change / changed",
+            kind: "event payload-read",
+            builder: "builder event string hook only",
+            args: "SliderChangeEventArgs",
+            returnOrPayload: "scalar value, previousValue, text, action, isInteracted",
+            proof: "scalar change, scalar changed",
+            csharp: "Change, Changed",
+            outcome: "implement scalar typed events; range event excluded from this slice"
+        });
+
+        if (new URLSearchParams(location.search).has("autorun")) {
+            setTimeout(runValueTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-split-button-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-split-button-probe.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF SplitButton API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF SplitButton API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <button id="split-button-probe" type="button">Initial Action</button>
+        <button id="outside-button" type="button">Outside focus target</button>
+        <p>Active element: <span id="active-element"></span></p>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("split-button-probe");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            if (args === null || args === undefined) {
+                return {
+                    ownKeys: [],
+                    functions: [],
+                    properties: {}
+                };
+            }
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args))
+        };
+
+        window.__sfProbe = probe;
+
+        function secondary() {
+            return document.getElementById(target.id + "_dropdownbtn");
+        }
+
+        function popup() {
+            return document.getElementById(target.id + "_dropdownbtn-popup");
+        }
+
+        function wrapper() {
+            return target.closest(".e-split-btn-wrapper");
+        }
+
+        function isOpen() {
+            return popup()?.classList.contains("e-popup-open") || false;
+        }
+
+        function ensureOpen() {
+            if (!isOpen()) {
+                ej2.toggle();
+            }
+        }
+
+        function ensureClosed() {
+            if (isOpen()) {
+                ej2.toggle();
+            }
+        }
+
+        function items() {
+            return Array.from(popup()?.querySelectorAll("li.e-item") || []).map(li => ({
+                id: li.id,
+                text: li.textContent.trim(),
+                disabled: li.classList.contains("e-disabled"),
+                className: li.className
+            }));
+        }
+
+        function itemTexts() {
+            return ej2.items.map(item => item.text);
+        }
+
+        function snapshot(label) {
+            const popupElement = popup();
+            const secondaryElement = secondary();
+            const wrapperElement = wrapper();
+            record(label, {
+                content: ej2.content,
+                disabled: ej2.disabled,
+                cssClass: ej2.cssClass,
+                items: ej2.items.map(item => ({
+                    id: item.id,
+                    text: item.text,
+                    disabled: item.disabled,
+                    separator: item.separator
+                })),
+                text: target.textContent.trim(),
+                html: target.innerHTML,
+                disabledAttribute: target.hasAttribute("disabled"),
+                className: target.className,
+                wrapperClass: wrapperElement?.className || null,
+                secondaryExists: !!secondaryElement,
+                secondaryDisabled: secondaryElement?.hasAttribute("disabled") || false,
+                secondaryClass: secondaryElement?.className || null,
+                secondaryAriaExpanded: secondaryElement?.getAttribute("aria-expanded") || null,
+                popupClass: popupElement?.className || null,
+                popupOpen: popupElement?.classList.contains("e-popup-open") || false,
+                popupClose: popupElement?.classList.contains("e-popup-close") || false,
+                popupItems: items(),
+                primaryAriaExpanded: target.getAttribute("aria-expanded"),
+                focused: document.activeElement === target
+            });
+        }
+
+        const ej2 = new ej.splitbuttons.SplitButton({
+            content: "Initial Action",
+            cssClass: "care-split-actions",
+            animationSettings: { effect: "None" },
+            items: [
+                { id: "assign", text: "Assign nurse" },
+                { id: "schedule", text: "Schedule visit" },
+                { id: "hold", text: "Place hold", disabled: true }
+            ],
+            beforeItemRender: args => probe.event("beforeItemRender", args),
+            beforeOpen: args => probe.event("beforeOpen", args),
+            open: args => probe.event("open", args),
+            beforeClose: args => probe.event("beforeClose", args),
+            close: args => probe.event("close", args),
+            click: args => probe.event("click", args),
+            select: args => probe.event("select", args),
+            created: args => probe.event("created", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+            record("host instance", {
+                hasEj2Instances: Array.isArray(target.ej2_instances),
+                firstInstanceIsSplitButton: target.ej2_instances && target.ej2_instances[0] === ej2,
+                wrapperClass: wrapper()?.className || null,
+                secondaryId: secondary()?.id || null
+            });
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "split-button",
+            namespace: "ej.splitbuttons",
+            className: "SplitButton",
+            id: "split-button-probe"
+        });
+        snapshot("initial");
+
+        function runValueTrace() {
+            record("host instance", {
+                hasEj2Instances: Array.isArray(target.ej2_instances),
+                firstInstanceIsSplitButton: target.ej2_instances && target.ej2_instances[0] === ej2,
+                wrapperClass: wrapper()?.className || null,
+                secondaryId: secondary()?.id || null
+            });
+
+            ej2.content = "Primary Review";
+            ej2.disabled = true;
+            ej2.cssClass = "e-success extra-class";
+            snapshot("direct set before dataBind");
+
+            const dataBindResult = ej2.dataBind();
+            record("dataBind return", dataBindResult);
+            snapshot("direct set after dataBind");
+
+            ej2.disabled = false;
+            ej2.dataBind();
+            snapshot("enabled after dataBind");
+
+            const primaryClickResult = target.click();
+            record("primary native click return", primaryClickResult);
+            snapshot("after primary click");
+
+            ensureClosed();
+            const openResult = ej2.toggle();
+            record("toggle open return", openResult);
+            snapshot("after toggle open");
+
+            const closeResult = ej2.toggle();
+            record("toggle close return", closeResult);
+            snapshot("after toggle close");
+
+            const focusResult = ej2.focusIn();
+            record("focusIn return", focusResult);
+            snapshot("after focusIn");
+
+            const removeTextResult = ej2.removeItems(["Schedule visit"], false);
+            record("removeItems by text return", removeTextResult);
+            ensureOpen();
+            snapshot("after removeItems by text and open");
+            ensureClosed();
+            snapshot("after close post text removal");
+
+            const removeIdResult = ej2.removeItems(["hold"], true);
+            record("removeItems by id return", removeIdResult);
+            ensureOpen();
+            snapshot("after removeItems by id and open");
+
+            const selectTarget = Array.from(popup().querySelectorAll("li.e-item"))
+                .find(li => li.textContent.trim() === "Assign nurse");
+            selectTarget.click();
+            snapshot("after item click");
+
+            document.getElementById("outside-button").focus();
+            snapshot("after outside focus");
+
+            record("summary", {
+                finalContent: ej2.content,
+                finalDisabled: ej2.disabled,
+                finalCssClass: ej2.cssClass,
+                finalItemTexts: itemTexts(),
+                clickEventCount: trace.filter(entry => entry.label === "click").length,
+                selectedEventCount: trace.filter(entry => entry.label === "select").length,
+                hostInstanceStored: target.ej2_instances && target.ej2_instances[0] === ej2
+            });
+        }
+
+        proposal({
+            candidate: "ej2.content",
+            kind: "property read/write",
+            builder: "Content",
+            args: "string + dataBind()",
+            returnOrPayload: "string",
+            proof: "Trace compares primary button DOM text before and after dataBind.",
+            csharp: "Content(), SetContent(string)",
+            outcome: "onboard if browser trace updates visible primary text"
+        });
+        proposal({
+            candidate: "ej2.disabled",
+            kind: "property read/write",
+            builder: "Disabled",
+            args: "bool + dataBind()",
+            returnOrPayload: "bool",
+            proof: "Trace compares primary/secondary disabled attributes before and after dataBind.",
+            csharp: "Disabled(), SetDisabled(bool)",
+            outcome: "onboard if browser trace updates both button disabled states"
+        });
+        proposal({
+            candidate: "ej2.cssClass",
+            kind: "property read/write",
+            builder: "CssClass",
+            args: "string + dataBind()",
+            returnOrPayload: "string",
+            proof: "Trace compares wrapper/button/popup classes before and after dataBind.",
+            csharp: "CssClass(), SetCssClass(string)",
+            outcome: "onboard if browser trace updates rendered classes"
+        });
+        proposal({
+            candidate: "ej2.toggle()",
+            kind: "method",
+            builder: "-",
+            args: "none",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies popup open/close class changes.",
+            csharp: "Toggle()",
+            outcome: "onboard if browser trace toggles popup"
+        });
+        proposal({
+            candidate: "ej2.focusIn()",
+            kind: "method",
+            builder: "-",
+            args: "none",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies document.activeElement is the primary button.",
+            csharp: "FocusIn()",
+            outcome: "onboard if browser trace focuses primary host"
+        });
+        proposal({
+            candidate: "ej2.removeItems(string[], false)",
+            kind: "method",
+            builder: "-",
+            args: "string[]",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies named item is absent from the next popup render.",
+            csharp: "RemoveItemsByText(params string[])",
+            outcome: "onboard if browser trace removes by text"
+        });
+        proposal({
+            candidate: "ej2.removeItems(string[], true)",
+            kind: "method",
+            builder: "-",
+            args: "string[]",
+            returnOrPayload: "undefined",
+            proof: "Trace verifies id item is absent from the next popup render.",
+            csharp: "RemoveItemsById(params string[])",
+            outcome: "onboard if browser trace removes by id"
+        });
+        proposal({
+            candidate: "click",
+            kind: "event",
+            builder: "Click",
+            args: "ClickEventArgs",
+            returnOrPayload: "event notification; HTMLElement intentionally not exposed",
+            proof: "Trace captures click payload after a real primary button click.",
+            csharp: "Clicked(FusionSplitButtonClickArgs)",
+            outcome: "onboard notification only, not HTMLElement"
+        });
+        proposal({
+            candidate: "select",
+            kind: "event",
+            builder: "Select",
+            args: "MenuEventArgs",
+            returnOrPayload: "item.id, item.text, item.disabled",
+            proof: "Trace captures select payload after a real popup item click.",
+            csharp: "Selected(FusionSplitButtonSelectArgs)",
+            outcome: "onboard only typed item fields, not HTMLElement/Event"
+        });
+
+        if (new URLSearchParams(window.location.search).has("autorun")) {
+            window.addEventListener("load", () => {
+                setTimeout(runValueTrace, 250);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-stepper-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-stepper-probe.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Stepper API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; margin-bottom: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Stepper API Probe</h1>
+    <p>Trace the runtime surface before promoting it into typed Fusion API.</p>
+
+    <div id="host">
+        <div id="stepper"></div>
+    </div>
+
+    <h2>Trace Matrix</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return / Payload</th>
+                <th>Proof</th>
+                <th>Typed Fusion API</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <div>
+        <button id="set-review">Set Review</button>
+        <button id="next">Next</button>
+        <button id="previous">Previous</button>
+        <button id="reset">Reset</button>
+        <button id="refresh">Refresh</button>
+        <button id="dump">Dump Keys</button>
+        <button id="clear">Clear Trace</button>
+    </div>
+
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const rows = [];
+        const target = document.getElementById("stepper");
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return { ownKeys: own, properties };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            document.getElementById("trace").textContent = JSON.stringify(trace, null, 2);
+        }
+
+        function addRow(row) {
+            rows.push(row);
+            const tr = document.createElement("tr");
+            [row.candidate, row.kind, row.builder, row.args, row.returnOrPayload, row.proof, row.csharp, row.outcome].forEach(value => {
+                const td = document.createElement("td");
+                td.textContent = value;
+                tr.appendChild(td);
+            });
+            document.getElementById("proposal-body").appendChild(tr);
+        }
+
+        const ej2 = new ej.navigations.Stepper({
+            steps: [
+                { text: "1", label: "Intake", status: "InProgress" },
+                { text: "2", label: "Review", status: "NotStarted" },
+                { text: "3", label: "Complete", status: "NotStarted" }
+            ],
+            activeStep: 0,
+            cssClass: "rounded-md",
+            orientation: "Horizontal",
+            stepType: "Default",
+            labelPosition: "Bottom",
+            stepChanging: args => {
+                record("stepChanging", describePayload(args));
+                document.getElementById("step-changing-active").textContent = String(args.activeStep);
+                document.getElementById("step-changing-previous").textContent = String(args.previousStep);
+                document.getElementById("step-changing-interacted").textContent = String(args.isInteracted);
+                if (args.activeStep === 2 && !args.isInteracted) {
+                    args.cancel = true;
+                    document.getElementById("step-changing-guard").textContent = "blocked";
+                    record("stepChanging.cancel", {
+                        activeStep: args.activeStep,
+                        previousStep: args.previousStep,
+                        isInteracted: args.isInteracted,
+                        cancel: args.cancel
+                    });
+                } else {
+                    document.getElementById("step-changing-guard").textContent = "allowed";
+                }
+            },
+            stepClick: args => {
+                record("stepClick", describePayload(args));
+                document.getElementById("step-click-state").textContent = "clicked";
+                document.getElementById("step-click-active").textContent = String(args.activeStep);
+                document.getElementById("step-click-previous").textContent = String(args.previousStep);
+                document.getElementById("active-step-echo").textContent = String(ej2.activeStep);
+            },
+            stepChanged: args => {
+                record("stepChanged", describePayload(args));
+                document.getElementById("active-step-echo").textContent = String(ej2.activeStep);
+                document.getElementById("current-step").textContent = String(args.activeStep);
+                document.getElementById("step-changed-state").textContent = "changed";
+                document.getElementById("step-changed-active").textContent = String(args.activeStep);
+                document.getElementById("step-changed-previous").textContent = String(args.previousStep);
+                document.getElementById("step-changed-interacted").textContent = String(args.isInteracted);
+            }
+        });
+
+        ej2.appendTo(target);
+
+        document.getElementById("set-review").addEventListener("click", () => {
+            ej2.activeStep = 1;
+            record("activeStep.write", ej2.activeStep);
+            document.getElementById("command-state").textContent = "set review";
+        });
+
+        document.getElementById("next").addEventListener("click", () => {
+            ej2.nextStep();
+            record("activeStep.read", ej2.activeStep);
+            document.getElementById("command-state").textContent = "next";
+        });
+
+        document.getElementById("previous").addEventListener("click", () => {
+            ej2.previousStep();
+            record("activeStep.read", ej2.activeStep);
+            document.getElementById("command-state").textContent = "previous";
+        });
+
+        document.getElementById("reset").addEventListener("click", () => {
+            ej2.reset();
+            record("activeStep.read", ej2.activeStep);
+            document.getElementById("command-state").textContent = "reset";
+        });
+
+        document.getElementById("refresh").addEventListener("click", () => {
+            ej2.refreshProgressbar();
+            record("activeStep.read", ej2.activeStep);
+            document.getElementById("progress-state").textContent = "refreshed";
+            document.getElementById("command-state").textContent = "refresh";
+        });
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            record("prototype methods", Object.getOwnPropertyNames(Object.getPrototypeOf(ej2)).sort());
+            record("activeStep.read", ej2.activeStep);
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            document.getElementById("trace").textContent = "";
+        });
+
+        record("ready", {
+            component: "stepper",
+            namespace: "ej.navigations",
+            className: "Stepper",
+            id: "stepper"
+        });
+
+        addRow({
+            candidate: "activeStep read",
+            kind: "prop-read",
+            builder: "static-only",
+            args: "none",
+            returnOrPayload: "int",
+            proof: "load trace and dump keys show activeStep is readable",
+            csharp: "ActiveStep()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "activeStep write",
+            kind: "prop-write",
+            builder: "static-only",
+            args: "1",
+            returnOrPayload: "stepper updates to review",
+            proof: "Set Review updates activeStep and the rendered echo without a validation helper",
+            csharp: "SetActiveStep(1)",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "nextStep()",
+            kind: "method",
+            builder: "runtime",
+            args: "none",
+            returnOrPayload: "void",
+            proof: "Next from review to complete is blocked by stepChanging.cancel",
+            csharp: "NextStep()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "previousStep()",
+            kind: "method",
+            builder: "runtime",
+            args: "none",
+            returnOrPayload: "void",
+            proof: "Previous moves the active step back one index",
+            csharp: "PreviousStep()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "reset()",
+            kind: "method",
+            builder: "runtime",
+            args: "none",
+            returnOrPayload: "void",
+            proof: "Reset returns the stepper to index 0",
+            csharp: "Reset()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "refreshProgressbar()",
+            kind: "method",
+            builder: "runtime",
+            args: "none",
+            returnOrPayload: "void",
+            proof: "Refresh executes after state changes without throwing",
+            csharp: "RefreshProgressbar()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "stepChanging.cancel",
+            kind: "payload-write",
+            builder: "runtime",
+            args: "args.cancel = true",
+            returnOrPayload: "transition blocked",
+            proof: "programmatic next to step 2 is blocked while user step clicks are allowed",
+            csharp: "PreventDefault()",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "stepChanging payload",
+            kind: "payload-read",
+            builder: "runtime",
+            args: "activeStep, previousStep, isInteracted",
+            returnOrPayload: "typed payload",
+            proof: "trace shows stepChanging payload fields on every transition attempt",
+            csharp: "FusionStepperChangingArgs",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "stepChanged payload",
+            kind: "payload-read",
+            builder: "runtime",
+            args: "activeStep, previousStep, isInteracted",
+            returnOrPayload: "typed payload",
+            proof: "trace shows stepChanged payload fields after each accepted transition",
+            csharp: "FusionStepperChangedArgs",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "stepClick payload",
+            kind: "payload-read",
+            builder: "runtime",
+            args: "activeStep, previousStep",
+            returnOrPayload: "typed payload",
+            proof: "clicking the Complete step records the current and previous indices",
+            csharp: "FusionStepperClickArgs",
+            outcome: "implement"
+        });
+
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-text-area-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-text-area-probe.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF TextArea API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF TextArea API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <textarea id="text-area"></textarea>
+        <div style="margin-top: 12px;">
+            <button id="read-value">Read Value</button>
+            <button id="set-value-direct">Set Value Directly</button>
+            <button id="set-value-databind">Set Value + DataBind</button>
+            <button id="focus-in">Focus In</button>
+            <button id="focus-out">Focus Out</button>
+        </div>
+        <div style="margin-top: 12px;">
+            <label for="typing-target">Typing target:</label>
+            <input id="typing-target" value="browser textarea source" />
+        </div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("text-area");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        const ej2 = new ej.inputs.TextArea({
+            value: "initial note",
+            placeholder: "Resident care note",
+            showClearButton: true,
+            input: args => probe.event("input", args),
+            change: args => probe.event("change", args),
+            focus: args => probe.event("focus", args),
+            blur: args => probe.event("blur", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("read-value").addEventListener("click", () => {
+            record("value read", {
+                property: ej2.value,
+                elementValue: target.value,
+                activeElement: document.activeElement && document.activeElement.id
+            });
+        });
+
+        document.getElementById("set-value-direct").addEventListener("click", () => {
+            ej2.value = "direct set note";
+            record("value direct write", {
+                property: ej2.value,
+                elementValue: target.value,
+                visibleValue: document.querySelector("#text-area").value
+            });
+        });
+
+        document.getElementById("set-value-databind").addEventListener("click", () => {
+            ej2.value = "databind set note";
+            ej2.dataBind();
+            record("value write with databind", {
+                property: ej2.value,
+                elementValue: target.value,
+                visibleValue: document.querySelector("#text-area").value
+            });
+        });
+
+        document.getElementById("focus-in").addEventListener("click", () => {
+            ej2.focusIn();
+            record("focusIn call", {
+                activeElement: document.activeElement && document.activeElement.id,
+                focusedClass: ej2.textareaWrapper.container.classList.contains("e-input-focus")
+            });
+        });
+
+        document.getElementById("focus-out").addEventListener("click", () => {
+            ej2.focusOut();
+            record("focusOut call", {
+                activeElement: document.activeElement && document.activeElement.id,
+                focusedClass: ej2.textareaWrapper.container.classList.contains("e-input-focus")
+            });
+        });
+
+        document.getElementById("typing-target").addEventListener("change", event => {
+            target.value = event.target.value;
+            target.dispatchEvent(new Event("input", { bubbles: true }));
+            target.dispatchEvent(new Event("change", { bubbles: true }));
+        });
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "text-area",
+            namespace: "ej.inputs",
+            className: "TextArea",
+            id: "text-area"
+        });
+        [
+            {
+                candidate: "ej2.value",
+                kind: "prop-read",
+                builder: "covered by Value; runtime source still useful",
+                args: "none",
+                returnOrPayload: "string",
+                proof: "value read trace; input/change consumer",
+                csharp: "Value()",
+                outcome: "implement"
+            },
+            {
+                candidate: "ej2.value = string",
+                kind: "prop-write",
+                builder: "covered by Value; runtime mutation candidate",
+                args: "string",
+                returnOrPayload: "void",
+                proof: "value direct write leaves DOM stale; value write with databind updates visible textarea",
+                csharp: "SetValue(string)",
+                outcome: "implement"
+            },
+            {
+                candidate: "ej2.focusIn()",
+                kind: "method",
+                builder: "not covered",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "focusIn call trace; activeElement is text-area",
+                csharp: "FocusIn()",
+                outcome: "implement"
+            },
+            {
+                candidate: "ej2.focusOut()",
+                kind: "method",
+                builder: "not covered",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "focusOut call trace; activeElement leaves text-area",
+                csharp: "FocusOut()",
+                outcome: "implement"
+            },
+            {
+                candidate: "input event",
+                kind: "event + payload-read",
+                builder: "event builder exists",
+                args: "event payload",
+                returnOrPayload: "value?: string, previousValue?: string",
+                proof: "input trace",
+                csharp: "Input",
+                outcome: "implement"
+            },
+            {
+                candidate: "change event",
+                kind: "event + payload-read",
+                builder: "event builder exists",
+                args: "event payload",
+                returnOrPayload: "value?: string, previousValue?: string, isInteracted?: boolean",
+                proof: "change trace",
+                csharp: "Changed",
+                outcome: "implement"
+            },
+            {
+                candidate: "created/destroyed events",
+                kind: "event",
+                builder: "event builder exists",
+                args: "object",
+                returnOrPayload: "no useful typed payload for this row",
+                proof: "not traced",
+                csharp: "none",
+                outcome: "exclude"
+            },
+            {
+                candidate: "addAttributes/removeAttributes",
+                kind: "method",
+                builder: "not covered, but arbitrary attribute bag",
+                args: "dictionary/string[]",
+                returnOrPayload: "void",
+                proof: "source shows arbitrary attributes",
+                csharp: "none",
+                outcome: "exclude"
+            }
+        ].forEach(proposal);
+
+        async function runAutorunTrace() {
+            document.getElementById("read-value").click();
+            document.getElementById("set-value-direct").click();
+            document.getElementById("set-value-databind").click();
+            document.getElementById("focus-in").click();
+            document.getElementById("focus-out").click();
+            const typing = document.getElementById("typing-target");
+            typing.value = "typed textarea proof";
+            typing.dispatchEvent(new Event("change", { bubbles: true }));
+            await new Promise(resolve => setTimeout(resolve, 100));
+            record("autorun complete", {
+                activeElement: document.activeElement && document.activeElement.id,
+                finalValue: ej2.value,
+                finalElementValue: target.value
+            });
+            window.__sfProbeDone = true;
+        }
+
+        if (new URLSearchParams(window.location.search).has("autorun")) {
+            setTimeout(runAutorunTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-text-box-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-text-box-probe.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF TextBox API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF TextBox API Probe</h1>
+    <p>This page is temporary. Use it to discover the exact JS object API before onboarding typed C# members.</p>
+    <div id="host">
+        <input id="text-box" />
+        <div style="margin-top: 12px;">
+            <button id="read-value">Read Value</button>
+            <button id="set-value-direct">Set Value Directly</button>
+            <button id="set-value-databind">Set Value + DataBind</button>
+            <button id="focus-in">Focus In</button>
+            <button id="focus-out">Focus Out</button>
+            <button id="add-icon">Add Append Icon</button>
+        </div>
+        <div style="margin-top: 12px;">
+            <label for="typing-target">Typing target:</label>
+            <input id="typing-target" value="browser input source" />
+        </div>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <p>Every row must be proven here before it becomes typed Fusion API.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <button id="dump">Dump Keys</button>
+    <button id="clear">Clear Trace</button>
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const proposalRows = [];
+        const target = document.getElementById("text-box");
+
+        function safeJson(key, value) {
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (typeof value === "function") return "[Function]";
+            return value;
+        }
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function functionNames(value) {
+            const names = new Set();
+            let current = value;
+            while (current && current !== Object.prototype) {
+                Object.getOwnPropertyNames(current).forEach(name => {
+                    if (name !== "constructor" && typeof value[name] === "function") {
+                        names.add(name);
+                    }
+                });
+                current = Object.getPrototypeOf(current);
+            }
+            return Array.from(names).sort();
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return {
+                ownKeys: own,
+                functions: functionNames(args),
+                properties
+            };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            renderTrace();
+        }
+
+        function renderTrace() {
+            document.getElementById("trace").textContent =
+                JSON.stringify(trace, safeJson, 2);
+        }
+
+        function renderProposal() {
+            const body = document.getElementById("proposal-body");
+            body.innerHTML = "";
+            proposalRows.forEach(row => {
+                const tr = document.createElement("tr");
+                [
+                    row.candidate,
+                    row.kind,
+                    row.builder,
+                    row.args,
+                    row.returnOrPayload,
+                    row.proof,
+                    row.csharp,
+                    row.outcome
+                ].forEach(value => {
+                    const td = document.createElement("td");
+                    td.textContent = value || "";
+                    tr.appendChild(td);
+                });
+                body.appendChild(tr);
+            });
+        }
+
+        function proposal(row) {
+            proposalRows.push(row);
+            renderProposal();
+            return row;
+        }
+
+        const probe = {
+            target,
+            trace,
+            proposalRows,
+            proposal,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args)),
+            eventCall: (label, args, method, call) => {
+                const before = describePayload(args);
+                const result = call();
+                record(label, {
+                    method,
+                    before,
+                    result: clean(result, new WeakSet(), 0),
+                    after: describePayload(args)
+                });
+            }
+        };
+
+        window.__sfProbe = probe;
+
+        const ej2 = new ej.inputs.TextBox({
+            value: "initial value",
+            placeholder: "Resident note",
+            showClearButton: true,
+            input: args => probe.event("input", args),
+            change: args => probe.event("change", args),
+            focus: args => probe.event("focus", args),
+            blur: args => probe.event("blur", args)
+        });
+        ej2.appendTo(target);
+        probe.ej2 = ej2;
+
+        document.getElementById("read-value").addEventListener("click", () => {
+            record("value read", {
+                property: ej2.value,
+                elementValue: target.value,
+                activeElement: document.activeElement && document.activeElement.id
+            });
+        });
+
+        document.getElementById("set-value-direct").addEventListener("click", () => {
+            ej2.value = "direct set value";
+            record("value direct write", {
+                property: ej2.value,
+                elementValue: target.value,
+                visibleValue: document.querySelector("#text-box").value
+            });
+        });
+
+        document.getElementById("set-value-databind").addEventListener("click", () => {
+            ej2.value = "databind set value";
+            ej2.dataBind();
+            record("value write with databind", {
+                property: ej2.value,
+                elementValue: target.value,
+                visibleValue: document.querySelector("#text-box").value
+            });
+        });
+
+        document.getElementById("focus-in").addEventListener("click", () => {
+            ej2.focusIn();
+            record("focusIn call", {
+                activeElement: document.activeElement && document.activeElement.id,
+                focusedClass: ej2.textboxWrapper.container.classList.contains("e-input-focus")
+            });
+        });
+
+        document.getElementById("focus-out").addEventListener("click", () => {
+            ej2.focusOut();
+            record("focusOut call", {
+                activeElement: document.activeElement && document.activeElement.id,
+                focusedClass: ej2.textboxWrapper.container.classList.contains("e-input-focus")
+            });
+        });
+
+        document.getElementById("add-icon").addEventListener("click", () => {
+            ej2.addIcon("append", "e-icons e-search");
+            record("addIcon append", {
+                iconCount: ej2.textboxWrapper.container.querySelectorAll(".e-icons.e-search").length,
+                wrapperClass: ej2.textboxWrapper.container.className
+            });
+        });
+
+        document.getElementById("typing-target").addEventListener("change", event => {
+            target.value = event.target.value;
+            target.dispatchEvent(new Event("input", { bubbles: true }));
+            target.dispatchEvent(new Event("change", { bubbles: true }));
+        });
+
+        document.getElementById("dump").addEventListener("click", () => {
+            record("own keys", Object.keys(ej2).sort());
+            const proto = Object.getPrototypeOf(ej2);
+            record("prototype methods", Object.getOwnPropertyNames(proto).sort());
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            renderTrace();
+        });
+
+        record("ready", {
+            component: "text-box",
+            namespace: "ej.inputs",
+            className: "TextBox",
+            id: "text-box"
+        });
+        [
+            {
+                candidate: "ej2.value",
+                kind: "prop-read",
+                builder: "covered by Value; runtime source still useful",
+                args: "none",
+                returnOrPayload: "string",
+                proof: "value read trace; input/change consumer",
+                csharp: "Value()",
+                outcome: "implement"
+            },
+            {
+                candidate: "ej2.value = string",
+                kind: "prop-write",
+                builder: "covered by Value; runtime mutation candidate",
+                args: "string",
+                returnOrPayload: "void",
+                proof: "value direct write leaves DOM stale; value write with databind updates visible input",
+                csharp: "SetValue(string)",
+                outcome: "implement"
+            },
+            {
+                candidate: "ej2.focusIn()",
+                kind: "method",
+                builder: "not covered",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "focusIn call trace; activeElement is text-box",
+                csharp: "FocusIn()",
+                outcome: "implement"
+            },
+            {
+                candidate: "ej2.focusOut()",
+                kind: "method",
+                builder: "not covered",
+                args: "none",
+                returnOrPayload: "void",
+                proof: "focusOut call trace; activeElement leaves text-box",
+                csharp: "FocusOut()",
+                outcome: "implement"
+            },
+            {
+                candidate: "ej2.addIcon(\"append\", string)",
+                kind: "method",
+                builder: "not covered",
+                args: "position: append|prepend, icons: string",
+                returnOrPayload: "void",
+                proof: "addIcon append trace; icon span appears",
+                csharp: "AddAppendIcon(string)",
+                outcome: "implement"
+            },
+            {
+                candidate: "input event",
+                kind: "event + payload-read",
+                builder: "event builder exists",
+                args: "event payload",
+                returnOrPayload: "value?: string, previousValue?: string",
+                proof: "input trace",
+                csharp: "Input",
+                outcome: "implement"
+            },
+            {
+                candidate: "change event",
+                kind: "event + payload-read",
+                builder: "event builder exists",
+                args: "event payload",
+                returnOrPayload: "value?: string, previousValue?: string, isInteracted?: boolean",
+                proof: "change trace",
+                csharp: "Changed",
+                outcome: "implement"
+            },
+            {
+                candidate: "created/destroyed events",
+                kind: "event",
+                builder: "event builder exists",
+                args: "object",
+                returnOrPayload: "no useful typed payload for this row",
+                proof: "not traced",
+                csharp: "none",
+                outcome: "exclude"
+            },
+            {
+                candidate: "addAttributes/removeAttributes",
+                kind: "method",
+                builder: "not covered, but arbitrary attribute bag",
+                args: "dictionary/string[]",
+                returnOrPayload: "void",
+                proof: "source shows arbitrary attributes",
+                csharp: "none",
+                outcome: "exclude"
+            }
+        ].forEach(proposal);
+
+        async function runAutorunTrace() {
+            document.getElementById("read-value").click();
+            document.getElementById("set-value-direct").click();
+            document.getElementById("set-value-databind").click();
+            document.getElementById("focus-in").click();
+            document.getElementById("focus-out").click();
+            document.getElementById("add-icon").click();
+            const typing = document.getElementById("typing-target");
+            typing.value = "typed proof";
+            typing.dispatchEvent(new Event("change", { bubbles: true }));
+            await new Promise(resolve => setTimeout(resolve, 100));
+            record("autorun complete", {
+                activeElement: document.activeElement && document.activeElement.id,
+                finalValue: ej2.value,
+                finalElementValue: target.value,
+                iconCount: ej2.textboxWrapper.container.querySelectorAll(".e-icons.e-search").length
+            });
+            window.__sfProbeDone = true;
+        }
+
+        if (new URLSearchParams(window.location.search).has("autorun")) {
+            setTimeout(runAutorunTrace, 100);
+        }
+    </script>
+</body>
+</html>

--- a/Alis.Reactive.SandboxApp/wwwroot/sf-toolbar-probe.html
+++ b/Alis.Reactive.SandboxApp/wwwroot/sf-toolbar-probe.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SF Toolbar API Probe</title>
+    <link rel="stylesheet" href="/vendor/syncfusion/material.css" />
+    <script src="/vendor/syncfusion/dist/ej2.min.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 20px; }
+        #host { border: 1px solid #d0d7de; padding: 16px; margin-bottom: 16px; }
+        table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+        th, td { border: 1px solid #d0d7de; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f6f8fa; }
+        pre { background: #111827; color: #e5e7eb; padding: 12px; overflow: auto; }
+        button { margin-right: 8px; margin-bottom: 8px; }
+    </style>
+</head>
+<body>
+    <h1>SF Toolbar API Probe</h1>
+    <p>Trace the runtime surface before onboarding typed Fusion API.</p>
+
+    <div id="host">
+        <div id="toolbar"></div>
+    </div>
+
+    <div>
+        <button id="disable">Disable</button>
+        <button id="enable">Enable</button>
+        <button id="change-orientation">Change orientation</button>
+        <button id="refresh-overflow">Refresh overflow</button>
+        <button id="enable-item">Enable item 0</button>
+        <button id="disable-item">Disable item 0</button>
+        <button id="hide-item">Hide item 0</button>
+        <button id="show-item">Show item 0</button>
+        <button id="add-item">Add item</button>
+        <button id="remove-item">Remove item 1</button>
+        <button id="clear">Clear Trace</button>
+    </div>
+
+    <h2>Candidate Matrix</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Candidate</th>
+                <th>Kind</th>
+                <th>Builder</th>
+                <th>Args</th>
+                <th>Return/Payload</th>
+                <th>Proof</th>
+                <th>Proposed C#</th>
+                <th>Outcome</th>
+            </tr>
+        </thead>
+        <tbody id="proposal-body"></tbody>
+    </table>
+
+    <pre id="trace"></pre>
+
+    <script>
+        const trace = [];
+        const rows = [];
+        const target = document.getElementById("toolbar");
+        const initialItems = [
+            { id: "toolbar-save", text: "Save", type: "Button" },
+            { id: "toolbar-delete", text: "Delete", type: "Button" }
+        ];
+        let toolbar;
+
+        function clean(value, seen, depth) {
+            if (value === null || typeof value !== "object") return value;
+            if (value instanceof Element) return "[Element#" + (value.id || value.tagName) + "]";
+            if (depth > 4) return "[MaxDepth]";
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+            if (Array.isArray(value)) return value.slice(0, 20).map(item => clean(item, seen, depth + 1));
+            const output = {};
+            Object.keys(value).slice(0, 80).forEach(key => {
+                const item = value[key];
+                output[key] = typeof item === "function" ? "[Function]" : clean(item, seen, depth + 1);
+            });
+            return output;
+        }
+
+        function describePayload(args) {
+            const own = Object.keys(args).sort();
+            const properties = {};
+            own.forEach(key => {
+                const item = args[key];
+                properties[key] = {
+                    type: item === null ? "null" : Array.isArray(item) ? "array" : typeof item,
+                    sample: clean(item, new WeakSet(), 0)
+                };
+            });
+            return { ownKeys: own, properties };
+        }
+
+        function record(label, value) {
+            trace.push({
+                at: new Date().toISOString(),
+                label,
+                value: clean(value, new WeakSet(), 0)
+            });
+            document.getElementById("trace").textContent = JSON.stringify(trace, null, 2);
+        }
+
+        function addRow(row) {
+            rows.push(row);
+            const tr = document.createElement("tr");
+            [row.candidate, row.kind, row.builder, row.args, row.returnOrPayload, row.proof, row.csharp, row.outcome].forEach(value => {
+                const td = document.createElement("td");
+                td.textContent = value || "";
+                tr.appendChild(td);
+            });
+            document.getElementById("proposal-body").appendChild(tr);
+        }
+
+        window.__sfProbe = {
+            trace,
+            rows,
+            record,
+            member: (label, read) => record(label, read()),
+            call: (label, invoke) => record(label, invoke()),
+            event: (label, args) => record(label, describePayload(args))
+        };
+
+        toolbar = new ej.navigations.Toolbar({
+            items: initialItems,
+            clicked: args => {
+                record("clicked", {
+                    payload: describePayload(args),
+                    item: {
+                        id: args.item && args.item.id,
+                        text: args.item && args.item.text,
+                        disabled: args.item && args.item.disabled,
+                        visible: args.item && args.item.visible,
+                        type: args.item && args.item.type
+                    },
+                    cancel: args.cancel
+                });
+            },
+            created: args => record("created", describePayload(args)),
+            beforeCreate: args => record("beforeCreate", describePayload(args)),
+            destroyed: args => record("destroyed", describePayload(args)),
+            keyDown: args => record("keyDown", describePayload(args))
+        });
+
+        toolbar.appendTo(target);
+
+        record("ready", {
+            component: "toolbar",
+            namespace: "ej.navigations",
+            className: "Toolbar",
+            id: "toolbar",
+            methods: Object.getOwnPropertyNames(Object.getPrototypeOf(toolbar)).sort()
+        });
+
+        document.getElementById("disable").addEventListener("click", () => {
+            toolbar.disable(true);
+            record("after-disable", {
+                isDisabledClass: target.classList.contains("e-disabled"),
+                classes: Array.from(target.classList).sort()
+            });
+        });
+
+        document.getElementById("enable").addEventListener("click", () => {
+            toolbar.disable(false);
+            record("after-enable", {
+                isDisabledClass: target.classList.contains("e-disabled"),
+                classes: Array.from(target.classList).sort()
+            });
+        });
+
+        document.getElementById("change-orientation").addEventListener("click", () => {
+            toolbar.changeOrientation();
+            record("after-changeOrientation", {
+                classes: Array.from(target.classList).sort(),
+                nav: document.getElementById("toolbar_nav") ? document.getElementById("toolbar_nav").className : null
+            });
+        });
+
+        document.getElementById("refresh-overflow").addEventListener("click", () => {
+            toolbar.refreshOverflow();
+            record("after-refreshOverflow", {
+                itemCount: toolbar.items.length,
+                classes: Array.from(target.classList).sort()
+            });
+        });
+
+        document.getElementById("enable-item").addEventListener("click", () => {
+            toolbar.enableItems(0, true);
+            record("after-enableItems", {
+                item0Disabled: toolbar.items[0].disabled,
+                item0Visible: toolbar.items[0].visible
+            });
+        });
+
+        document.getElementById("disable-item").addEventListener("click", () => {
+            toolbar.enableItems(0, false);
+            record("after-disableItem", {
+                item0Disabled: toolbar.items[0].disabled,
+                item0Visible: toolbar.items[0].visible
+            });
+        });
+
+        document.getElementById("hide-item").addEventListener("click", () => {
+            toolbar.hideItem(0, true);
+            record("after-hideItem", {
+                item0Disabled: toolbar.items[0].disabled,
+                item0Visible: toolbar.items[0].visible
+            });
+        });
+
+        document.getElementById("show-item").addEventListener("click", () => {
+            toolbar.hideItem(0, false);
+            record("after-showItem", {
+                item0Disabled: toolbar.items[0].disabled,
+                item0Visible: toolbar.items[0].visible
+            });
+        });
+
+        document.getElementById("add-item").addEventListener("click", () => {
+            toolbar.addItems([
+                { id: "toolbar-more", text: "More", type: "Button", disabled: false }
+            ], 1);
+            record("after-addItems", {
+                items: toolbar.items.map(item => ({
+                    id: item.id,
+                    text: item.text,
+                    disabled: item.disabled,
+                    visible: item.visible,
+                    type: item.type
+                }))
+            });
+        });
+
+        document.getElementById("remove-item").addEventListener("click", () => {
+            toolbar.removeItems(1);
+            record("after-removeItems", {
+                items: toolbar.items.map(item => ({
+                    id: item.id,
+                    text: item.text,
+                    disabled: item.disabled,
+                    visible: item.visible,
+                    type: item.type
+                }))
+            });
+        });
+
+        document.getElementById("clear").addEventListener("click", () => {
+            trace.length = 0;
+            document.getElementById("trace").textContent = "";
+        });
+
+        addRow({
+            candidate: "disable(value)",
+            kind: "method",
+            builder: "runtime",
+            args: "boolean",
+            returnOrPayload: "void; root gets/loses e-disabled",
+            proof: "disable button toggles root class",
+            csharp: "Disable(bool)",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "clicked",
+            kind: "event",
+            builder: "builder event",
+            args: "ClickEventArgs",
+            returnOrPayload: "item.id/text/disabled + cancel",
+            proof: "click Save button emits typed payload",
+            csharp: "Clicked event with FusionToolbarClickedArgs",
+            outcome: "implement"
+        });
+
+        addRow({
+            candidate: "changeOrientation()",
+            kind: "method",
+            builder: "runtime",
+            args: "void",
+            returnOrPayload: "layout flips orientation",
+            proof: "button call changes rendered orientation",
+            csharp: "ChangeOrientation()",
+            outcome: "candidate"
+        });
+
+        addRow({
+            candidate: "refreshOverflow()",
+            kind: "method",
+            builder: "runtime",
+            args: "void",
+            returnOrPayload: "reflows overflow state",
+            proof: "button call re-runs overflow rendering",
+            csharp: "RefreshOverflow()",
+            outcome: "candidate"
+        });
+
+        addRow({
+            candidate: "enableItems(index, isEnable)",
+            kind: "method",
+            builder: "runtime",
+            args: "index:number, isEnable:boolean",
+            returnOrPayload: "void; item disabled state mutates",
+            proof: "button toggles item 0 disabled flag",
+            csharp: "SetItemEnabled(int index, bool enabled)",
+            outcome: "candidate"
+        });
+
+        addRow({
+            candidate: "hideItem(index, value)",
+            kind: "method",
+            builder: "runtime",
+            args: "index:number, value:boolean",
+            returnOrPayload: "void; item visible state mutates",
+            proof: "button toggles item 0 visible flag",
+            csharp: "SetItemVisible(int index, bool visible)",
+            outcome: "candidate"
+        });
+
+        addRow({
+            candidate: "addItems(items, index)",
+            kind: "method",
+            builder: "runtime",
+            args: "ItemModel[], number?",
+            returnOrPayload: "void; new item appears in toolbar",
+            proof: "button inserts a More item",
+            csharp: "AddItems(...)",
+            outcome: "needs-proof"
+        });
+
+        addRow({
+            candidate: "removeItems(args)",
+            kind: "method",
+            builder: "runtime",
+            args: "number | HTMLElement | NodeList | Element | HTMLElement[]",
+            returnOrPayload: "void; item removed from toolbar",
+            proof: "button removes item at index 1",
+            csharp: "RemoveItemAtIndex(int)",
+            outcome: "candidate"
+        });
+    </script>
+</body>
+</html>

--- a/Alis.Reactive/Validation/ValidationRule.cs
+++ b/Alis.Reactive/Validation/ValidationRule.cs
@@ -19,6 +19,14 @@ namespace Alis.Reactive.Validation
         public string Message => _message.Value;
         public Shape Shape => _shape;
 
+        // Projections for a vendor emitter that translates this rule into a native
+        // component validation shape (e.g. Syncfusion EJ2 column.validationRules).
+        // Internal so the public rule surface stays message + shape only.
+        internal ValidationRuleName Name => _rule;
+        internal bool IsUnconditional => _activation.IsAlways;
+        internal object? LiteralOperand => _operand.LiteralValue;
+        internal object[]? RangeOperand => _operand.RangeValues;
+
         internal ValidationRule(
             ValidationRuleName rule,
             ValidationMessage message,
@@ -77,6 +85,11 @@ namespace Alis.Reactive.Validation
             return new PeerFieldValidationRuleOperand(ClientValidationFieldReference.Of(fieldPath, shape));
         }
 
+        // Emit projections for a native-component validation emitter. The default is
+        // "no value"; operands that carry a literal or a range override these.
+        internal virtual object? LiteralValue => null;
+        internal virtual object[]? RangeValues => null;
+
         internal abstract IEnumerable<ClientValidationFieldReference> PeerFieldReferences { get; }
 
         internal abstract ValidationRuleOperand PrefixedBy(ValidationFieldPath prefix);
@@ -121,6 +134,8 @@ namespace Alis.Reactive.Validation
             _shape = shape;
         }
 
+        internal override object? LiteralValue => _value;
+
         internal override IEnumerable<ClientValidationFieldReference> PeerFieldReferences
         {
             get { yield break; }
@@ -151,6 +166,8 @@ namespace Alis.Reactive.Validation
         {
             _bounds = bounds;
         }
+
+        internal override object[]? RangeValues => _bounds.ToDescriptorArray();
 
         internal override IEnumerable<ClientValidationFieldReference> PeerFieldReferences
         {
@@ -217,6 +234,10 @@ namespace Alis.Reactive.Validation
             return new ConditionalClientRuleActivation(condition);
         }
 
+        // True only for an unconditional rule. A native-component validation emitter
+        // skips conditional rules because EJ2 column rules are always-on.
+        internal abstract bool IsAlways { get; }
+
         internal abstract Alis.Reactive.PlanModel.ValidationRuleActivation ToPlanActivation(ValidationPlanBinding binding);
 
         internal abstract ClientRuleActivation Combine(ClientRuleActivation incoming);
@@ -229,6 +250,8 @@ namespace Alis.Reactive.Validation
     internal sealed class AlwaysClientRuleActivation : ClientRuleActivation
     {
         internal AlwaysClientRuleActivation() { }
+
+        internal override bool IsAlways => true;
 
         internal override Alis.Reactive.PlanModel.ValidationRuleActivation ToPlanActivation(ValidationPlanBinding binding)
         {
@@ -259,6 +282,8 @@ namespace Alis.Reactive.Validation
         {
             _condition = condition;
         }
+
+        internal override bool IsAlways => false;
 
         internal override Alis.Reactive.PlanModel.ValidationRuleActivation ToPlanActivation(ValidationPlanBinding binding)
         {

--- a/docs/design/grid-inline-validation.md
+++ b/docs/design/grid-inline-validation.md
@@ -1,6 +1,7 @@
 # Validation × Syncfusion Grid Inline Editing
 
-Status: research + evaluation (pick-up doc). No code change yet.
+Status: **implemented (v1)** — the metadata→EJ2 emitter ships and is proven in the
+browser. Sections 1–5 are the original research; section 7 records what shipped.
 Date: 2026-05-30.
 
 This captures (1) why `ReactiveValidator` client validation cannot bind to a
@@ -160,3 +161,53 @@ few exotic rules do **not** map — those stay server-authoritative.
    (`column.ValidationFrom<TValidator, TRow>(...)`) so the common single-field
    rules are generated from FluentValidation into SF-native column rules — single
    source, client-side free — with server-on-save as the authority for the gaps.
+
+## 7. Implemented (v1)
+
+The metadata→EJ2 emitter shipped. The flagged risk ("does EJ2 run
+`column.validationRules` under our custom server binding + EditTemplate cells?")
+was de-risked with a browser spike first: a numeric column with hand-written
+`{ min, max }` showed EJ2's native tooltip and blocked the cell, confirming EJ2's
+`FormValidator` fires under custom binding in batch mode. The typed emitter then
+replaced the hand-written rules.
+
+**API (no new public surface on the validation contract).**
+- `ValidationRule` gained four `internal` projections — `Name`, `IsUnconditional`,
+  `LiteralOperand`, `RangeOperand` — read by the Fusion emitter through the
+  existing `InternalsVisibleTo("Alis.Reactive.Fusion")`. The public rule surface
+  stays `Message` + `Shape`.
+- `FusionGridValidation.From<TValidator, TRow>(IClientValidationRuleSource)` →
+  `FusionGridFieldValidation<TRow>.Field(r => r.X)` returns the EJ2
+  `column.validationRules` object (or `null` when nothing maps client-side). The
+  validator metadata is read through the public DI `IClientValidationRuleSource`;
+  Fusion takes **no** dependency on `Alis.Reactive.FluentValidator`.
+
+**Mapping (v1).** `required`/`email`/`url` → `[true, msg]`; `minLength`/`maxLength`
+→ `[len, msg]`; `regex` → `[pattern, msg]`; `min`/`max` (numeric) → `[value, msg]`;
+`range` (numeric) → `[[lo, hi], msg]`. The rule key comes straight from
+`ValidationRuleName.Value`, which is already EJ2-shaped. Each EJ2 value carries the
+FluentValidation message as `[value, message]`, so the cell tooltip is the same
+text the form shows.
+
+**Honest gaps (deferred to server-on-save).** Conditional (`WhenField`),
+cross-field/peer (`equalTo` other field), and `gt`/`lt`/`exclusiveRange`/
+`notEqual`/`creditCard`/`atLeastOne`/`empty` have no EJ2 FormValidator equivalent
+and are skipped — they stay server-authoritative. Non-numeric `min`/`max`/`range`
+(e.g. dates) are skipped in v1.
+
+**Proof.**
+- Wiring: `CareOps.cshtml` `@inject IClientValidationRuleSource` +
+  `FusionGridValidation.From<ResidentCareItemValidator, ResidentCareItem>(...)`;
+  the `openTasks` column carries `ValidationRules = care.Field(r => r.OpenTasks)`
+  from `ResidentCareItemValidator.ClientRule(r => r.OpenTasks).Range(0, 7, ...)`.
+- Browser: editing `openTasks` to `99` shows EJ2's native tooltip with the exact
+  FluentValidation message *"Open tasks must be between 0 and 7."* and blocks the
+  cell — under custom server binding + batch mode.
+- Tests: 4 emitter-mapping unit tests
+  (`WhenAGridColumnGeneratesNativeValidationFromClientRules`, covering direct/
+  numeric/email/unmapped/conditional cases) + 1 Playwright behavior
+  (`an_out_of_range_open_tasks_edit_is_blocked_by_the_generated_care_rule`).
+
+**Next.** Pair the client emit with the server validate-on-save guard
+(section 4, row 1) so cross-field/conditional/async rules are enforced on commit;
+extend mapping to date `min`/`max`/`range` via EJ2 `date` rules.

--- a/docs/design/grid-inline-validation.md
+++ b/docs/design/grid-inline-validation.md
@@ -1,0 +1,162 @@
+# Validation × Syncfusion Grid Inline Editing
+
+Status: research + evaluation (pick-up doc). No code change yet.
+Date: 2026-05-30.
+
+This captures (1) why `ReactiveValidator` client validation cannot bind to a
+Syncfusion grid **in-cell** editor today, and (2) an evaluation of the proposed
+bridge: **generate Syncfusion-native column validation rules from our existing
+FluentValidation metadata**, so the DSL source stays single and we get
+client-side in-cell validation "for free".
+
+---
+
+## 1. How our client validation binds (today)
+
+Recorded at **C# render time**, resolved in the browser by **`getElementById`
+only**:
+
+1. `ReactiveValidator<T>.ClientRule(m => m.Field)` records browser rule metadata
+   into a `ClientValidationRuleSet`, keyed by model property path. Each
+   `ClientValidationField` carries field path + `Shape` + `ValidationRule[]` +
+   activation (`Always` or a `WhenField` condition). Server-only rules
+   (`RuleFor`, `When/Unless`, `MustAsync`) are **not** recorded as client rules.
+   (`ReactiveValidator.cs`, `ClientValidationFieldRuleBuilder.cs`)
+2. A request opts in with `.Validate<TValidator>(formId)` — it sets the request's
+   validation target to the form container and registers a `ValidationJob`.
+3. At the **end of `Render()`**, `ClientValidationRuleBinder.BindQueuedJobs()`
+   maps each field path to a concrete element id: the rendered `Html.InputField`'s
+   `ComponentId`, else the deterministic `IdGenerator.For(modelType, path)`. The
+   result — `{ component: elementId, value, rules, serverFieldName }` — is merged
+   onto the form container's `ContainerScope` and serialized into the plan.
+4. `Html.InputField` also emits the inline `<span id="{id}_error" data-valmsg-for>`
+   slot and a per-plan summary div.
+5. Runtime: at **boot**, `wireContainerValidation` wires `input`/`blur`/`change`
+   per field by `getElementById` of the fixed id. On submit, `validateContainer`
+   re-resolves each field by id and runs the rules; `ValidationErrors(formId)`
+   shows inline (`{id}_error`) or routes to the summary.
+
+**Binding key: fixed element IDs known at render time, resolved by `getElementById`.**
+
+## 2. Why in-cell grid editing can't use it
+
+> The validator has one id; the grid has one editor **per row**.
+
+1. **No plan element id.** A cell editor is not an `Html.InputField`. Our
+   `FusionGridEditTemplates.Select/DateInput` emit `<select name="careLevel">` /
+   `<input type="date" name="nextReview">` — Syncfusion identifies them by
+   `name="{field}"` (a per-row field name), not a stable, model-expression id.
+   No `ComponentRegistration` exists, so the binder has nothing to map and
+   `getElementById` has no id to find. Built-in editors (`numericedit`) are
+   worse — SF mints an auto id at edit time.
+2. **No `{id}_error` slot and no container scope.** Only `InputField`/`Field`
+   emit the inline error span; the grid is a *display* component, so
+   `.Validate<T>()` never targets it and no rules attach to it.
+3. **Transient DOM.** Cell editors are created on edit and destroyed on save;
+   they don't exist at boot when validation wires, and they live outside any
+   validated form container, so `container.contains()` and the boot-time
+   `getElementById` wiring miss them.
+
+## 3. Why the dialog *does* work
+
+The Billing/CareOps admit dialog uses real `Html.InputField` inputs in a standing
+form with a summary slot. Each input registers a render-time `ComponentId`,
+emits its `{id}_error` span, and the form carries a `ContainerScope`. So
+`.Validate<TValidator>(formId)` resolves every field by id and maps server-side
+400 errors back by field name. This is the surface the model is designed for.
+
+## 4. Integration options (verified)
+
+| Option | Feasible | Hack | Verdict |
+|---|---|---|---|
+| **Server validate-on-save** (`BeforeBatchSave`/`cellSave` → gather → POST → 400 → `args.Cancel` + summary) | ✅ | ❌ | Native in-cell path; FluentValidation stays the single authority |
+| `actionBegin`/`cellSave` + `args.Cancel` client guard | ✅ | ❌ | A hand-authored `When` guard per cell — not `ReactiveValidator` metadata |
+| `EditTemplate` hosts `Html.InputField` | ❌ | ✅ | One id vs one-editor-per-row collides; violates no-fallback-id; lifecycle breaks id lookup. **Forbidden** |
+| SF native column rules (hand-declared) | ✅ | ❌ | Idiomatic SF, but a *second* hand-written engine → FluentValidation no longer single authority (**drift**) |
+| Validate standing form → update row | ✅ | ❌ | Cleanest; edits *outside* the cell (the dialog pattern) |
+
+---
+
+## 5. Evaluation — emit SF-native column rules **from** our FluentValidation metadata
+
+The "SF native column rules" option above is only a hack/drift risk **when
+hand-declared twice**. If instead we **generate** `column.validationRules`
+from the *same* `ReactiveValidator` metadata we already capture, the source
+stays single (`ClientRule` once), there is no second authority to drift, and
+Syncfusion's own `FormValidator` does the in-cell client validation for free.
+
+### What we already have
+`ClientValidationFieldRuleBuilder` records, per field, typed rules with messages:
+`Required, Empty, Email, Url, CreditCard, AtLeastOne, MinLength, MaxLength,
+Regex, Range, ExclusiveRange, Min, Max, Gt, Lt, EqualTo, NotEqual` (literal and
+peer-field), each with `Shape` and `Always`/`When` activation. This is exposed
+through `IClientValidationRuleSource` (DI) — the same source the binder reads.
+
+### Mapping our rule names → EJ2 `column.validationRules`
+EJ2 grid columns accept a `validationRules` object (EJ2 `FormValidator` rules),
+with messages as `{ rule: [value, "message"] }`:
+
+| Our `ValidationRuleName` | EJ2 rule | Notes |
+|---|---|---|
+| `Required` | `required: [true, msg]` | direct |
+| `MinLength` | `minLength: [n, msg]` | direct |
+| `MaxLength` | `maxLength: [n, msg]` | direct |
+| `Range` | `range: [[lo, hi], msg]` | numeric range |
+| `Min` / `GreaterThanOrEqualTo` | `min: [n, msg]` | direct |
+| `Max` / `LessThanOrEqualTo` | `max: [n, msg]` | direct |
+| `Email` | `email: [true, msg]` | direct |
+| `Url` | `url: [true, msg]` | direct |
+| `Regex` | `regex: [pattern, msg]` | direct |
+| `EqualTo` (peer) | `equalTo: ['otherFieldId', msg]` | peer = another cell in the **same row** — needs same-row field name; usable but row-scoped |
+| `Gt`/`Lt`/`ExclusiveRange`/`NotEqual` | custom rule fn | EJ2 has no built-in; emit a small custom validator |
+| `CreditCard`/`AtLeastOne`/`Empty` | — | no native equivalent; leave to server |
+| `When(...)` activation | — | EJ2 column rules are unconditional; conditional rules can't map |
+
+**Coverage:** the common single-field rules (`Required`, lengths, `Range`,
+`Min`/`Max`, `Email`/`Url`, `Regex`) map **directly** and cover the large
+majority of real field validation. Cross-field, conditional (`WhenField`), and a
+few exotic rules do **not** map — those stay server-authoritative.
+
+### Proposed design (no hack, single source)
+1. **C# emitter** in the FusionGrid slice, e.g.
+   `column.ValidationFrom<TValidator, TRow>(r => r.CareLevel)` — resolves the
+   `ClientValidationField` for that model path from `IClientValidationRuleSource`,
+   maps each unconditional rule to the EJ2 rule key/value (+ message), and sets
+   `GridColumn.ValidationRules` to the emitted object. Conditional rules are
+   skipped (logged) and deferred to the server.
+2. **Syncfusion runs it natively** — EJ2 `editModule` validates the cell against
+   `column.validationRules` on cell save/blur, showing its own inline tooltip.
+   Zero new runtime TS; zero new validation engine; the grid stays a typed slice.
+3. **Server stays the authority for the rest** — on `BeforeBatchSave`, gather the
+   batch and POST to a controller that runs the *full* FluentValidation
+   (`TryValidate`); on 400, `args.Cancel` the commit and surface messages in the
+   plan validation summary (the existing dialog error contract). This covers
+   cross-field/conditional/`MustAsync`/server-only rules that can't live client-side.
+
+### Net result
+- **Source stays the same**: developer writes `ReactiveValidator<T>` once.
+- **Client-side in-cell validation "for free"**: generated from the metadata into
+  SF's native column rules — no second hand-written ruleset, so no drift.
+- **No hack**: no per-row id minting, no `InputField`-in-`EditTemplate`, no
+  rebuilt rules — we translate the *one* truth into SF's native shape.
+- **Honest gaps**: conditional + cross-field + exotic + async rules fall through
+  to server-on-save, which is the correct authority for them anyway.
+
+### Risks / open questions
+- Exact EJ2 message syntax + custom-rule registration for `Gt`/`Lt`/exclusive —
+  confirm against EJ2 32.x `FormValidator` during implementation.
+- Peer (`EqualTo` other-field) is row-scoped in a grid — map to the same-row
+  field name; verify EJ2 `equalTo` resolves within the edit form.
+- `Shape`/culture: numeric vs date `range` must serialize in the editor's culture.
+- Decide the trigger: explicit `column.ValidationFrom(...)` (typed, opt-in) vs
+  auto-derive from the bound `TRow` validator. Opt-in is safer and more typed.
+
+## 6. Recommendation
+1. **Now**: in-cell editing → **server validate-on-save** (`BeforeBatchSave` →
+   gather → POST → 400 → `args.Cancel` + summary). Rich client feedback → the
+   **templated dialog / standing form** (already in Billing/CareOps). Do **not**
+   host `InputField` in a string `EditTemplate` or hand-declare native rules.
+2. **Next (recommended feature)**: build the **metadata→EJ2 emitter**
+   (`column.ValidationFrom<TValidator, TRow>(...)`) so the common single-field
+   rules are generated from FluentValidation into SF-native column rules — single
+   source, client-side free — with server-on-save as the authority for the gaps.

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionBreadcrumbLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionBreadcrumbLocator.cs
@@ -1,0 +1,41 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionBreadcrumb.
+/// </summary>
+public sealed class FusionBreadcrumbLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionBreadcrumbLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered breadcrumb root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>The current breadcrumb item rendered with aria-current.</summary>
+    public ILocator CurrentItem => Root.Locator("[aria-current='page']");
+
+    /// <summary>Locates a clickable breadcrumb link by its visible text.</summary>
+    public ILocator Link(string text) => Root.GetByRole(AriaRole.Link, new() { Name = text });
+
+    /// <summary>Clicks a breadcrumb link through the browser UI.</summary>
+    public async Task ClickLink(string text, int timeoutMs = 15000)
+    {
+        var link = Link(text);
+        await link.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+        await link.ClickWhenStableAsync(_page, timeoutMs);
+    }
+
+    /// <summary>Returns the current visible breadcrumb text.</summary>
+    public async Task<string> CurrentText()
+    {
+        return await CurrentItem.TextContentAsync() ?? string.Empty;
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionBulletChartLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionBulletChartLocator.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionBulletChart.
+/// </summary>
+public sealed class FusionBulletChartLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionBulletChartLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered bullet chart root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>The first feature measure bar.</summary>
+    public ILocator FeatureMeasure => _page.Locator($"#{_componentId}_svg_FeatureMeasure_0");
+
+    /// <summary>The first comparative measure marker.</summary>
+    public ILocator ComparativeMeasure => _page.Locator($"#{_componentId}_svg_ComparativeMeasure_0");
+
+    /// <summary>The rendered tooltip container.</summary>
+    public ILocator Tooltip => _page.Locator($"#tooltipDiv{_componentId}");
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionButtonLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionButtonLocator.cs
@@ -1,0 +1,39 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionButton.
+/// </summary>
+public sealed class FusionButtonLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionButtonLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered Syncfusion Button element.</summary>
+    public ILocator Button => _page.Locator($"#{_componentId}");
+
+    /// <summary>The rendered Syncfusion icon span.</summary>
+    public ILocator Icon => Button.Locator("span.e-btn-icon");
+
+    /// <summary>Gets the rendered button class attribute.</summary>
+    public async Task<string> ClassAttribute() =>
+        await Button.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Returns whether the button currently has the given CSS class.</summary>
+    public async Task<bool> HasClass(string className)
+    {
+        var classes = await ClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Gets the rendered icon class attribute.</summary>
+    public async Task<string> IconClassAttribute() =>
+        await Icon.GetAttributeAsync("class") ?? string.Empty;
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionCarouselLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionCarouselLocator.cs
@@ -1,0 +1,27 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionCarousel.
+/// </summary>
+public sealed class FusionCarouselLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionCarouselLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered carousel root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>The currently active slide.</summary>
+    public ILocator ActiveSlide => Root.Locator(".e-carousel-item.e-active");
+
+    /// <summary>The current active slide text.</summary>
+    public async Task<string> ActiveText() => await ActiveSlide.TextContentAsync() ?? string.Empty;
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionCheckBoxLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionCheckBoxLocator.cs
@@ -1,0 +1,48 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionCheckBox.
+/// </summary>
+public sealed class FusionCheckBoxLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionCheckBoxLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered Syncfusion CheckBox input.</summary>
+    public ILocator Input => _page.Locator($"#{_componentId}");
+
+    /// <summary>The Syncfusion wrapper around the checkbox input.</summary>
+    public ILocator Wrapper => Input.Locator("xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' e-checkbox-wrapper ')][1]");
+
+    /// <summary>The visible Syncfusion checkbox frame.</summary>
+    public ILocator Frame => Wrapper.Locator(".e-frame");
+
+    /// <summary>Returns whether the native input is checked.</summary>
+    public async Task<bool> IsChecked() => await Input.IsCheckedAsync();
+
+    /// <summary>Returns whether the native input is indeterminate.</summary>
+    public async Task<bool> IsIndeterminate() =>
+        await Input.EvaluateAsync<bool>("element => element.indeterminate");
+
+    /// <summary>Returns whether the visible frame has the given CSS class.</summary>
+    public async Task<bool> FrameHasClass(string className)
+    {
+        var classes = await Frame.GetAttributeAsync("class") ?? string.Empty;
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the wrapper has the given CSS class.</summary>
+    public async Task<bool> WrapperHasClass(string className)
+    {
+        var classes = await Wrapper.GetAttributeAsync("class") ?? string.Empty;
+        return classes.Split(' ').Contains(className);
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionComboBoxLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionComboBoxLocator.cs
@@ -1,0 +1,43 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionComboBox.
+/// </summary>
+public sealed class FusionComboBoxLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionComboBoxLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered ComboBox input.</summary>
+    public ILocator Input => _page.Locator($"#{_componentId}");
+
+    /// <summary>The Syncfusion wrapper around the input.</summary>
+    public ILocator Wrapper => Input.Locator("xpath=..");
+
+    /// <summary>The popup for this ComboBox instance.</summary>
+    public ILocator Popup => _page.Locator($"#{_componentId}_popup");
+
+    /// <summary>The popup items for this ComboBox instance.</summary>
+    public ILocator PopupItems => Popup.Locator(".e-list-item");
+
+    /// <summary>A popup item by exact visible text.</summary>
+    public ILocator PopupItem(string text) => PopupItems.GetByText(text, new() { Exact = true });
+
+    /// <summary>Selects an item from the currently open popup.</summary>
+    public async Task SelectItem(string text, int timeoutMs = 15000)
+    {
+        await Popup.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+        var item = PopupItem(text);
+        await item.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+        await item.ClickWhenStableAsync(_page, timeoutMs);
+        await Popup.WaitForAsync(new() { State = WaitForSelectorState.Hidden, Timeout = timeoutMs });
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionContextMenuLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionContextMenuLocator.cs
@@ -1,0 +1,33 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionContextMenu.
+/// </summary>
+public sealed class FusionContextMenuLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionContextMenuLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered context menu root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>The sandbox target area that drives the context menu.</summary>
+    public ILocator Target => _page.Locator("#resident-context-target");
+
+    /// <summary>The programmatic open button on the sandbox page.</summary>
+    public ILocator OpenButton => _page.Locator("#open-context-menu-btn");
+
+    /// <summary>The programmatic close button on the sandbox page.</summary>
+    public ILocator CloseButton => _page.Locator("#close-context-menu-btn");
+
+    /// <summary>Menu item by exact visible text.</summary>
+    public ILocator Item(string text) => _page.GetByRole(AriaRole.Menuitem, new() { Name = text });
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionDropDownButtonLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionDropDownButtonLocator.cs
@@ -1,0 +1,56 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionDropDownButton.
+/// </summary>
+public sealed class FusionDropDownButtonLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionDropDownButtonLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered Syncfusion DropDownButton element.</summary>
+    public ILocator Button => _page.Locator($"#{_componentId}");
+
+    /// <summary>The rendered Syncfusion popup element.</summary>
+    public ILocator Popup => _page.Locator($"#{_componentId}-popup");
+
+    /// <summary>The rendered popup action items.</summary>
+    public ILocator Items => Popup.Locator("li.e-item");
+
+    /// <summary>Locates a popup action item by exact visible text.</summary>
+    public ILocator Item(string text) =>
+        _page.Locator($"//*[@id='{_componentId}-popup']//li[contains(concat(' ', normalize-space(@class), ' '), ' e-item ') and normalize-space(.)='{text}']");
+
+    /// <summary>Gets the rendered button class attribute.</summary>
+    public async Task<string> ClassAttribute() =>
+        await Button.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Gets the rendered popup class attribute.</summary>
+    public async Task<string> PopupClassAttribute() =>
+        await Popup.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Returns whether the button currently has the given CSS class.</summary>
+    public async Task<bool> HasClass(string className)
+    {
+        var classes = await ClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the popup currently has the given CSS class.</summary>
+    public async Task<bool> PopupHasClass(string className)
+    {
+        var classes = await PopupClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the popup is currently open.</summary>
+    public async Task<bool> IsPopupOpen() => await PopupHasClass("e-popup-open");
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionDropDownTreeLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionDropDownTreeLocator.cs
@@ -1,0 +1,45 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionDropDownTree.
+/// </summary>
+public sealed class FusionDropDownTreeLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionDropDownTreeLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered DropDownTree input.</summary>
+    public ILocator Input => _page.Locator($"#{_componentId}");
+
+    /// <summary>The Syncfusion wrapper around the input.</summary>
+    public ILocator Wrapper => Input.Locator("xpath=..");
+
+    /// <summary>The popup for this DropDownTree instance.</summary>
+    public ILocator Popup => _page.Locator($"#{_componentId}_options");
+
+    /// <summary>The rendered tree inside the popup.</summary>
+    public ILocator Tree => _page.Locator($"#{_componentId}_tree");
+
+    /// <summary>A tree item text span by exact visible text.</summary>
+    public ILocator TreeItemText(string text) =>
+        Tree.Locator(".e-list-text").GetByText(text, new() { Exact = true });
+
+    /// <summary>Selects an item from the currently open popup.</summary>
+    public async Task SelectItem(string text, int timeoutMs = 15000)
+    {
+        await Popup.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+        var itemText = TreeItemText(text);
+        await itemText.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+        var row = itemText.Locator("xpath=ancestor::li[contains(@class,'e-list-item')][1]").Locator(".e-fullrow").First;
+        await row.ClickWhenStableAsync(_page, timeoutMs);
+        await Popup.WaitForAsync(new() { State = WaitForSelectorState.Hidden, Timeout = timeoutMs });
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionListBoxLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionListBoxLocator.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionListBox.
+/// </summary>
+public sealed class FusionListBoxLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionListBoxLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered ListBox wrapper.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}_parent");
+
+    /// <summary>A list item by exact visible text.</summary>
+    public ILocator Item(string text) => Root
+        .Locator("li.e-list-item")
+        .Filter(new() { HasTextString = text })
+        .First;
+
+    /// <summary>Selects or toggles an item through the browser UI.</summary>
+    public async Task ClickItem(string text, int timeoutMs = 15000)
+    {
+        var item = Item(text);
+        await item.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+        await item.ClickWhenStableAsync(_page, timeoutMs);
+    }
+
+    public async Task<bool> IsSelected(string text)
+    {
+        var className = await Item(text).GetAttributeAsync("class");
+        return Regex.IsMatch(className ?? string.Empty, @"\be-(selected|active)\b");
+    }
+
+    public async Task<bool> IsDisabled(string text)
+    {
+        var className = await Item(text).GetAttributeAsync("class");
+        return Regex.IsMatch(className ?? string.Empty, @"\be-disabled\b");
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionListViewLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionListViewLocator.cs
@@ -1,0 +1,44 @@
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionListView.
+/// </summary>
+public sealed class FusionListViewLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionListViewLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered ListView root.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>A list item by exact visible text.</summary>
+    public ILocator Item(string text) =>
+        Root.GetByText(text, new() { Exact = true })
+            .Locator("xpath=ancestor::li[contains(@class,'e-list-item')][1]");
+
+    /// <summary>The checked icon for a list item.</summary>
+    public ILocator CheckedIcon(string text) => Item(text).Locator(".e-check");
+
+    /// <summary>Selects or toggles an item through the browser UI.</summary>
+    public async Task ClickItem(string text, int timeoutMs = 15000)
+    {
+        var item = Item(text);
+        await item.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+        await item.ClickWhenStableAsync(_page, timeoutMs);
+    }
+
+    public async Task<bool> IsSelected(string text)
+    {
+        var className = await Item(text).GetAttributeAsync("class");
+        return Regex.IsMatch(className ?? string.Empty, @"\be-active\b");
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionMenuLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionMenuLocator.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionMenu.
+/// </summary>
+public sealed class FusionMenuLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionMenuLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered menu root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>Menu item by exact visible text.</summary>
+    public ILocator Item(string text) => Root.GetByText(text, new() { Exact = true });
+
+    /// <summary>The open-menu button on the sandbox page.</summary>
+    public ILocator OpenButton => _page.Locator("#open-menu-btn");
+
+    /// <summary>The close-menu button on the sandbox page.</summary>
+    public ILocator CloseButton => _page.Locator("#close-menu-btn");
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionOtpInputLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionOtpInputLocator.cs
@@ -1,0 +1,46 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionOtpInput.
+/// </summary>
+public sealed class FusionOtpInputLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionOtpInputLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The Syncfusion OtpInput host element.</summary>
+    public ILocator Host => _page.Locator($"#{_componentId}");
+
+    /// <summary>The hidden input Syncfusion uses as the submitted value.</summary>
+    public ILocator HiddenInput => Host.Locator("input[type='hidden']");
+
+    /// <summary>Gets a visible OTP field by zero-based index.</summary>
+    public ILocator Field(int index) => Host.Locator("input.e-otp-input-field").Nth(index);
+
+    /// <summary>Gets the hidden submitted value.</summary>
+    public async Task<string> HiddenValue() => await HiddenInput.InputValueAsync();
+
+    /// <summary>Gets the visible field value at the zero-based index.</summary>
+    public async Task<string> FieldValue(int index) => await Field(index).InputValueAsync();
+
+    /// <summary>Fill the OTP fields from left to right.</summary>
+    public async Task FillCode(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            await Field(index).FillAsync(value[index].ToString());
+        }
+    }
+
+    /// <summary>Focus the first visible OTP field.</summary>
+    public async Task Focus() => await Field(0).ClickAsync();
+
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionProgressButtonLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionProgressButtonLocator.cs
@@ -1,0 +1,41 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionProgressButton.
+/// </summary>
+public sealed class FusionProgressButtonLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionProgressButtonLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered Syncfusion ProgressButton element.</summary>
+    public ILocator Button => _page.Locator($"#{_componentId}");
+
+    /// <summary>The rendered Syncfusion content span.</summary>
+    public ILocator Content => Button.Locator(".e-btn-content");
+
+    /// <summary>The rendered Syncfusion progress filler span.</summary>
+    public ILocator Progress => Button.Locator(".e-progress");
+
+    /// <summary>Gets the rendered button class attribute.</summary>
+    public async Task<string> ClassAttribute() =>
+        await Button.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Returns whether the button currently has the given CSS class.</summary>
+    public async Task<bool> HasClass(string className)
+    {
+        var classes = await ClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the button is in Syncfusion's active progress state.</summary>
+    public async Task<bool> IsProgressActive() => await HasClass("e-progress-active");
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionRadioButtonLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionRadioButtonLocator.cs
@@ -1,0 +1,27 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionRadioButton.
+/// </summary>
+public sealed class FusionRadioButtonLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionRadioButtonLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered Syncfusion RadioButton input.</summary>
+    public ILocator Input => _page.Locator($"#{_componentId}");
+
+    /// <summary>The Syncfusion wrapper around the radio input.</summary>
+    public ILocator Wrapper => Input.Locator("xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' e-radio-wrapper ')][1]");
+
+    /// <summary>Returns whether the native input is checked.</summary>
+    public async Task<bool> IsChecked() => await Input.IsCheckedAsync();
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionRatingLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionRatingLocator.cs
@@ -1,0 +1,36 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionRating.
+/// </summary>
+public sealed class FusionRatingLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionRatingLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The Syncfusion Rating input element.</summary>
+    public ILocator Input => _page.Locator($"#{_componentId}");
+
+    /// <summary>Gets the current input value attribute.</summary>
+    public async Task<string?> ValueAttribute() =>
+        await Input.GetAttributeAsync("value");
+
+    /// <summary>Gets the visible rating list's ARIA value.</summary>
+    public async Task<string?> AriaValue() =>
+        await _page.EvaluateAsync<string?>(
+            @"id => {
+                const el = document.getElementById(id);
+                const root = el?.parentElement ?? document;
+                const list = root.querySelector('.e-rating-item-list') ?? document.querySelector('.e-rating-item-list');
+                return list ? list.getAttribute('aria-valuenow') : null;
+            }",
+            _componentId);
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionSidebarLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionSidebarLocator.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionSidebar.
+/// </summary>
+public sealed class FusionSidebarLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionSidebarLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered sidebar root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>The open-state root element.</summary>
+    public ILocator OpenRoot => _page.Locator($"#{_componentId}.e-open");
+
+    /// <summary>The closed-state root element.</summary>
+    public ILocator ClosedRoot => _page.Locator($"#{_componentId}.e-close");
+
+    /// <summary>The sidebar text content.</summary>
+    public async Task<string> Text() => await Root.TextContentAsync() ?? string.Empty;
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionSliderLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionSliderLocator.cs
@@ -1,0 +1,28 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionSlider.
+/// </summary>
+public sealed class FusionSliderLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionSliderLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The Syncfusion Slider host element.</summary>
+    public ILocator Host => _page.Locator($"#{_componentId}");
+
+    /// <summary>Gets a slider handle by zero-based index.</summary>
+    public ILocator Handle(int index) => Host.Locator(".e-handle").Nth(index);
+
+    /// <summary>Gets the current ARIA value for a slider handle.</summary>
+    public async Task<string?> ValueNow(int index = 0) =>
+        await Handle(index).GetAttributeAsync("aria-valuenow");
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionSplitButtonLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionSplitButtonLocator.cs
@@ -1,0 +1,84 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionSplitButton.
+/// </summary>
+public sealed class FusionSplitButtonLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionSplitButtonLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered Syncfusion SplitButton primary button element.</summary>
+    public ILocator Primary => _page.Locator($"#{_componentId}");
+
+    /// <summary>The rendered Syncfusion SplitButton secondary dropdown button element.</summary>
+    public ILocator Secondary => _page.Locator($"#{_componentId}_dropdownbtn");
+
+    /// <summary>The rendered Syncfusion SplitButton wrapper.</summary>
+    public ILocator Wrapper => _page.Locator($"#{_componentId}").Locator("xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' e-split-btn-wrapper ')][1]");
+
+    /// <summary>The rendered Syncfusion popup element.</summary>
+    public ILocator Popup => _page.Locator($"#{_componentId}_dropdownbtn-popup");
+
+    /// <summary>The rendered popup action items.</summary>
+    public ILocator Items => Popup.Locator("li.e-item");
+
+    /// <summary>Locates a popup action item by exact visible text.</summary>
+    public ILocator Item(string text) =>
+        _page.Locator($"//*[@id='{_componentId}_dropdownbtn-popup']//li[contains(concat(' ', normalize-space(@class), ' '), ' e-item ') and normalize-space(.)='{text}']");
+
+    /// <summary>Gets the rendered primary button class attribute.</summary>
+    public async Task<string> PrimaryClassAttribute() =>
+        await Primary.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Gets the rendered secondary button class attribute.</summary>
+    public async Task<string> SecondaryClassAttribute() =>
+        await Secondary.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Gets the rendered wrapper class attribute.</summary>
+    public async Task<string> WrapperClassAttribute() =>
+        await Wrapper.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Gets the rendered popup class attribute.</summary>
+    public async Task<string> PopupClassAttribute() =>
+        await Popup.GetAttributeAsync("class") ?? string.Empty;
+
+    /// <summary>Returns whether the primary button currently has the given CSS class.</summary>
+    public async Task<bool> PrimaryHasClass(string className)
+    {
+        var classes = await PrimaryClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the secondary button currently has the given CSS class.</summary>
+    public async Task<bool> SecondaryHasClass(string className)
+    {
+        var classes = await SecondaryClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the wrapper currently has the given CSS class.</summary>
+    public async Task<bool> WrapperHasClass(string className)
+    {
+        var classes = await WrapperClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the popup currently has the given CSS class.</summary>
+    public async Task<bool> PopupHasClass(string className)
+    {
+        var classes = await PopupClassAttribute();
+        return classes.Split(' ').Contains(className);
+    }
+
+    /// <summary>Returns whether the popup is currently open.</summary>
+    public async Task<bool> IsPopupOpen() => await PopupHasClass("e-popup-open");
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionStepperLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionStepperLocator.cs
@@ -1,0 +1,48 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionStepper.
+/// </summary>
+public sealed class FusionStepperLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionStepperLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered stepper root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>The next command button.</summary>
+    public ILocator NextButton => _page.Locator("#next-step-btn");
+
+    /// <summary>The previous command button.</summary>
+    public ILocator PreviousButton => _page.Locator("#previous-step-btn");
+
+    /// <summary>The reset command button.</summary>
+    public ILocator ResetButton => _page.Locator("#reset-step-btn");
+
+    /// <summary>The command button that writes active step 1.</summary>
+    public ILocator SetReviewButton => _page.Locator("#set-review-step-btn");
+
+    /// <summary>The command button that writes active step 2.</summary>
+    public ILocator SetCompleteButton => _page.Locator("#set-complete-step-btn");
+
+    /// <summary>The command button that writes active step 0.</summary>
+    public ILocator SetIntakeButton => _page.Locator("#set-intake-step-btn");
+
+    /// <summary>The refresh command button.</summary>
+    public ILocator RefreshButton => _page.Locator("#refresh-step-btn");
+
+    /// <summary>The Review step label.</summary>
+    public ILocator ReviewStep => Root.GetByText("Review");
+
+    /// <summary>The Complete step label.</summary>
+    public ILocator CompleteStep => Root.GetByText("Complete");
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionStepperLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionStepperLocator.cs
@@ -19,6 +19,12 @@ public sealed class FusionStepperLocator
     /// <summary>The rendered stepper root element.</summary>
     public ILocator Root => _page.Locator($"#{_componentId}");
 
+    /// <summary>The validation stepper root element.</summary>
+    public ILocator ValidationRoot => _page.Locator("#resident-stepper-validation");
+
+    /// <summary>The validation stepper items.</summary>
+    public ILocator ValidationStepItems => ValidationRoot.Locator(".e-step-container");
+
     /// <summary>The next command button.</summary>
     public ILocator NextButton => _page.Locator("#next-step-btn");
 
@@ -45,4 +51,16 @@ public sealed class FusionStepperLocator
 
     /// <summary>The Complete step label.</summary>
     public ILocator CompleteStep => Root.GetByText("Complete");
+
+    /// <summary>The validation Intake step label.</summary>
+    public ILocator ValidationIntakeStep => ValidationStepItems.Nth(0);
+
+    /// <summary>The validation Review step label.</summary>
+    public ILocator ValidationReviewStep => ValidationStepItems.Nth(1);
+
+    /// <summary>The validation Complete step label.</summary>
+    public ILocator ValidationCompleteStep => ValidationStepItems.Nth(2);
+
+    /// <summary>The validation stepper tooltip.</summary>
+    public ILocator ValidationTooltip => _page.Locator(".e-tooltip-wrap.e-stepper-tooltip");
 }

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionTextAreaLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionTextAreaLocator.cs
@@ -1,0 +1,44 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionTextArea.
+/// </summary>
+public sealed class FusionTextAreaLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionTextAreaLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The visible Syncfusion TextArea element.</summary>
+    public ILocator TextArea => _page.Locator($"#{_componentId}");
+
+    /// <summary>Click and fill the textarea with text.</summary>
+    public async Task Fill(string value)
+    {
+        await TextArea.ClickAsync();
+        await TextArea.FillAsync(value);
+    }
+
+    /// <summary>Clear the textarea.</summary>
+    public async Task Clear() => await TextArea.FillAsync("");
+
+    /// <summary>Click the textarea to focus it.</summary>
+    public async Task Focus() => await TextArea.ClickAsync();
+
+    /// <summary>Blur the textarea.</summary>
+    public async Task Blur() => await TextArea.BlurAsync();
+
+    /// <summary>Fill text and then blur to trigger Syncfusion's change event.</summary>
+    public async Task FillAndBlur(string value)
+    {
+        await Fill(value);
+        await Blur();
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionTextBoxLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionTextBoxLocator.cs
@@ -1,0 +1,47 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionTextBox.
+/// </summary>
+public sealed class FusionTextBoxLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionTextBoxLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The visible Syncfusion TextBox input.</summary>
+    public ILocator Input => _page.Locator($"#{_componentId}");
+
+    /// <summary>The Syncfusion wrapper generated around the input.</summary>
+    public ILocator Wrapper => _page.Locator($"#{_componentId}").Locator("xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' e-input-group ')][1]");
+
+    /// <summary>Click and fill the input with text.</summary>
+    public async Task Fill(string value)
+    {
+        await Input.ClickAsync();
+        await Input.FillAsync(value);
+    }
+
+    /// <summary>Clear the input.</summary>
+    public async Task Clear() => await Input.FillAsync("");
+
+    /// <summary>Click the input to focus it.</summary>
+    public async Task Focus() => await Input.ClickAsync();
+
+    /// <summary>Blur the input.</summary>
+    public async Task Blur() => await Input.BlurAsync();
+
+    /// <summary>Fill text and then blur to trigger Syncfusion's change event.</summary>
+    public async Task FillAndBlur(string value)
+    {
+        await Fill(value);
+        await Blur();
+    }
+}

--- a/tests/Alis.Reactive.Playwright.Extensions/FusionToolbarLocator.cs
+++ b/tests/Alis.Reactive.Playwright.Extensions/FusionToolbarLocator.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.Playwright.Extensions;
+
+/// <summary>
+/// User interaction primitives for FusionToolbar.
+/// </summary>
+public sealed class FusionToolbarLocator
+{
+    private readonly IPage _page;
+    private readonly string _componentId;
+
+    public FusionToolbarLocator(IPage page, string componentId)
+    {
+        _page = page;
+        _componentId = componentId;
+    }
+
+    /// <summary>The rendered toolbar root element.</summary>
+    public ILocator Root => _page.Locator($"#{_componentId}");
+
+    /// <summary>The save toolbar item.</summary>
+    public ILocator SaveItem => _page.Locator("#toolbar-save");
+
+    /// <summary>The delete toolbar item.</summary>
+    public ILocator DeleteItem => _page.Locator("#toolbar-delete");
+
+    /// <summary>The disabled-state root element.</summary>
+    public ILocator DisabledRoot => _page.Locator($"#{_componentId}.e-disabled");
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGrid.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGrid.cs
@@ -1,4 +1,4 @@
-namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion.Grid;
 
 /// <summary>
 /// Exercises FusionGrid server-side custom binding end-to-end:

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridBilling.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridBilling.cs
@@ -1,0 +1,155 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion.Grid;
+
+[TestFixture]
+public class WhenUsingFusionGridBilling : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Grid/Billing";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_ResidentBillingViewModel";
+    private const string GridId = "billing-grid";
+
+    private FusionTextBoxLocator NewResidentName => new(Page, Scope + "__NewResidentName");
+    private DropDownListLocator NewCareLevel => new(Page, Scope + "__NewCareLevel");
+    private NumericTextBoxLocator NewMonthlyRate => new(Page, Scope + "__NewMonthlyRate");
+    private NumericTextBoxLocator NewAddOnCharges => new(Page, Scope + "__NewAddOnCharges");
+
+    private ILocator ErrorFor(string property) => Page.Locator($"#{Scope}__{property}_error");
+    private ILocator FirstRowCell(int columnIndex) =>
+        Page.Locator($"#{GridId} .e-row").First.Locator(".e-rowcell").Nth(columnIndex);
+
+    private async Task NavigateBilling()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#billing-status"))
+            .ToHaveTextAsync("loaded current census", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId} .e-row").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task billing_board_loads_census_with_currency_and_outstanding_summary()
+    {
+        await NavigateBilling();
+
+        await Expect(Page.Locator($"#{GridId}")).ToContainTextAsync("Amina Patel", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).ToContainTextAsync("$3,200", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#billing-summary")).ToContainTextAsync("outstanding", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task applying_five_percent_increase_to_selected_resident_raises_their_rate()
+    {
+        await NavigateBilling();
+
+        await ClickWhenStable(FirstRowCell(1));
+        await ClickWhenStable(Page.Locator("#billing-bulk-increase"));
+
+        await Expect(Page.Locator("#billing-summary"))
+            .ToHaveTextAsync("applied 5% increase to 1 resident(s)", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#billing-status"))
+            .ToHaveTextAsync("rate increase applied", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).ToContainTextAsync("$3,360", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task saving_batch_cell_edits_posts_all_charges_to_the_server()
+    {
+        await NavigateBilling();
+
+        await FirstRowCell(4).DblClickAsync();
+        await Expect(Page.Locator($"#{GridId} input.e-field").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Page.Locator($"#{GridId} input.e-field").First.FillAsync("5000");
+        await Page.Keyboard.PressAsync("Enter");
+
+        await ClickWhenStable(Page.Locator("#billing-save-all"));
+
+        await Expect(Page.Locator("#billing-summary"))
+            .ToContainTextAsync("saved 1 resident charge(s)", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#billing-status"))
+            .ToHaveTextAsync("charges saved", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).ToContainTextAsync("$5,000", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task adding_a_charge_through_the_dialog_validates_then_inserts_a_row()
+    {
+        await NavigateBilling();
+
+        await ClickWhenStable(Page.Locator("#billing-add-open"));
+        await Expect(Page.Locator("#add-charge-dialog")).Not.ToHaveClassAsync(
+            new System.Text.RegularExpressions.Regex("hidden"), new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#add-charge-save"));
+        await Expect(ErrorFor("NewResidentName")).ToContainTextAsync("required", new() { Timeout = 10000 });
+        await Expect(ErrorFor("NewCareLevel")).ToContainTextAsync("required", new() { Timeout = 10000 });
+
+        await NewResidentName.FillAndBlur("Dorothy Admit");
+        await NewCareLevel.Select("Assisted Living");
+        await NewMonthlyRate.FillAndBlur("5200");
+        await NewAddOnCharges.FillAndBlur("250");
+        await ClickWhenStable(Page.Locator("#add-charge-save"));
+
+        await Expect(Page.Locator("#billing-status")).ToHaveTextAsync("charge added", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).ToContainTextAsync("Dorothy Admit", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#add-charge-dialog")).ToHaveClassAsync(
+            new System.Text.RegularExpressions.Regex("hidden"), new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task clicking_email_statements_toolbar_item_runs_the_toolbar_workflow()
+    {
+        await NavigateBilling();
+
+        await ClickWhenStable(
+            Page.Locator($"#{GridId} .e-toolbar-item").Filter(new() { HasText = "Email Statements" }));
+
+        await Expect(Page.Locator("#toolbar-status"))
+            .ToHaveTextAsync("statements queued for emailing", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task memory_care_quick_filter_reloads_only_memory_care_residents()
+    {
+        await NavigateBilling();
+
+        await ClickWhenStable(Page.Locator("#billing-quick-memory"));
+
+        await Expect(Page.Locator("#billing-summary"))
+            .ToContainTextAsync("Memory Care", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#billing-status"))
+            .ToHaveTextAsync("showing memory care residents", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).Not.ToContainTextAsync("Independent", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task roster_tools_autofit_and_column_chooser_run_through_onboarded_methods()
+    {
+        await NavigateBilling();
+
+        await ClickWhenStable(Page.Locator("#billing-autofit"));
+        await Expect(Page.Locator("#tool-status"))
+            .ToHaveTextAsync("columns auto-fitted", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#billing-columns"));
+        await Expect(Page.Locator("#tool-status"))
+            .ToHaveTextAsync("column chooser opened", new() { Timeout = 10000 });
+        await Expect(Page.Locator(".e-ccdlg").First).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridCareOps.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridCareOps.cs
@@ -1,0 +1,134 @@
+using Microsoft.Playwright;
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion.Grid;
+
+[TestFixture]
+public class WhenUsingFusionGridCareOps : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Grid/CareOps";
+    private const string GridId = "careops-grid";
+
+    private async Task NavigateCareOps()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#careops-status"))
+            .ToHaveTextAsync("loaded care census", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId} .e-row").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task care_board_loads_with_chip_filters_and_census()
+    {
+        await NavigateCareOps();
+
+        await Expect(Page.Locator("#careops-risk-chips")).ToContainTextAsync("Critical", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).ToContainTextAsync("Amina Patel", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#careops-summary")).ToContainTextAsync("whole census", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task critical_chip_fast_filter_shows_only_critical_residents()
+    {
+        await NavigateCareOps();
+
+        await ClickWhenStable(Page.Locator("#careops-risk-chips").GetByText("Critical", new() { Exact = true }));
+
+        await Expect(Page.Locator("#careops-summary"))
+            .ToContainTextAsync("Critical risk", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).Not.ToContainTextAsync("Moderate", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task editing_nurse_with_the_typed_select_editor_saves_to_the_server()
+    {
+        await NavigateCareOps();
+
+        var nurseCell = Page.Locator($"#{GridId}")
+            .GetByRole(AriaRole.Gridcell).Filter(new() { HasText = "Nora Ellis" }).First;
+        await nurseCell.DblClickAsync();
+
+        var editor = Page.Locator($"#{GridId} select[name='primaryNurse']");
+        await Expect(editor).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await editor.SelectOptionAsync("Night Float Team");
+
+        // Save directly with the editor still OPEN (no intermediate cell click).
+        // The Save-All pipeline must call grid.SaveCell() to commit the open cell
+        // into the batch before getBatchChanges — regression guard for the bug
+        // where changing a select then clicking Save did not persist.
+        await ClickWhenStable(Page.Locator("#careops-save-all"));
+
+        await Expect(Page.Locator("#careops-summary"))
+            .ToContainTextAsync("saved care-plan updates", new() { Timeout = 10000 });
+        await Expect(Page.Locator($"#{GridId}")).ToContainTextAsync("Night Float Team", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task discharging_selected_resident_through_native_action_link_removes_them()
+    {
+        await NavigateCareOps();
+
+        await ClickWhenStable(Page.Locator($"#{GridId} .e-row").First.Locator(".e-checkselect").First);
+        await ClickWhenStable(Page.GetByRole(AriaRole.Link, new() { Name = "Discharge Selected" }));
+
+        var dialog = Page.Locator("#alisConfirmDialog");
+        await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await dialog.Locator("button.e-primary").ClickAsync();
+
+        await Expect(Page.Locator("#careops-status"))
+            .ToHaveTextAsync("resident discharged", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#careops-summary"))
+            .ToContainTextAsync("discharged", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task per_row_flag_critical_action_link_updates_the_row_and_reinjects_the_list()
+    {
+        await NavigateCareOps();
+        await Expect(Page.Locator("#careops-action-rows a").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#careops-action-rows")
+            .GetByRole(AriaRole.Link, new() { Name = "Flag Critical" }).First);
+
+        await Expect(Page.Locator("#careops-rows-status"))
+            .ToContainTextAsync("flagged critical", new() { Timeout = 10000 });
+        await Expect(Page.Locator("[data-testid^='careops-action-row-']").First)
+            .ToContainTextAsync("Critical risk", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task per_row_discharge_action_link_confirms_and_removes_that_resident()
+    {
+        await NavigateCareOps();
+        await Expect(Page.Locator("#careops-action-rows a").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#careops-action-rows")
+            .GetByRole(AriaRole.Link, new() { Name = "Discharge" }).First);
+
+        var dialog = Page.Locator("#alisConfirmDialog");
+        await Expect(dialog).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await dialog.Locator("button.e-primary").ClickAsync();
+
+        await Expect(Page.Locator("#careops-rows-status"))
+            .ToContainTextAsync("discharged", new() { Timeout = 10000 });
+        // Amina Patel is the seed first resident; the confirm-gated link removed her.
+        await Expect(Page.Locator("#careops-action-rows"))
+            .Not.ToContainTextAsync("Amina Patel", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridCareOps.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridCareOps.cs
@@ -131,4 +131,29 @@ public class WhenUsingFusionGridCareOps : PlaywrightTestBase
 
         AssertNoConsoleErrors();
     }
+
+    [Test]
+    public async Task an_out_of_range_open_tasks_edit_is_blocked_by_the_generated_care_rule()
+    {
+        await NavigateCareOps();
+
+        // Open Tasks is the aria-colindex 8 column; edit the first row's cell.
+        var openTasksCells = Page.Locator($"#{GridId} td[aria-colindex='8']");
+        await openTasksCells.First.DblClickAsync();
+
+        var editor = Page.Locator("#careops-gridopenTasks");
+        await Expect(editor).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await editor.FillAsync("99");
+
+        // Leaving the cell runs EJ2's native cell validation. The rule was generated
+        // from ResidentCareItemValidator.ClientRule(r => r.OpenTasks).Range(0, 7, ...) —
+        // the same FluentValidation metadata that powers form validation. No second
+        // ruleset is authored: the message proves the single source reached the cell.
+        await openTasksCells.Nth(1).DblClickAsync();
+
+        await Expect(Page.GetByText("Open tasks must be between 0 and 7."))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
 }

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridDirectory.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridDirectory.cs
@@ -1,4 +1,4 @@
-namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion.Grid;
 
 [TestFixture]
 public class WhenUsingFusionGridDirectory : PlaywrightTestBase
@@ -104,8 +104,11 @@ public class WhenUsingFusionGridDirectory : PlaywrightTestBase
         await Expect(Page.Locator("#resident-virtual-grid .e-row").First)
             .ToBeVisibleAsync(new() { Timeout = 10000 });
 
+        // Real wheel gesture over the virtual content — lets Syncfusion's own
+        // scroll handling fire the data-state fetch (no synthetic scroll event).
         var content = Page.Locator("#resident-virtual-grid .e-content").First;
-        await content.EvaluateAsync("el => { el.scrollTop = 1200; el.dispatchEvent(new Event('scroll')); }");
+        await content.HoverAsync();
+        await Page.Mouse.WheelAsync(0, 1200);
 
         await Expect(Page.Locator("#virtual-status"))
             .ToHaveTextAsync("virtual block refreshed", new() { Timeout = 10000 });

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridEditing.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridEditing.cs
@@ -1,6 +1,6 @@
 using Alis.Reactive.Playwright.Extensions;
 
-namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion.Grid;
 
 [TestFixture]
 public class WhenUsingFusionGridEditing : PlaywrightTestBase
@@ -97,7 +97,10 @@ public class WhenUsingFusionGridEditing : PlaywrightTestBase
         await ClickWhenStable(Page.Locator("#dialog-select-first"));
         await ClickWhenStable(Page.Locator("#dialog-start-edit"));
 
-        await Expect(Page.Locator("#resident-dialog-template-marker"))
+        // The typed DialogForm rendered its labeled fields (Resident / Risk / Open tasks).
+        await Expect(Page.Locator("input[name='residentName']"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("select[name='riskLevel']"))
             .ToBeVisibleAsync(new() { Timeout = 10000 });
         await Expect(Page.Locator("#dialog-begin-resident"))
             .Not.ToHaveTextAsync("waiting", new() { Timeout = 10000 });

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridOperations.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/Grid/WhenUsingFusionGridOperations.cs
@@ -1,6 +1,6 @@
 using Alis.Reactive.Playwright.Extensions;
 
-namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion.Grid;
 
 [TestFixture]
 public class WhenUsingFusionGridOperations : PlaywrightTestBase

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBreadcrumb.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBreadcrumb.cs
@@ -72,6 +72,9 @@ public class WhenUsingFusionBreadcrumb : PlaywrightTestBase
         await Expect(Page.Locator("#clicked-url")).ToHaveTextAsync("/home", new() { Timeout = 5000 });
         await Expect(Page.Locator("#clicked-icon-css")).ToHaveTextAsync("e-icons e-home", new() { Timeout = 5000 });
         await Expect(Page.Locator("#clicked-disabled")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#route-message")).ToHaveTextAsync("Opening Home in workspace", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#route-category")).ToHaveTextAsync("workspace", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#route-trail")).ToHaveTextAsync("home:/home", new() { Timeout = 5000 });
         await Expect(Breadcrumb.CurrentItem).ToHaveTextAsync("Home", new() { Timeout = 5000 });
         AssertNoConsoleErrors();
     }

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBreadcrumb.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBreadcrumb.cs
@@ -1,0 +1,75 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionBreadcrumb : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionBreadcrumb";
+
+    private FusionBreadcrumbLocator Breadcrumb => new(Page, "navigation-breadcrumb");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#active-item-echo", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionBreadcrumb — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_breadcrumb_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("navigation-breadcrumb"));
+        Assert.That(planJson, Does.Contain("\"activeItem\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"itemClick\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task dom_ready_reads_active_item_source_and_current_item()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#active-item-echo")).ToHaveTextAsync("/docs", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#active-state")).ToHaveTextAsync("has active item", new() { Timeout = 5000 });
+        await Expect(Breadcrumb.CurrentItem).ToHaveTextAsync("Docs", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_active_item_updates_source_and_rendered_current_item()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-guide-btn").ClickAsync();
+
+        await Expect(Page.Locator("#active-item-echo")).ToHaveTextAsync("/docs/guide", new() { Timeout = 5000 });
+        await Expect(Breadcrumb.CurrentItem).ToHaveTextAsync("Guide", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task item_click_reads_typed_payload_and_updates_current_item()
+    {
+        await NavigateAndBoot();
+
+        await Breadcrumb.ClickLink("Home");
+
+        await Expect(Page.Locator("#clicked-text")).ToHaveTextAsync("Home", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#clicked-url")).ToHaveTextAsync("/home", new() { Timeout = 5000 });
+        await Expect(Breadcrumb.CurrentItem).ToHaveTextAsync("Home", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBreadcrumb.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBreadcrumb.cs
@@ -68,7 +68,10 @@ public class WhenUsingFusionBreadcrumb : PlaywrightTestBase
         await Breadcrumb.ClickLink("Home");
 
         await Expect(Page.Locator("#clicked-text")).ToHaveTextAsync("Home", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#clicked-id")).ToHaveTextAsync("home", new() { Timeout = 5000 });
         await Expect(Page.Locator("#clicked-url")).ToHaveTextAsync("/home", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#clicked-icon-css")).ToHaveTextAsync("e-icons e-home", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#clicked-disabled")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Breadcrumb.CurrentItem).ToHaveTextAsync("Home", new() { Timeout = 5000 });
         AssertNoConsoleErrors();
     }

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBulletChart.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBulletChart.cs
@@ -76,6 +76,8 @@ public class WhenUsingFusionBulletChart : PlaywrightTestBase
         await Expect(Page.Locator("#tooltip-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
         await Expect(Page.Locator("#tooltip-value")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
         await Expect(Page.Locator("#tooltip-target")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#tooltip-name")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#tooltip-template")).ToHaveTextAsync("none", new() { Timeout = 5000 });
         await Expect(Page.Locator("#tooltip-text")).ToHaveTextAsync("Bullet tooltip rewritten", new() { Timeout = 5000 });
 
         AssertNoConsoleErrors();

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBulletChart.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBulletChart.cs
@@ -1,0 +1,83 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionBulletChart : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionBulletChart";
+
+    private FusionBulletChartLocator BulletChart => new(Page, "resident-bullet-chart");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("#resident-bullet-chart svg")).ToHaveCountAsync(1, new() { Timeout = 5000 });
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionBulletChart — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_bullet_chart_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("resident-bullet-chart"));
+        Assert.That(planJson, Does.Contain("\"tooltipRender\""));
+        Assert.That(planJson, Does.Contain("\"bulletChartMouseClick\""));
+        Assert.That(planJson, Does.Contain("\"getActualIndex\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task load_and_method_reads_are_proven()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#actual-index-negative")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#actual-index-overflow")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task click_payload_exposes_target_and_mouse_coordinates()
+    {
+        await NavigateAndBoot();
+
+        await BulletChart.FeatureMeasure.ClickAsync(new() { Force = true });
+
+        await Expect(Page.Locator("#mouse-click-state")).ToHaveTextAsync("clicked", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#mouse-click-target")).ToContainTextAsync("FeatureMeasure", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#mouse-click-x")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#mouse-click-y")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task tooltip_render_is_mutated_and_reports_target_payload()
+    {
+        await NavigateAndBoot();
+
+        await BulletChart.FeatureMeasure.HoverAsync();
+
+        await Expect(BulletChart.Tooltip).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await Expect(BulletChart.Tooltip).ToContainTextAsync("Bullet tooltip rewritten", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#tooltip-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#tooltip-value")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#tooltip-target")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#tooltip-text")).ToHaveTextAsync("Bullet tooltip rewritten", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBulletChart.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionBulletChart.cs
@@ -60,6 +60,9 @@ public class WhenUsingFusionBulletChart : PlaywrightTestBase
         await Expect(Page.Locator("#mouse-click-target")).ToContainTextAsync("FeatureMeasure", new() { Timeout = 5000 });
         await Expect(Page.Locator("#mouse-click-x")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
         await Expect(Page.Locator("#mouse-click-y")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#click-audit-message")).ToHaveTextAsync("Opened readiness drilldown for North Wing", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#click-audit-wing")).ToHaveTextAsync("North Wing", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#click-audit-coordinates")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
 
         AssertNoConsoleErrors();
     }

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionButton.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionButton.cs
@@ -1,0 +1,163 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionButton : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Button";
+    private const string ButtonId = "fusion-action-button";
+
+    private FusionButtonLocator Button => new(Page, ButtonId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#content-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionButton — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_button_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(ButtonId));
+        Assert.That(planJson, Does.Contain("\"content\""));
+        Assert.That(planJson, Does.Contain("\"disabled\""));
+        Assert.That(planJson, Does.Contain("\"iconCss\""));
+        Assert.That(planJson, Does.Contain("\"iconPosition\""));
+        Assert.That(planJson, Does.Contain("\"cssClass\""));
+        Assert.That(planJson, Does.Contain("\"isPrimary\""));
+        Assert.That(planJson, Does.Contain("\"isToggle\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"click\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_content_and_reads_content_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Button.Button).ToContainTextAsync("Ready", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Ready", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_content_updates_visible_button_and_content_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+
+        await Expect(Button.Button).ToContainTextAsync("Queued", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Queued", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("content set", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task disabled_write_updates_dom_source_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-button-btn").ClickAsync();
+        await Expect(Page.Locator("#disabled-state")).ToHaveTextAsync("enabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#disable-btn").ClickAsync();
+        await Expect(Button.Button).ToBeDisabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-button-btn").ClickAsync();
+        await Expect(Page.Locator("#disabled-state")).ToHaveTextAsync("disabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-btn").ClickAsync();
+        await Expect(Button.Button).ToBeEnabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task icon_css_class_and_primary_writes_update_visible_classes()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-icon-btn").ClickAsync();
+        await Expect(Button.Icon).ToHaveCountAsync(1);
+        var iconClasses = await Button.IconClassAttribute();
+        Assert.That(iconClasses, Does.Contain("e-edit"));
+        Assert.That(iconClasses, Does.Contain("e-icon-right"));
+
+        await Page.Locator("#set-css-btn").ClickAsync();
+        Assert.That(await Button.HasClass("e-success"), Is.True);
+        Assert.That(await Button.HasClass("extra-class"), Is.True);
+        await Expect(Page.Locator("#css-echo")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+
+        await Page.Locator("#set-primary-btn").ClickAsync();
+        Assert.That(await Button.HasClass("e-primary"), Is.True);
+        await Expect(Page.Locator("#primary-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task click_method_invokes_button_and_toggle_can_be_disabled()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#click-button-btn").ClickAsync();
+        await Expect(Page.Locator("#click-state")).ToHaveTextAsync("click called", new() { Timeout = 5000 });
+        Assert.That(await Button.HasClass("e-active"), Is.True);
+
+        await Page.Locator("#set-toggle-btn").ClickAsync();
+        await Expect(Page.Locator("#toggle-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        Assert.That(await Button.HasClass("e-active"), Is.False);
+
+        await Page.Locator("#click-button-btn").ClickAsync();
+        Assert.That(await Button.HasClass("e-active"), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_button()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-button-btn").ClickAsync();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(Button.Button).ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_button_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+        await Page.Locator("#set-css-btn").ClickAsync();
+        await Page.Locator("#set-primary-btn").ClickAsync();
+        await Page.Locator("#set-toggle-btn").ClickAsync();
+        await Page.Locator("#disable-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-content")).ToHaveTextAsync("Queued", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-disabled")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-css")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-primary")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-toggle")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("Queued:True:True:False", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCarousel.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCarousel.cs
@@ -1,0 +1,89 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionCarousel : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionCarousel";
+
+    private FusionCarouselLocator Carousel => new(Page, "resident-carousel");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#selected-index-echo", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionCarousel — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_carousel_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("resident-carousel"));
+        Assert.That(planJson, Does.Contain("\"selectedIndex\""));
+        Assert.That(planJson, Does.Contain("\"next\""));
+        Assert.That(planJson, Does.Contain("\"prev\""));
+        Assert.That(planJson, Does.Contain("\"slideChanging\""));
+        Assert.That(planJson, Does.Contain("\"slideChanged\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task dom_ready_reads_selected_index_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-state")).ToHaveTextAsync("second slide", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task next_and_previous_methods_update_selected_slide_and_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#next-btn").ClickAsync();
+        await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-current")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-direction")).ToHaveTextAsync("Next", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Three", new() { Timeout = 5000 });
+
+        await Page.Locator("#prev-btn").ClickAsync();
+        await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-current")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-direction")).ToHaveTextAsync("Previous", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task slide_changing_can_cancel_the_final_previous_transition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#next-btn").ClickAsync();
+        await Page.Locator("#prev-btn").ClickAsync();
+        await Page.Locator("#prev-btn").ClickAsync();
+
+        await Expect(Page.Locator("#cancel-state")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-state")).ToHaveTextAsync("changed", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCarousel.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCarousel.cs
@@ -46,7 +46,7 @@ public class WhenUsingFusionCarousel : PlaywrightTestBase
 
         await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#selected-state")).ToHaveTextAsync("second slide", new() { Timeout = 5000 });
-        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToContainTextAsync("Care Plan Review", new() { Timeout = 5000 });
         AssertNoConsoleErrors();
     }
 
@@ -63,7 +63,10 @@ public class WhenUsingFusionCarousel : PlaywrightTestBase
         await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-is-swiped")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-direction")).ToHaveTextAsync("Next", new() { Timeout = 5000 });
-        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Three", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#review-persisted")).ToHaveTextAsync("Saved review slide 2: discharge readiness", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#review-section")).ToHaveTextAsync("discharge readiness", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#review-direction")).ToHaveTextAsync("Next", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToContainTextAsync("Discharge Readiness", new() { Timeout = 5000 });
 
         await Page.Locator("#prev-btn").ClickAsync();
         await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
@@ -73,7 +76,10 @@ public class WhenUsingFusionCarousel : PlaywrightTestBase
         await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("2", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-is-swiped")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-direction")).ToHaveTextAsync("Previous", new() { Timeout = 5000 });
-        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#review-persisted")).ToHaveTextAsync("Saved review slide 1: care plan review", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#review-section")).ToHaveTextAsync("care plan review", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#review-direction")).ToHaveTextAsync("Previous", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToContainTextAsync("Care Plan Review", new() { Timeout = 5000 });
         AssertNoConsoleErrors();
     }
 
@@ -91,7 +97,8 @@ public class WhenUsingFusionCarousel : PlaywrightTestBase
         await Expect(Page.Locator("#changing-cancel")).ToHaveTextAsync("true", new() { Timeout = 5000 });
         await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-state")).ToHaveTextAsync("changed", new() { Timeout = 5000 });
-        await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#review-persisted")).ToHaveTextAsync("Saved review slide 1: care plan review", new() { Timeout = 5000 });
+        await Expect(Carousel.ActiveSlide).ToContainTextAsync("Care Plan Review", new() { Timeout = 5000 });
         AssertNoConsoleErrors();
     }
 }

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCarousel.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCarousel.cs
@@ -57,15 +57,21 @@ public class WhenUsingFusionCarousel : PlaywrightTestBase
 
         await Page.Locator("#next-btn").ClickAsync();
         await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changing-is-swiped")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changing-cancel")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-current")).ToHaveTextAsync("2", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-is-swiped")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-direction")).ToHaveTextAsync("Next", new() { Timeout = 5000 });
         await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Three", new() { Timeout = 5000 });
 
         await Page.Locator("#prev-btn").ClickAsync();
         await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changing-is-swiped")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changing-cancel")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-current")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-is-swiped")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-direction")).ToHaveTextAsync("Previous", new() { Timeout = 5000 });
         await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });
         AssertNoConsoleErrors();
@@ -81,6 +87,8 @@ public class WhenUsingFusionCarousel : PlaywrightTestBase
         await Page.Locator("#prev-btn").ClickAsync();
 
         await Expect(Page.Locator("#cancel-state")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changing-is-swiped")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changing-cancel")).ToHaveTextAsync("true", new() { Timeout = 5000 });
         await Expect(Page.Locator("#selected-index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#changed-state")).ToHaveTextAsync("changed", new() { Timeout = 5000 });
         await Expect(Carousel.ActiveSlide).ToHaveTextAsync("Two", new() { Timeout = 5000 });

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCheckBox.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionCheckBox.cs
@@ -1,0 +1,159 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionCheckBox : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionCheckBox";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_FusionCheckBoxModel";
+    private const string ConsentAcceptedId = Scope + "__ConsentAccepted";
+    private const string ReviewNeededId = Scope + "__ReviewNeeded";
+
+    private FusionCheckBoxLocator ConsentAccepted => new(Page, ConsentAcceptedId);
+    private FusionCheckBoxLocator ReviewNeeded => new(Page, ReviewNeededId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#checked-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionCheckBox — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_checkbox_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(ConsentAcceptedId));
+        Assert.That(planJson, Does.Contain(ReviewNeededId));
+        Assert.That(planJson, Does.Contain("\"checked\""));
+        Assert.That(planJson, Does.Contain("\"indeterminate\""));
+        Assert.That(planJson, Does.Contain("\"disabled\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"click\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        Assert.That(planJson, Does.Contain("\"change\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_checked_and_indeterminate_state_sources()
+    {
+        await NavigateAndBoot();
+
+        Assert.That(await ConsentAccepted.IsChecked(), Is.True);
+        Assert.That(await ConsentAccepted.FrameHasClass("e-check"), Is.True);
+        await Expect(Page.Locator("#checked-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        Assert.That(await ReviewNeeded.IsIndeterminate(), Is.True);
+        Assert.That(await ReviewNeeded.FrameHasClass("e-stop"), Is.True);
+        await Expect(Page.Locator("#indeterminate-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_checked_updates_visible_state_source_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-consent-btn").ClickAsync();
+        await Expect(Page.Locator("#checked-state")).ToHaveTextAsync("accepted", new() { Timeout = 5000 });
+
+        await Page.Locator("#set-unchecked-btn").ClickAsync();
+        Assert.That(await ConsentAccepted.IsChecked(), Is.False);
+        Assert.That(await ConsentAccepted.FrameHasClass("e-check"), Is.False);
+        await Expect(Page.Locator("#checked-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-consent-btn").ClickAsync();
+        await Expect(Page.Locator("#checked-state")).ToHaveTextAsync("missing", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_indeterminate_updates_visible_state_and_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-indeterminate-btn").ClickAsync();
+
+        Assert.That(await ReviewNeeded.IsIndeterminate(), Is.True);
+        Assert.That(await ReviewNeeded.FrameHasClass("e-stop"), Is.True);
+        await Expect(Page.Locator("#indeterminate-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("indeterminate set", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_disabled_updates_visible_state_and_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#disable-review-btn").ClickAsync();
+        await Expect(ReviewNeeded.Input).ToBeDisabledAsync(new() { Timeout = 5000 });
+        Assert.That(await ReviewNeeded.WrapperHasClass("e-checkbox-disabled"), Is.True);
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-review-btn").ClickAsync();
+        await Expect(ReviewNeeded.Input).ToBeEnabledAsync(new() { Timeout = 5000 });
+        Assert.That(await ReviewNeeded.WrapperHasClass("e-checkbox-disabled"), Is.False);
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task click_method_toggles_checked_state_and_change_event_reads_payload()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#click-consent-btn").ClickAsync();
+
+        await Expect(Page.Locator("#click-state")).ToHaveTextAsync("click called", new() { Timeout = 5000 });
+        Assert.That(await ConsentAccepted.IsChecked(), Is.False);
+        await Expect(Page.Locator("#change-checked")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("unchecked", new() { Timeout = 5000 });
+
+        await Page.Locator("#click-consent-btn").ClickAsync();
+        Assert.That(await ConsentAccepted.IsChecked(), Is.True);
+        await Expect(Page.Locator("#change-checked")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("checked", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_checkbox()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-consent-btn").ClickAsync();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(ConsentAccepted.Input).ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_checkbox_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-unchecked-btn").ClickAsync();
+        await Page.Locator("#set-indeterminate-btn").ClickAsync();
+        await Page.Locator("#disable-review-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-checked")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-indeterminate")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-disabled")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("False:True:True", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionComboBox.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionComboBox.cs
@@ -1,0 +1,177 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionComboBox : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionComboBox";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_FusionComboBoxModel";
+    private const string ResidentId = Scope + "__Resident";
+
+    private FusionComboBoxLocator Resident => new(Page, ResidentId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#value-echo", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionComboBox — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_combo_box_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(ResidentId));
+        Assert.That(planJson, Does.Contain("\"value\""));
+        Assert.That(planJson, Does.Contain("\"text\""));
+        Assert.That(planJson, Does.Contain("\"index\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"showPopup\""));
+        Assert.That(planJson, Does.Contain("\"hidePopup\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        Assert.That(planJson, Does.Contain("\"focusOut\""));
+        Assert.That(planJson, Does.Contain("\"clear\""));
+        Assert.That(planJson, Does.Contain("\"change\""));
+        Assert.That(planJson, Does.Contain("\"focus\""));
+        Assert.That(planJson, Does.Contain("\"blur\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_value_and_reads_value_text_index_sources()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Resident.Input).ToHaveValueAsync("Alice", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("alice", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#text-echo")).ToHaveTextAsync("Alice", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-echo")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_value_text_and_index_update_visible_state_and_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-value-btn").ClickAsync();
+        await Expect(Resident.Input).ToHaveValueAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#text-echo")).ToHaveTextAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+
+        await Page.Locator("#set-text-btn").ClickAsync();
+        await Expect(Resident.Input).ToHaveValueAsync("Carey", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("carey", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#text-echo")).ToHaveTextAsync("Carey", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-echo")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+
+        await Page.Locator("#set-index-btn").ClickAsync();
+        await Expect(Resident.Input).ToHaveValueAsync("Dawson", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("dawson", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#text-echo")).ToHaveTextAsync("Dawson", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#index-echo")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task showpopup_and_hidepopup_methods_control_popup()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#show-popup-btn").ClickAsync();
+        await Expect(Resident.Popup).ToBeVisibleAsync(new() { Timeout = 5000 });
+
+        await Page.Locator("#hide-popup-btn").ClickAsync();
+        await Expect(Resident.Popup).ToBeHiddenAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_and_focusout_methods_control_focus_and_fire_events()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-combo-btn").ClickAsync();
+        await Expect(Resident.Input).ToBeFocusedAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focused", new() { Timeout = 5000 });
+
+        await Page.Locator("#blur-combo-btn").ClickAsync();
+        await Expect(Resident.Input).Not.ToBeFocusedAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#blur-state")).ToHaveTextAsync("blurred", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task changed_event_payload_and_conditions_update_trace()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#show-popup-btn").ClickAsync();
+        await Resident.SelectItem("Bennett");
+
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#event-text")).ToHaveTextAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("other resident", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-indicator")).ToBeVisibleAsync(new() { Timeout = 5000 });
+
+        await Page.Locator("#show-popup-btn").ClickAsync();
+        await Resident.SelectItem("Alice");
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("alice selected", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task clear_method_resets_input_and_hides_component_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#show-popup-btn").ClickAsync();
+        await Resident.SelectItem("Carey");
+        await Expect(Page.Locator("#selected-indicator")).ToBeVisibleAsync(new() { Timeout = 5000 });
+
+        await Page.Locator("#clear-combo-btn").ClickAsync();
+        await Expect(Resident.Input).ToHaveValueAsync("", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("cleared", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-indicator")).ToBeHiddenAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_index_source_supports_conditions()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-index-btn").ClickAsync();
+        await Page.Locator("#check-index-btn").ClickAsync();
+
+        await Expect(Page.Locator("#index-condition")).ToHaveTextAsync("index three", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_value_text_and_index_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-index-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-value")).ToHaveTextAsync("dawson", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-text")).ToHaveTextAsync("Dawson", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-index")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("dawson:Dawson:3", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionContextMenu.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionContextMenu.cs
@@ -49,13 +49,19 @@ public class WhenUsingFusionContextMenu : PlaywrightTestBase
         await NavigateAndBoot();
 
         await ContextMenu.OpenButton.ClickAsync();
+        await Expect(Page.Locator("#before-open-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-top")).ToHaveTextAsync("96", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-left")).ToHaveTextAsync("168", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-focused")).ToHaveTextAsync(new System.Text.RegularExpressions.Regex("^(true|false)$"), new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-cancel")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-cancel-value")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#open-state")).ToHaveTextAsync("opened", new() { Timeout = 5000 });
         await Expect(Page.Locator("#open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
 
         AssertNoConsoleErrors();
@@ -73,7 +79,11 @@ public class WhenUsingFusionContextMenu : PlaywrightTestBase
         await Expect(Page.Locator("#before-item-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-item-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-item-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-url")).ToHaveTextAsync(string.Empty, new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-icon-css")).ToHaveTextAsync("e-icons e-archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-separator")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("submenu", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-first-item")).ToHaveTextAsync("Reports", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("Projects", new() { Timeout = 5000 });
 
         await ContextMenu.Item("Archive").ClickAsync();
@@ -81,6 +91,8 @@ public class WhenUsingFusionContextMenu : PlaywrightTestBase
         await Expect(Page.Locator("#select-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
         await Expect(Page.Locator("#select-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
         await Expect(Page.Locator("#select-url")).ToHaveTextAsync(string.Empty, new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-icon-css")).ToHaveTextAsync("e-icons e-archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-separator")).ToHaveTextAsync("false", new() { Timeout = 5000 });
 
         AssertNoConsoleErrors();
     }
@@ -93,14 +105,20 @@ public class WhenUsingFusionContextMenu : PlaywrightTestBase
         await ContextMenu.OpenButton.ClickAsync();
         await ContextMenu.CloseButton.ClickAsync();
         await Expect(Page.Locator("#before-close-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-cancel-value")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#close-state")).ToHaveTextAsync("closed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("hidden", new() { Timeout = 5000 });
 
         await Page.GetByLabel("Block close").CheckAsync();
         await ContextMenu.OpenButton.ClickAsync();
         await ContextMenu.CloseButton.ClickAsync();
         await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-cancel-value")).ToHaveTextAsync("true", new() { Timeout = 5000 });
         await Expect(Page.Locator("#close-state")).ToHaveTextAsync("closed", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
 
@@ -115,6 +133,7 @@ public class WhenUsingFusionContextMenu : PlaywrightTestBase
         await Page.GetByLabel("Block open").CheckAsync();
         await ContextMenu.OpenButton.ClickAsync();
         await Expect(Page.Locator("#before-open-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-cancel-value")).ToHaveTextAsync("true", new() { Timeout = 5000 });
         await Expect(Page.Locator("#open-state")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
 

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionContextMenu.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionContextMenu.cs
@@ -1,0 +1,135 @@
+using Microsoft.Playwright;
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionContextMenu : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/ContextMenu";
+
+    private FusionContextMenuLocator ContextMenu => new(Page, "resident-context-menu");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForBoot(Path);
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionContextMenu — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_context_menu_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("resident-context-menu"));
+        Assert.That(planJson, Does.Contain("\"beforeItemRender\""));
+        Assert.That(planJson, Does.Contain("\"beforeOpen\""));
+        Assert.That(planJson, Does.Contain("\"onOpen\""));
+        Assert.That(planJson, Does.Contain("\"beforeClose\""));
+        Assert.That(planJson, Does.Contain("\"onClose\""));
+        Assert.That(planJson, Does.Contain("\"select\""));
+        Assert.That(planJson, Does.Contain("\"open\""));
+        Assert.That(planJson, Does.Contain("\"close\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task open_method_exposes_root_payloads_and_programmatic_state()
+    {
+        await NavigateAndBoot();
+
+        await ContextMenu.OpenButton.ClickAsync();
+        await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-top")).ToHaveTextAsync("96", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-left")).ToHaveTextAsync("168", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-cancel")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-state")).ToHaveTextAsync("opened", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task submenu_render_and_select_payloads_are_projected()
+    {
+        await NavigateAndBoot();
+
+        await ContextMenu.OpenButton.ClickAsync();
+        await ContextMenu.Item("Projects").HoverAsync();
+        await Expect(ContextMenu.Item("Archive")).ToBeVisibleAsync(new() { Timeout = 5000 });
+
+        await Expect(Page.Locator("#before-item-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("submenu", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("Projects", new() { Timeout = 5000 });
+
+        await ContextMenu.Item("Archive").ClickAsync();
+        await Expect(Page.Locator("#select-state")).ToHaveTextAsync("selected", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-url")).ToHaveTextAsync(string.Empty, new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task close_method_and_cancels_are_exercised()
+    {
+        await NavigateAndBoot();
+
+        await ContextMenu.OpenButton.ClickAsync();
+        await ContextMenu.CloseButton.ClickAsync();
+        await Expect(Page.Locator("#before-close-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-state")).ToHaveTextAsync("closed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("hidden", new() { Timeout = 5000 });
+
+        await Page.GetByLabel("Block close").CheckAsync();
+        await ContextMenu.OpenButton.ClickAsync();
+        await ContextMenu.CloseButton.ClickAsync();
+        await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-state")).ToHaveTextAsync("closed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task open_cancel_prevents_opening_from_a_clean_state()
+    {
+        await NavigateAndBoot();
+
+        await Page.GetByLabel("Block open").CheckAsync();
+        await ContextMenu.OpenButton.ClickAsync();
+        await Expect(Page.Locator("#before-open-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-state")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task right_click_target_opens_the_context_menu()
+    {
+        await NavigateAndBoot();
+
+        await ContextMenu.Target.ClickAsync(new() { Button = MouseButton.Right });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionDropDownButton.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionDropDownButton.cs
@@ -1,0 +1,177 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionDropDownButton : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionDropDownButton";
+    private const string MenuId = "resident-actions-menu";
+
+    private FusionDropDownButtonLocator Menu => new(Page, MenuId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#content-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionDropDownButton — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_dropdown_button_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(MenuId));
+        Assert.That(planJson, Does.Contain("\"content\""));
+        Assert.That(planJson, Does.Contain("\"disabled\""));
+        Assert.That(planJson, Does.Contain("\"cssClass\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"toggle\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        Assert.That(planJson, Does.Contain("\"removeItems\""));
+        Assert.That(planJson, Does.Contain("\"select\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_content_and_reads_content_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Menu.Button).ToContainTextAsync("Ready Actions", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Ready Actions", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_content_and_disabled_update_visible_state_sources_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+        await Expect(Menu.Button).ToContainTextAsync("Discharge Actions", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Discharge Actions", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-disabled-btn").ClickAsync();
+        await Expect(Page.Locator("#disabled-state")).ToHaveTextAsync("enabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#disable-menu-btn").ClickAsync();
+        await Expect(Menu.Button).ToBeDisabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-disabled-btn").ClickAsync();
+        await Expect(Page.Locator("#disabled-state")).ToHaveTextAsync("disabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-menu-btn").ClickAsync();
+        await Expect(Menu.Button).ToBeEnabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_css_class_updates_button_popup_and_css_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-css-btn").ClickAsync();
+
+        Assert.That(await Menu.HasClass("e-success"), Is.True);
+        Assert.That(await Menu.HasClass("extra-class"), Is.True);
+        await Expect(Page.Locator("#css-echo")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+
+        await Page.Locator("#toggle-menu-btn").ClickAsync();
+        await Expect(Menu.Button).ToHaveAttributeAsync("aria-expanded", "true", new() { Timeout = 5000 });
+        Assert.That(await Menu.IsPopupOpen(), Is.True);
+        Assert.That(await Menu.PopupHasClass("e-success"), Is.True);
+        Assert.That(await Menu.PopupHasClass("extra-class"), Is.True);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task toggle_method_opens_and_closes_popup()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#toggle-menu-btn").ClickAsync();
+        await Expect(Page.Locator("#toggle-state")).ToHaveTextAsync("toggle called", new() { Timeout = 5000 });
+        await Expect(Menu.Button).ToHaveAttributeAsync("aria-expanded", "true", new() { Timeout = 5000 });
+        Assert.That(await Menu.IsPopupOpen(), Is.True);
+
+        await Page.Locator("#toggle-menu-btn").DispatchEventAsync("click");
+        await Expect(Menu.Button).ToHaveAttributeAsync("aria-expanded", "false", new() { Timeout = 5000 });
+        Assert.That(await Menu.IsPopupOpen(), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_dropdown_button()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-menu-btn").ClickAsync();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(Menu.Button).ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task remove_items_methods_remove_popup_items_by_text_and_id()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#remove-assign-btn").ClickAsync();
+        await Expect(Page.Locator("#remove-state")).ToHaveTextAsync("assign removed", new() { Timeout = 5000 });
+        await Menu.Button.ClickAsync();
+        await Expect(Menu.Item("Assign nurse")).ToHaveCountAsync(0, new() { Timeout = 5000 });
+        await Expect(Menu.Item("Place hold")).ToHaveCountAsync(1, new() { Timeout = 5000 });
+
+        await Page.Locator("#remove-hold-btn").ClickAsync();
+        await Expect(Page.Locator("#remove-state")).ToHaveTextAsync("hold removed", new() { Timeout = 5000 });
+        await Menu.Button.ClickAsync();
+        await Expect(Menu.Item("Place hold")).ToHaveCountAsync(0, new() { Timeout = 5000 });
+        await Expect(Menu.Item("View profile")).ToHaveCountAsync(1, new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_event_reads_typed_item_payload_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Menu.Button.ClickAsync();
+        await Menu.Item("Assign nurse").ClickAsync();
+
+        await Expect(Page.Locator("#selected-id")).ToHaveTextAsync("assign", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-text")).ToHaveTextAsync("Assign nurse", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-disabled")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-condition")).ToHaveTextAsync("assign selected", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_dropdown_button_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+        await Page.Locator("#set-css-btn").ClickAsync();
+        await Page.Locator("#disable-menu-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-content")).ToHaveTextAsync("Discharge Actions", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-disabled")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-css")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("Discharge Actions:True:e-success extra-class", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionDropDownTree.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionDropDownTree.cs
@@ -1,0 +1,115 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionDropDownTree : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionDropDownTree";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_FusionDropDownTreeModel";
+    private const string ResidentIdsId = Scope + "__ResidentIds";
+
+    private FusionDropDownTreeLocator ResidentTree => new(Page, ResidentIdsId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#text-echo", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionDropDownTree — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_value_and_reads_text_and_value_condition()
+    {
+        await NavigateAndBoot();
+
+        await Expect(ResidentTree.Input).ToHaveValueAsync("Alice", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#text-echo")).ToHaveTextAsync("Alice", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-state")).ToHaveTextAsync("has values", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_value_and_text_update_visible_state_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-value-btn").ClickAsync();
+        await Expect(ResidentTree.Input).ToHaveValueAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#text-echo")).ToHaveTextAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-state")).ToHaveTextAsync("has values", new() { Timeout = 5000 });
+
+        await Page.Locator("#set-text-btn").ClickAsync();
+        await Expect(ResidentTree.Input).ToHaveValueAsync("Carey", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#text-echo")).ToHaveTextAsync("Carey", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task showpopup_and_hidepopup_methods_control_popup()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#show-popup-btn").ClickAsync();
+        await Expect(ResidentTree.Popup).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await Expect(ResidentTree.TreeItemText("Carey")).ToBeVisibleAsync(new() { Timeout = 5000 });
+
+        await Page.Locator("#hide-popup-btn").ClickAsync();
+        await Expect(ResidentTree.Popup).ToBeHiddenAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task changed_event_payload_and_component_condition_update_trace()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#show-popup-btn").ClickAsync();
+        await ResidentTree.SelectItem("Bennett");
+
+        await Expect(ResidentTree.Input).ToHaveValueAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-value-state")).ToHaveTextAsync("has values", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-old-value-state")).ToHaveTextAsync("had old values", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#event-text")).ToHaveTextAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-indicator")).ToBeVisibleAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task clear_method_resets_input_and_hides_component_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#show-popup-btn").ClickAsync();
+        await ResidentTree.SelectItem("Carey");
+        await Expect(Page.Locator("#selected-indicator")).ToBeVisibleAsync(new() { Timeout = 5000 });
+
+        await Page.Locator("#clear-tree-btn").ClickAsync();
+        await Expect(ResidentTree.Input).ToHaveValueAsync("", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("cleared", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-state")).ToHaveTextAsync("empty", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-indicator")).ToBeHiddenAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_value_and_text_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-value-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-value")).ToHaveTextAsync("bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-text")).ToHaveTextAsync("Bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("bennett:Bennett", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionGridDirectory.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionGridDirectory.cs
@@ -1,0 +1,117 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionGridDirectory : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Grid/Directory";
+
+    private async Task NavigateDirectory()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#directory-status"))
+            .ToHaveTextAsync("loaded first page", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-directory-grid .e-row").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task components_index_links_to_grid_directory_and_editing_cards()
+    {
+        await NavigateTo("/Sandbox/Components");
+
+        await Expect(Page.Locator("a").Filter(new() { HasText = "Grid Directory" }))
+            .ToBeVisibleAsync();
+        await Expect(Page.Locator("a").Filter(new() { HasText = "Grid Editing" }))
+            .ToBeVisibleAsync();
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task public_methods_drive_server_paging_sorting_search_filtering_and_grouping()
+    {
+        await NavigateDirectory();
+
+        await ClickWhenStable(Page.Locator("#grid-page-2"));
+        await Expect(Page.Locator("#grid-action")).ToHaveTextAsync("paging", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#grid-skip")).ToHaveTextAsync("8", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-sort-risk"));
+        await Expect(Page.Locator("#grid-action")).ToHaveTextAsync("sorting", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#grid-column")).ToHaveTextAsync("riskLevel", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#grid-direction")).ToHaveTextAsync("Descending", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-search-memory"));
+        await Expect(Page.Locator("#grid-action")).ToHaveTextAsync("searching", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#directory-summary")).ToHaveTextAsync("60 residents matched", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-clear-search"));
+        await Expect(Page.Locator("#directory-summary")).ToHaveTextAsync("240 residents matched", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-filter-north"));
+        await Expect(Page.Locator("#grid-action")).ToHaveTextAsync("filtering", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#directory-summary")).ToHaveTextAsync("60 residents matched", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-clear-filters"));
+        await Expect(Page.Locator("#directory-summary")).ToHaveTextAsync("240 residents matched", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-group-care"));
+        await Expect(Page.Locator("#grid-action")).ToHaveTextAsync("grouping", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#directory-summary")).ToHaveTextAsync(
+            "240 residents grouped by care level",
+            new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-clear-grouping"));
+        await Expect(Page.Locator("#directory-summary")).ToHaveTextAsync("240 residents matched", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task row_events_and_method_return_sources_flow_into_http_requests()
+    {
+        await NavigateDirectory();
+
+        await ClickWhenStable(Page.Locator("#grid-select-second"));
+        await Expect(Page.Locator("#selected-row-index")).ToHaveTextAsync("1", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#selected-summary")).ToContainTextAsync("open tasks", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-gather-selection"));
+        await Expect(Page.Locator("#selection-indexes")).ToHaveTextAsync("selected row indexes: 1", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-gather-selected-records"));
+        await Expect(Page.Locator("#selected-records")).ToContainTextAsync("selected records:", new() { Timeout = 10000 });
+
+        await Page.Locator("#resident-directory-grid .e-row .e-rowcell").First.ClickAsync();
+        await Expect(Page.Locator("#clicked-resident")).Not.ToHaveTextAsync("waiting", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#clicked-cell")).Not.ToHaveTextAsync("waiting", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#grid-clear-selection"));
+        await ClickWhenStable(Page.Locator("#grid-gather-selection"));
+        await Expect(Page.Locator("#selection-indexes")).ToHaveTextAsync("no selected row indexes", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task virtual_scroll_uses_grid_data_state_to_fetch_later_blocks()
+    {
+        await NavigateDirectory();
+
+        await Expect(Page.Locator("#virtual-status"))
+            .ToHaveTextAsync("loaded first virtual block", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-virtual-grid .e-row").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        var content = Page.Locator("#resident-virtual-grid .e-content").First;
+        await content.EvaluateAsync("el => { el.scrollTop = 1200; el.dispatchEvent(new Event('scroll')); }");
+
+        await Expect(Page.Locator("#virtual-status"))
+            .ToHaveTextAsync("virtual block refreshed", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#virtual-skip"))
+            .Not.ToHaveTextAsync("waiting", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionGridEditing.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionGridEditing.cs
@@ -1,0 +1,139 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionGridEditing : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Grid/Editing";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_ResidentGridEditingModel";
+    private const string ResidentNameId = Scope + "__ResidentName";
+    private const string RiskLevelId = Scope + "__RiskLevel";
+    private const string OpenTasksId = Scope + "__OpenTasks";
+
+    private FusionTextBoxLocator ResidentName => new(Page, ResidentNameId);
+    private DropDownListLocator RiskLevel => new(Page, RiskLevelId);
+    private NumericTextBoxLocator OpenTasks => new(Page, OpenTasksId);
+
+    private ILocator ErrorFor(string property) => Page.Locator($"#{Scope}__{property}_error");
+
+    private async Task NavigateEditing()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#editing-load-status"))
+            .ToHaveTextAsync("loaded editing rows", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-inline-edit-grid .e-row").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task inline_editing_methods_add_update_edit_and_delete_rows()
+    {
+        await NavigateEditing();
+
+        await ClickWhenStable(Page.Locator("#inline-add-literal"));
+        await Expect(Page.Locator("#resident-inline-edit-grid")).ToContainTextAsync("Zara Inline", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#inline-add-server"));
+        await Expect(Page.Locator("#resident-inline-edit-grid")).ToContainTextAsync("Sofia Server", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#inline-command-status")).ToHaveTextAsync(
+            "Sofia Server loaded from the server",
+            new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#inline-select-first"));
+        await ClickWhenStable(Page.Locator("#inline-start-edit"));
+        await Expect(Page.Locator("#inline-begin-row")).ToHaveTextAsync("0", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-inline-edit-grid .e-editedrow")).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#inline-close-edit"));
+        await Expect(Page.Locator("#inline-command-status")).ToHaveTextAsync("closeEdit called", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#inline-update-row"));
+        await Expect(Page.Locator("#resident-inline-edit-grid")).ToContainTextAsync("Amina Updated", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#inline-select-first"));
+        await ClickWhenStable(Page.Locator("#inline-delete-selected"));
+        await Expect(Page.Locator("#inline-command-status")).ToHaveTextAsync("deleteRecord called", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task batch_editing_exposes_cell_events_indexed_batch_payload_and_batch_changes_source()
+    {
+        await NavigateEditing();
+
+        await ClickWhenStable(Page.Locator("#batch-edit-cell"));
+        await Expect(Page.Locator("#resident-batch-edit-grid input.e-field").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Page.Locator("#resident-batch-edit-grid input.e-field").First.FillAsync("4");
+        await ClickWhenStable(Page.Locator("#batch-save-cell"));
+
+        await Expect(Page.Locator("#batch-cell-save-column")).ToHaveTextAsync("openTasks", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#batch-cell-save-value")).ToHaveTextAsync("4", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#batch-cell-saved-value")).ToHaveTextAsync("4", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#batch-update-cell"));
+        await Expect(Page.Locator("#resident-batch-edit-grid")).ToContainTextAsync("6", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#batch-gather-changes"));
+        await Expect(Page.Locator("#batch-summary")).ToHaveTextAsync(
+            "batch added 0, changed 1, deleted 0",
+            new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#batch-end-edit"));
+        await Expect(Page.Locator("#batch-before-save-tasks")).ToHaveTextAsync("6", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#batch-action-complete")).Not.ToHaveTextAsync("waiting", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task dialog_editing_uses_the_builder_template_and_typed_begin_event()
+    {
+        await NavigateEditing();
+
+        await ClickWhenStable(Page.Locator("#dialog-select-first"));
+        await ClickWhenStable(Page.Locator("#dialog-start-edit"));
+
+        await Expect(Page.Locator("#resident-dialog-template-marker"))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#dialog-begin-resident"))
+            .Not.ToHaveTextAsync("waiting", new() { Timeout = 10000 });
+
+        await Page.Keyboard.PressAsync("Escape");
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task validation_updates_grid_only_after_form_rules_pass()
+    {
+        await NavigateEditing();
+
+        await ClickWhenStable(Page.Locator("#validation-save-grid-row"));
+        await Expect(ErrorFor("ResidentName")).ToContainTextAsync("required", new() { Timeout = 10000 });
+        await Expect(ErrorFor("RiskLevel")).ToContainTextAsync("required", new() { Timeout = 10000 });
+        await Expect(ErrorFor("OpenTasks")).ToContainTextAsync("required", new() { Timeout = 10000 });
+
+        await ResidentName.FillAndBlur("Li");
+        await Expect(ErrorFor("ResidentName")).ToContainTextAsync("at least 3", new() { Timeout = 10000 });
+
+        await ResidentName.FillAndBlur("Mara Validated");
+        await RiskLevel.Select("High");
+        await OpenTasks.FillAndBlur("9");
+        await ClickWhenStable(Page.Locator("#validation-save-grid-row"));
+        await Expect(ErrorFor("OpenTasks")).ToContainTextAsync("between 0 and 7", new() { Timeout = 10000 });
+
+        await OpenTasks.FillAndBlur("4");
+        await ClickWhenStable(Page.Locator("#validation-save-grid-row"));
+
+        await Expect(Page.Locator("#validation-status")).ToContainTextAsync(
+            "Mara Validated passed validation",
+            new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-inline-edit-grid")).ToContainTextAsync("Mara Validated", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionGridOperations.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionGridOperations.cs
@@ -1,0 +1,135 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionGridOperations : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Grid/Operations";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_GridOperationsModel";
+    private const string PatchRiskLevelId = Scope + "__PatchRiskLevel";
+    private const string PatchOpenTasksId = Scope + "__PatchOpenTasks";
+
+    private DropDownListLocator PatchRiskLevel => new(Page, PatchRiskLevelId);
+    private NumericTextBoxLocator PatchOpenTasks => new(Page, PatchOpenTasksId);
+
+    private async Task NavigateOperations()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#operations-load-status"))
+            .ToHaveTextAsync("loaded operations rows", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-operations-grid .e-row").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task components_index_links_to_grid_operations_card()
+    {
+        await NavigateTo("/Sandbox/Components");
+
+        await Expect(Page.Locator("a").Filter(new() { HasText = "Grid Operations" }))
+            .ToBeVisibleAsync();
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task template_columns_and_template_actions_drive_real_workflows()
+    {
+        await NavigateOperations();
+
+        await Expect(Page.Locator("#resident-operations-grid .grid-resident-template").First)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-operations-grid .grid-action-template button").First)
+            .ToHaveTextAsync("Review", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#resident-operations-grid .grid-action-template button").First);
+        await Expect(Page.Locator("#template-action-status"))
+            .ToContainTextAsync("review started for", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task column_methods_hide_show_and_reorder_visible_columns()
+    {
+        await NavigateOperations();
+
+        await ClickWhenStable(Page.Locator("#ops-hide-care-columns"));
+        await Expect(Page.Locator("#column-command-status"))
+            .ToHaveTextAsync("care columns hidden", new() { Timeout = 10000 });
+        await Expect(VisibleHeader("Primary Nurse"))
+            .ToHaveCountAsync(0, new() { Timeout = 10000 });
+        await Expect(VisibleHeader("Next Review"))
+            .ToHaveCountAsync(0, new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#ops-show-care-columns"));
+        await Expect(VisibleHeader("Primary Nurse"))
+            .ToHaveCountAsync(1, new() { Timeout = 10000 });
+        await Expect(VisibleHeader("Next Review"))
+            .ToHaveCountAsync(1, new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#ops-reorder-risk"));
+        await Expect(Page.Locator("#column-command-status"))
+            .ToHaveTextAsync("risk column moved before resident", new() { Timeout = 10000 });
+        var headers = await Page.Locator("#resident-operations-grid .e-headercell:visible .e-headertext")
+            .AllInnerTextsAsync();
+        var visibleHeaders = headers.ToList();
+
+        Assert.That(visibleHeaders.IndexOf("Risk"), Is.LessThan(visibleHeaders.IndexOf("Resident")));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task current_view_key_and_selection_sources_feed_http_requests()
+    {
+        await NavigateOperations();
+
+        await ClickWhenStable(Page.Locator("#ops-select-range"));
+        await Expect(Page.Locator("#selection-range-status"))
+            .ToContainTextAsync("selected records:", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#ops-current-view"));
+        await Expect(Page.Locator("#current-view-status"))
+            .ToContainTextAsync("current view has 12 residents", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#ops-row-index"));
+        await Expect(Page.Locator("#row-index-status"))
+            .ToHaveTextAsync("resident 6005 is visible at row index 5", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task keyed_cell_and_row_updates_change_visible_rows()
+    {
+        await NavigateOperations();
+
+        await ClickWhenStable(Page.Locator("#ops-set-risk-cell"));
+        await Expect(Page.Locator("#keyed-update-status"))
+            .ToHaveTextAsync("resident 6002 risk flagged", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-operations-grid"))
+            .ToContainTextAsync("Critical", new() { Timeout = 10000 });
+
+        await ClickWhenStable(Page.Locator("#ops-set-tasks-cell"));
+        var row6003 = Page.Locator("#resident-operations-grid .e-row").Filter(new() { HasText = "Irene Morgan" }).First;
+        await Expect(row6003).ToContainTextAsync("7", new() { Timeout = 10000 });
+
+        await PatchRiskLevel.Select("Moderate");
+        await PatchOpenTasks.FillAndBlur("6");
+        await ClickWhenStable(Page.Locator("#ops-server-patch-row"));
+        await Expect(Page.Locator("#keyed-update-status"))
+            .ToHaveTextAsync("Lena Server Patch changed to Moderate risk with 6 tasks", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-operations-grid"))
+            .ToContainTextAsync("Lena Server Patch", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#resident-operations-grid"))
+            .ToContainTextAsync("Clinical Review Team", new() { Timeout = 10000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    private ILocator VisibleHeader(string text) =>
+        Page.Locator("#resident-operations-grid .e-headercell:visible .e-headertext")
+            .Filter(new() { HasText = text });
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionListBox.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionListBox.cs
@@ -1,0 +1,144 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionListBox : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionListBox";
+
+    private FusionListBoxLocator Residents => new(Page, "resident-list-box");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#value-echo", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionListBox — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task dom_ready_set_value_and_value_source_condition_update_trace()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#value-state")).ToHaveTextAsync("has values", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Alice"), Is.True);
+        Assert.That(await Residents.IsSelected("Bennett"), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_value_and_data_bind_update_selection()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-value-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("value set", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("bennett,dawson", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Alice"), Is.False);
+        Assert.That(await Residents.IsSelected("Bennett"), Is.True);
+        Assert.That(await Residents.IsSelected("Dawson"), Is.True);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_and_unselect_values_update_value_and_emit_change()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#select-carey-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("carey selected", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("alice,carey", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("alice,carey", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-state")).ToHaveTextAsync("has values", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Carey"), Is.True);
+
+        await Page.Locator("#unselect-carey-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("carey unselected", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("alice", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("alice", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Carey"), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_all_and_unselect_all_update_values()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#select-all-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("all selected", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("alice,bennett,carey,dawson", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Alice"), Is.True);
+        Assert.That(await Residents.IsSelected("Bennett"), Is.True);
+        Assert.That(await Residents.IsSelected("Carey"), Is.True);
+        Assert.That(await Residents.IsSelected("Dawson"), Is.True);
+
+        await Page.Locator("#unselect-all-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("all unselected", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync(string.Empty, new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-state")).ToHaveTextAsync("empty", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Alice"), Is.False);
+        Assert.That(await Residents.IsSelected("Bennett"), Is.False);
+        Assert.That(await Residents.IsSelected("Carey"), Is.False);
+        Assert.That(await Residents.IsSelected("Dawson"), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task disable_and_enable_values_update_item_state()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#disable-carey-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("carey disabled", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsDisabled("Carey"), Is.True);
+
+        await Page.Locator("#enable-carey-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("carey enabled", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsDisabled("Carey"), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task changed_event_reads_value_payload_from_user_click()
+    {
+        await NavigateAndBoot();
+
+        await Residents.ClickItem("Bennett");
+
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("bennett", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-state")).ToHaveTextAsync("has values", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-indicator")).ToHaveTextAsync("selected", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Bennett"), Is.True);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_posts_value_source_to_real_endpoint()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-value-btn").ClickAsync();
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("bennett,dawson", new() { Timeout = 5000 });
+
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-value")).ToHaveTextAsync("bennett,dawson", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-count")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionListView.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionListView.cs
@@ -1,0 +1,104 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionListView : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionListView";
+
+    private FusionListViewLocator Residents => new(Page, "resident-list");
+    private FusionListViewLocator Tasks => new(Page, "task-list");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#command-state", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionListView — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_text_and_unselect_text_methods_update_selection()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#select-bennett-btn").ClickAsync();
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("selected Bennett", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Bennett"), Is.True);
+
+        await Page.Locator("#unselect-bennett-btn").ClickAsync();
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("unselected Bennett", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Bennett"), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task check_all_and_uncheck_all_methods_update_checkbox_items()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-all-btn").ClickAsync();
+        await Expect(Page.Locator("#task-command-state")).ToHaveTextAsync("checked all", new() { Timeout = 5000 });
+        await Expect(Tasks.CheckedIcon("Hydration")).ToHaveCountAsync(1);
+        await Expect(Tasks.CheckedIcon("Mobility")).ToHaveCountAsync(1);
+        await Expect(Tasks.CheckedIcon("Dining")).ToHaveCountAsync(1);
+
+        await Page.Locator("#uncheck-all-btn").ClickAsync();
+        await Expect(Page.Locator("#task-command-state")).ToHaveTextAsync("unchecked all", new() { Timeout = 5000 });
+        await Expect(Tasks.CheckedIcon("Hydration")).ToHaveCountAsync(0);
+        await Expect(Tasks.CheckedIcon("Mobility")).ToHaveCountAsync(0);
+        await Expect(Tasks.CheckedIcon("Dining")).ToHaveCountAsync(0);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_event_reads_scalar_payload_and_conditions()
+    {
+        await NavigateAndBoot();
+
+        await Residents.ClickItem("Alice");
+
+        await Expect(Page.Locator("#selected-text")).ToHaveTextAsync("Alice", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-index")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-kind")).ToHaveTextAsync("primary", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#cancel-state")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Alice"), Is.True);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_event_cancel_mutation_prevents_selection()
+    {
+        await NavigateAndBoot();
+
+        await Residents.ClickItem("Carey");
+
+        await Expect(Page.Locator("#selected-text")).ToHaveTextAsync("Carey", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-index")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#cancel-state")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        Assert.That(await Residents.IsSelected("Carey"), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task checkbox_selected_event_reads_checked_state()
+    {
+        await NavigateAndBoot();
+
+        await Tasks.ClickItem("Hydration");
+
+        await Expect(Page.Locator("#task-selected-text")).ToHaveTextAsync("Hydration", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#task-checked")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#task-check-state")).ToHaveTextAsync("checked", new() { Timeout = 5000 });
+        await Expect(Tasks.CheckedIcon("Hydration")).ToHaveCountAsync(1);
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionMenu.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionMenu.cs
@@ -1,0 +1,123 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionMenu : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionMenu";
+
+    private FusionMenuLocator Menu => new(Page, "resident-menu");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForBoot(Path);
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionMenu — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_menu_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("resident-menu"));
+        Assert.That(planJson, Does.Contain("\"beforeItemRender\""));
+        Assert.That(planJson, Does.Contain("\"beforeOpen\""));
+        Assert.That(planJson, Does.Contain("\"onOpen\""));
+        Assert.That(planJson, Does.Contain("\"beforeClose\""));
+        Assert.That(planJson, Does.Contain("\"onClose\""));
+        Assert.That(planJson, Does.Contain("\"select\""));
+        Assert.That(planJson, Does.Contain("\"open\""));
+        Assert.That(planJson, Does.Contain("\"close\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task render_payload_is_projected_into_the_trace()
+    {
+        await NavigateAndBoot();
+
+        await Menu.OpenButton.ClickAsync();
+        await Menu.Item("Projects").ClickAsync();
+        await Expect(Page.Locator("#before-item-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task open_select_surfaces_root_and_submenu_payloads()
+    {
+        await NavigateAndBoot();
+
+        await Menu.OpenButton.ClickAsync();
+        await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-state")).ToHaveTextAsync("opened", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
+
+        await Menu.Item("Projects").ClickAsync();
+        await Expect(Page.Locator("#select-state")).ToHaveTextAsync("selected", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-text")).ToHaveTextAsync("Projects", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-id")).ToHaveTextAsync("projects-item", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-url")).ToHaveTextAsync(string.Empty, new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("submenu", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("Projects", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task close_method_surfaces_close_payloads()
+    {
+        await NavigateAndBoot();
+
+        await Menu.OpenButton.ClickAsync();
+        await Menu.CloseButton.ClickAsync();
+        await Expect(Page.Locator("#before-close-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-state")).ToHaveTextAsync("closed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("hidden", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task open_cancel_prevents_opening_and_close_cancel_preserves_visible_state()
+    {
+        await NavigateAndBoot();
+
+        await Page.GetByLabel("Block open").CheckAsync();
+        await Menu.OpenButton.ClickAsync();
+        await Expect(Page.Locator("#before-open-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-state")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
+
+        await Page.GetByLabel("Block open").UncheckAsync();
+        await Menu.OpenButton.ClickAsync();
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
+
+        await Page.GetByLabel("Block close").CheckAsync();
+        await Menu.CloseButton.ClickAsync();
+        await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-state")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionMenu.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionMenu.cs
@@ -52,6 +52,9 @@ public class WhenUsingFusionMenu : PlaywrightTestBase
         await Expect(Page.Locator("#before-item-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-item-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-item-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-url")).ToHaveTextAsync("/archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-icon-css")).ToHaveTextAsync("e-icons e-archive", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-item-separator")).ToHaveTextAsync("false", new() { Timeout = 5000 });
 
         AssertNoConsoleErrors();
     }
@@ -62,10 +65,18 @@ public class WhenUsingFusionMenu : PlaywrightTestBase
         await NavigateAndBoot();
 
         await Menu.OpenButton.ClickAsync();
+        await Expect(Page.Locator("#before-open-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-top")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-left")).Not.ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-focused")).ToHaveTextAsync(new System.Text.RegularExpressions.Regex("^(true|false)$"), new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-cancel-value")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#open-state")).ToHaveTextAsync("opened", new() { Timeout = 5000 });
         await Expect(Page.Locator("#open-kind")).ToHaveTextAsync("root", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
 
         await Menu.Item("Projects").ClickAsync();
@@ -73,11 +84,17 @@ public class WhenUsingFusionMenu : PlaywrightTestBase
         await Expect(Page.Locator("#select-text")).ToHaveTextAsync("Projects", new() { Timeout = 5000 });
         await Expect(Page.Locator("#select-id")).ToHaveTextAsync("projects-item", new() { Timeout = 5000 });
         await Expect(Page.Locator("#select-url")).ToHaveTextAsync(string.Empty, new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-icon-css")).ToHaveTextAsync("e-icons e-folder", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-separator")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#select-first-child")).ToHaveTextAsync("Reports", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-item-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-item-text")).ToHaveTextAsync("Archive", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-item-id")).ToHaveTextAsync("archive-item", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-kind")).ToHaveTextAsync("submenu", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-first-item")).ToHaveTextAsync("Reports", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-open-parent")).ToHaveTextAsync("Projects", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
 
         AssertNoConsoleErrors();
     }
@@ -90,8 +107,13 @@ public class WhenUsingFusionMenu : PlaywrightTestBase
         await Menu.OpenButton.ClickAsync();
         await Menu.CloseButton.ClickAsync();
         await Expect(Page.Locator("#before-close-state")).ToHaveTextAsync("rendered", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-cancel-value")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#close-state")).ToHaveTextAsync("closed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-first-item")).ToHaveTextAsync("Dashboard", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-parent")).ToHaveTextAsync("root", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("hidden", new() { Timeout = 5000 });
 
         AssertNoConsoleErrors();
@@ -105,6 +127,7 @@ public class WhenUsingFusionMenu : PlaywrightTestBase
         await Page.GetByLabel("Block open").CheckAsync();
         await Menu.OpenButton.ClickAsync();
         await Expect(Page.Locator("#before-open-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-open-cancel-value")).ToHaveTextAsync("true", new() { Timeout = 5000 });
         await Expect(Page.Locator("#open-state")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
 
@@ -115,6 +138,7 @@ public class WhenUsingFusionMenu : PlaywrightTestBase
         await Page.GetByLabel("Block close").CheckAsync();
         await Menu.CloseButton.ClickAsync();
         await Expect(Page.Locator("#before-close-cancel")).ToHaveTextAsync("cancelled", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#before-close-cancel-value")).ToHaveTextAsync("true", new() { Timeout = 5000 });
         await Expect(Page.Locator("#close-state")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
         await Expect(Page.Locator("#menu-visibility")).ToHaveTextAsync("visible", new() { Timeout = 5000 });
 

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionOtpInput.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionOtpInput.cs
@@ -1,0 +1,173 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionOtpInput : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/OtpInput";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_OtpInputModel";
+    private const string PasscodeId = Scope + "__Passcode";
+    private const string AutoBlurCodeId = Scope + "__AutoBlurCode";
+
+    private FusionOtpInputLocator Passcode => new(Page, PasscodeId);
+    private FusionOtpInputLocator AutoBlurCode => new(Page, AutoBlurCodeId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#value-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionOtpInput — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_otp_input_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(PasscodeId));
+        Assert.That(planJson, Does.Contain("\"value\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        Assert.That(planJson, Does.Contain("\"focusOut\""));
+        Assert.That(planJson, Does.Contain("\"input\""));
+        Assert.That(planJson, Does.Contain("\"valueChanged\""));
+        Assert.That(planJson, Does.Contain("\"focus\""));
+        Assert.That(planJson, Does.Contain("\"blur\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_value_and_reads_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("1357", new() { Timeout = 5000 });
+        Assert.That(await Passcode.HiddenValue(), Is.EqualTo("1357"));
+        Assert.That(await Passcode.FieldValue(0), Is.EqualTo("1"));
+        Assert.That(await Passcode.FieldValue(1), Is.EqualTo("3"));
+        Assert.That(await Passcode.FieldValue(2), Is.EqualTo("5"));
+        Assert.That(await Passcode.FieldValue(3), Is.EqualTo("7"));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_value_updates_visible_fields_and_valuechanged_payload()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-code-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("code set", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("9876", new() { Timeout = 5000 });
+        Assert.That(await Passcode.HiddenValue(), Is.EqualTo("9876"));
+        Assert.That(await Passcode.FieldValue(0), Is.EqualTo("9"));
+        Assert.That(await Passcode.FieldValue(1), Is.EqualTo("8"));
+        Assert.That(await Passcode.FieldValue(2), Is.EqualTo("7"));
+        Assert.That(await Passcode.FieldValue(3), Is.EqualTo("6"));
+        await Expect(Page.Locator("#changed-value")).ToHaveTextAsync("9876", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("1357", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-interacted")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_first_empty_field_and_focus_event_reads_payload()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#clear-code-btn").ClickAsync();
+        await Page.Locator("#focus-code-btn").ClickAsync();
+
+        await Expect(Passcode.Field(0)).ToBeFocusedAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focused", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-value")).ToHaveTextAsync("", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-index")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-interacted")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task browser_input_events_expose_input_and_valuechanged_payloads()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#clear-code-btn").ClickAsync();
+        await Passcode.FillCode("2468");
+
+        await Expect(Page.Locator("#input-value")).ToHaveTextAsync("2468", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#input-previous")).ToHaveTextAsync("246", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#input-index")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-value")).ToHaveTextAsync("2468", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("1357", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("complete", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task blur_event_exposes_current_value_index_and_interaction_state()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#clear-code-btn").ClickAsync();
+        await Passcode.FillCode("2468");
+        await Passcode.Field(3).BlurAsync();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("blurred", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#blur-value")).ToHaveTextAsync("2468", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#blur-index")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#blur-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusout_method_removes_focus_without_button_click_stealing_focus()
+    {
+        await NavigateAndBoot();
+
+        await AutoBlurCode.Focus();
+
+        await Expect(Page.Locator("#focusout-method-state")).ToHaveTextAsync("focusout called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#autoblur-state")).ToHaveTextAsync("blurred", new() { Timeout = 5000 });
+        await Expect(AutoBlurCode.Field(0)).Not.ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_value_condition_reads_current_value()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-code-btn").ClickAsync();
+        await Page.Locator("#check-code-btn").ClickAsync();
+        await Expect(Page.Locator("#code-state")).ToHaveTextAsync("verified", new() { Timeout = 5000 });
+
+        await Page.Locator("#clear-code-btn").ClickAsync();
+        await Page.Locator("#check-code-btn").ClickAsync();
+        await Expect(Page.Locator("#code-state")).ToHaveTextAsync("pending", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_otp_input_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-code-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-code")).ToHaveTextAsync("9876", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("code:9876", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionProgressButton.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionProgressButton.cs
@@ -1,0 +1,183 @@
+using System.Globalization;
+using Alis.Reactive.Playwright.Extensions;
+using Microsoft.Playwright;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionProgressButton : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionProgressButton";
+    private const string ButtonId = "resident-progress-button";
+
+    private FusionProgressButtonLocator Button => new(Page, ButtonId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#content-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionProgressButton — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_progress_button_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(ButtonId));
+        Assert.That(planJson, Does.Contain("\"content\""));
+        Assert.That(planJson, Does.Contain("\"disabled\""));
+        Assert.That(planJson, Does.Contain("\"cssClass\""));
+        Assert.That(planJson, Does.Contain("\"enableProgress\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"start\""));
+        Assert.That(planJson, Does.Contain("\"startAt\""));
+        Assert.That(planJson, Does.Contain("\"progressComplete\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        Assert.That(planJson, Does.Contain("\"begin\""));
+        Assert.That(planJson, Does.Contain("\"progress\""));
+        Assert.That(planJson, Does.Contain("\"end\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_content_and_enables_progress_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Button.Content).ToHaveTextAsync("Ready Save", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Ready Save", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#progress-enabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Button.Progress).ToHaveCountAsync(1, new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_content_and_disabled_update_visible_state_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+        await Expect(Button.Content).ToHaveTextAsync("Discharge Save", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Discharge Save", new() { Timeout = 5000 });
+
+        await Page.Locator("#disable-progress-button-btn").ClickAsync();
+        await Expect(Button.Button).ToBeDisabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-progress-button-btn").ClickAsync();
+        await Expect(Button.Button).ToBeEnabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_css_and_progress_enabled_update_dom_sources_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-css-btn").ClickAsync();
+        Assert.That(await Button.HasClass("e-success"), Is.True);
+        Assert.That(await Button.HasClass("extra-class"), Is.True);
+        await Expect(Page.Locator("#css-echo")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-progress-enabled-btn").ClickAsync();
+        await Expect(Page.Locator("#progress-enabled-state")).ToHaveTextAsync("progress enabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#disable-progress-btn").ClickAsync();
+        await Expect(Button.Progress).ToHaveCountAsync(0, new() { Timeout = 5000 });
+        await Expect(Page.Locator("#progress-enabled-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-progress-enabled-btn").ClickAsync();
+        await Expect(Page.Locator("#progress-enabled-state")).ToHaveTextAsync("progress disabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-progress-btn").ClickAsync();
+        await Expect(Button.Progress).ToHaveCountAsync(1, new() { Timeout = 5000 });
+        await Expect(Page.Locator("#progress-enabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task start_method_fires_begin_payload_and_complete_fires_end_payload()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#start-progress-btn").ClickAsync();
+        await Expect(Page.Locator("#start-state")).ToHaveTextAsync("start called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#begin-percent")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#begin-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#begin-condition")).ToHaveTextAsync("begin zero", new() { Timeout = 5000 });
+
+        await Page.Locator("#complete-progress-btn").ClickAsync();
+        await Expect(Page.Locator("#complete-state")).ToHaveTextAsync("complete called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#end-percent")).ToHaveTextAsync("100", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#end-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#end-condition")).ToHaveTextAsync("complete", new() { Timeout = 5000 });
+        Assert.That(await Button.IsProgressActive(), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task start_at_method_fires_progress_payload_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#start-at-progress-btn").ClickAsync();
+        await Expect(Page.Locator("#start-state")).ToHaveTextAsync("start at 60 called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#progress-condition")).ToHaveTextAsync("at least sixty", new() { Timeout = 5000 });
+
+        var progressPercent = await NumericText(Page.Locator("#progress-percent"));
+        Assert.That(progressPercent, Is.GreaterThanOrEqualTo(60d));
+        await Expect(Page.Locator("#progress-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+
+        await Page.Locator("#complete-progress-btn").ClickAsync();
+        await Expect(Page.Locator("#end-percent")).ToHaveTextAsync("100", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#end-condition")).ToHaveTextAsync("complete", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_progress_button()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-progress-btn").ClickAsync();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(Button.Button).ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_progress_button_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+        await Page.Locator("#set-css-btn").ClickAsync();
+        await Page.Locator("#disable-progress-button-btn").ClickAsync();
+        await Page.Locator("#disable-progress-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-content")).ToHaveTextAsync("Discharge Save", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-disabled")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-css")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-progress-enabled")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("Discharge Save:True:e-success extra-class:False", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    private static async Task<double> NumericText(ILocator locator)
+    {
+        var text = await locator.TextContentAsync();
+        return double.Parse(text ?? string.Empty, CultureInfo.InvariantCulture);
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionRadioButton.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionRadioButton.cs
@@ -1,0 +1,139 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionRadioButton : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionRadioButton";
+    private const string PrivateId = "private-room-radio";
+    private const string SharedId = "shared-room-radio";
+
+    private FusionRadioButtonLocator PrivateRoom => new(Page, PrivateId);
+    private FusionRadioButtonLocator SharedRoom => new(Page, SharedId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#selected-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionRadioButton — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_radio_button_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(PrivateId));
+        Assert.That(planJson, Does.Contain(SharedId));
+        Assert.That(planJson, Does.Contain("\"checked\""));
+        Assert.That(planJson, Does.Contain("\"disabled\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"getSelectedValue\""));
+        Assert.That(planJson, Does.Contain("\"click\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        Assert.That(planJson, Does.Contain("\"change\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_checked_state_and_selected_value_source()
+    {
+        await NavigateAndBoot();
+
+        Assert.That(await SharedRoom.IsChecked(), Is.True);
+        Assert.That(await PrivateRoom.IsChecked(), Is.False);
+        await Expect(Page.Locator("#selected-echo")).ToHaveTextAsync("Shared", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#shared-checked-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_checked_updates_group_selection_sources_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-selected-btn").ClickAsync();
+        await Expect(Page.Locator("#selected-state")).ToHaveTextAsync("other selected", new() { Timeout = 5000 });
+
+        await Page.Locator("#set-private-btn").ClickAsync();
+        Assert.That(await PrivateRoom.IsChecked(), Is.True);
+        Assert.That(await SharedRoom.IsChecked(), Is.False);
+        await Expect(Page.Locator("#selected-echo")).ToHaveTextAsync("Private", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#private-checked-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#shared-checked-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-selected-btn").ClickAsync();
+        await Expect(Page.Locator("#selected-state")).ToHaveTextAsync("private selected", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_disabled_updates_visible_state_and_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#disable-shared-btn").ClickAsync();
+        await Expect(SharedRoom.Input).ToBeDisabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-shared-btn").ClickAsync();
+        await Expect(SharedRoom.Input).ToBeEnabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task click_method_selects_radio_and_change_event_reads_payload()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-private-btn").ClickAsync();
+        await Page.Locator("#click-shared-btn").ClickAsync();
+
+        await Expect(Page.Locator("#click-state")).ToHaveTextAsync("click called", new() { Timeout = 5000 });
+        Assert.That(await SharedRoom.IsChecked(), Is.True);
+        Assert.That(await PrivateRoom.IsChecked(), Is.False);
+        await Expect(Page.Locator("#selected-echo")).ToHaveTextAsync("Shared", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("Shared", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("shared", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_radio_button()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-private-btn").ClickAsync();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(PrivateRoom.Input).ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_selected_value_and_state_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-private-btn").ClickAsync();
+        await Page.Locator("#disable-shared-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-selected")).ToHaveTextAsync("Private", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-private-checked")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-shared-checked")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-shared-disabled")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("Private:True:False:True", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionRating.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionRating.cs
@@ -1,0 +1,112 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionRating : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Rating";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_RatingModel";
+    private const string SatisfactionScoreId = Scope + "__SatisfactionScore";
+
+    private FusionRatingLocator SatisfactionScore => new(Page, SatisfactionScoreId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#value-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionRating — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_rating_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(SatisfactionScoreId));
+        Assert.That(planJson, Does.Contain("\"value\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"reset\""));
+        Assert.That(planJson, Does.Contain("\"valueChanged\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_value_and_reads_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        Assert.That(await SatisfactionScore.ValueAttribute(), Is.EqualTo("3"));
+        Assert.That(await SatisfactionScore.AriaValue(), Is.EqualTo("3"));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_value_updates_visible_rating_and_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-rating-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("rating set", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("4", new() { Timeout = 5000 });
+        Assert.That(await SatisfactionScore.ValueAttribute(), Is.EqualTo("4"));
+        Assert.That(await SatisfactionScore.AriaValue(), Is.EqualTo("4"));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task reset_method_resets_rating_and_valuechanged_event_exposes_payload()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-rating-btn").ClickAsync();
+        await Page.Locator("#reset-rating-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("rating reset", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        Assert.That(await SatisfactionScore.ValueAttribute(), Is.EqualTo("0"));
+        Assert.That(await SatisfactionScore.AriaValue(), Is.EqualTo("0"));
+        await Expect(Page.Locator("#changed-value")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("4", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-interacted")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("reset", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_value_condition_reads_current_value()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-rating-btn").ClickAsync();
+        await Expect(Page.Locator("#rating-state")).ToHaveTextAsync("satisfied", new() { Timeout = 5000 });
+
+        await Page.Locator("#reset-rating-btn").ClickAsync();
+        await Page.Locator("#check-rating-btn").ClickAsync();
+        await Expect(Page.Locator("#rating-state")).ToHaveTextAsync("needs follow-up", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_rating_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-rating-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-score")).ToHaveTextAsync("4", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("score:4", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSidebar.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSidebar.cs
@@ -58,6 +58,9 @@ public class WhenUsingFusionSidebar : PlaywrightTestBase
         await Page.Locator("#show-btn").ClickAsync();
         await Expect(Page.Locator("#open-state")).ToHaveTextAsync("opened", new() { Timeout = 5000 });
         await Expect(Page.Locator("#open-interacted")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#panel-title")).ToHaveTextAsync("Resident navigation", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#panel-load-state")).ToHaveTextAsync("workflow opened resident navigation panel", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#panel-open-mode")).ToHaveTextAsync("workflow opened", new() { Timeout = 5000 });
         await Expect(Page.Locator("#is-open-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
         await Expect(Sidebar.OpenRoot).ToHaveCountAsync(1);
 

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSidebar.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSidebar.cs
@@ -1,0 +1,77 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionSidebar : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionSidebar";
+
+    private FusionSidebarLocator Sidebar => new(Page, "resident-sidebar");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#is-open-echo", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionSidebar — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_sidebar_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("resident-sidebar"));
+        Assert.That(planJson, Does.Contain("\"isOpen\""));
+        Assert.That(planJson, Does.Contain("\"show\""));
+        Assert.That(planJson, Does.Contain("\"hide\""));
+        Assert.That(planJson, Does.Contain("\"toggle\""));
+        Assert.That(planJson, Does.Contain("\"open\""));
+        Assert.That(planJson, Does.Contain("\"close\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task dom_ready_reads_is_open_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#is-open-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Sidebar.ClosedRoot).ToHaveCountAsync(1);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task show_hide_and_toggle_methods_update_state_and_payloads()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#show-btn").ClickAsync();
+        await Expect(Page.Locator("#open-state")).ToHaveTextAsync("opened", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#open-interacted")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#is-open-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Sidebar.OpenRoot).ToHaveCountAsync(1);
+
+        await Page.Locator("#hide-btn").ClickAsync();
+        await Expect(Page.Locator("#close-state")).ToHaveTextAsync("closed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#close-interacted")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#is-open-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Sidebar.ClosedRoot).ToHaveCountAsync(1);
+
+        await Page.Locator("#toggle-btn").ClickAsync();
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("toggle", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#is-open-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Sidebar.OpenRoot).ToHaveCountAsync(1);
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSlider.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSlider.cs
@@ -1,0 +1,141 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionSlider : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/Slider";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_SliderModel";
+    private const string PainScoreId = Scope + "__PainScore";
+    private const string PreferredRangeId = Scope + "__PreferredRange";
+
+    private FusionSliderLocator PainScore => new(Page, PainScoreId);
+    private FusionSliderLocator PreferredRange => new(Page, PreferredRangeId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#value-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionSlider — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_slider_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(PainScoreId));
+        Assert.That(planJson, Does.Contain(PreferredRangeId));
+        Assert.That(planJson, Does.Contain("\"rangeValue\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"change\""));
+        Assert.That(planJson, Does.Contain("\"changed\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_scalar_value_and_reads_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("35", new() { Timeout = 5000 });
+        Assert.That(await PainScore.ValueNow(), Is.EqualTo("35"));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_range_value_and_reads_range_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Page.Locator("#range-echo")).ToHaveTextAsync("15,75", new() { Timeout = 5000 });
+        Assert.That(await PreferredRange.ValueNow(0), Is.EqualTo("15"));
+        Assert.That(await PreferredRange.ValueNow(1), Is.EqualTo("75"));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_value_updates_visible_slider_and_change_payload()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-score-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("score set", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("65", new() { Timeout = 5000 });
+        Assert.That(await PainScore.ValueNow(), Is.EqualTo("65"));
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("65", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-previous")).ToHaveTextAsync("35", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-text")).ToHaveTextAsync("65", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-action")).ToHaveTextAsync("change", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-interacted")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task changed_event_exposes_value_previous_text_and_action()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-score-btn").ClickAsync();
+
+        await Expect(Page.Locator("#changed-value")).ToHaveTextAsync("65", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-previous")).ToHaveTextAsync("35", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-text")).ToHaveTextAsync("65", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#changed-action")).ToHaveTextAsync("changed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("at least 50", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_value_condition_reads_current_value()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-score-btn").ClickAsync();
+        await Expect(Page.Locator("#score-state")).ToHaveTextAsync("low", new() { Timeout = 5000 });
+
+        await Page.Locator("#set-score-btn").ClickAsync();
+        await Page.Locator("#check-score-btn").ClickAsync();
+        await Expect(Page.Locator("#score-state")).ToHaveTextAsync("high", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_range_value_updates_visible_slider_and_range_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-range-btn").ClickAsync();
+
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("range set", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#range-echo")).ToHaveTextAsync("30,90", new() { Timeout = 5000 });
+        Assert.That(await PreferredRange.ValueNow(0), Is.EqualTo("30"));
+        Assert.That(await PreferredRange.ValueNow(1), Is.EqualTo("90"));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_scalar_and_range_value_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-score-btn").ClickAsync();
+        await Page.Locator("#set-range-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-score")).ToHaveTextAsync("65", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-range")).ToHaveTextAsync("30,90", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("65:30,90", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSplitButton.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionSplitButton.cs
@@ -1,0 +1,193 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionSplitButton : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionSplitButton";
+    private const string MenuId = "resident-split-actions";
+
+    private FusionSplitButtonLocator Menu => new(Page, MenuId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#content-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionSplitButton — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_split_button_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain(MenuId));
+        Assert.That(planJson, Does.Contain("\"content\""));
+        Assert.That(planJson, Does.Contain("\"disabled\""));
+        Assert.That(planJson, Does.Contain("\"cssClass\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"toggle\""));
+        Assert.That(planJson, Does.Contain("\"focusIn\""));
+        Assert.That(planJson, Does.Contain("\"removeItems\""));
+        Assert.That(planJson, Does.Contain("\"click\""));
+        Assert.That(planJson, Does.Contain("\"select\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_content_and_reads_content_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Menu.Primary).ToContainTextAsync("Ready Review", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Ready Review", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task primary_click_event_runs_notification_pipeline()
+    {
+        await NavigateAndBoot();
+
+        await Menu.Primary.ClickAsync();
+
+        await Expect(Page.Locator("#primary-click-state")).ToHaveTextAsync("primary clicked", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("primary clicked", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_content_and_disabled_update_visible_state_sources_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+        await Expect(Menu.Primary).ToContainTextAsync("Discharge Review", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#content-echo")).ToHaveTextAsync("Discharge Review", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-disabled-btn").ClickAsync();
+        await Expect(Page.Locator("#disabled-state")).ToHaveTextAsync("enabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#disable-split-btn").ClickAsync();
+        await Expect(Menu.Primary).ToBeDisabledAsync(new() { Timeout = 5000 });
+        await Expect(Menu.Secondary).ToBeDisabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Page.Locator("#check-disabled-btn").ClickAsync();
+        await Expect(Page.Locator("#disabled-state")).ToHaveTextAsync("disabled", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-split-btn").ClickAsync();
+        await Expect(Menu.Primary).ToBeEnabledAsync(new() { Timeout = 5000 });
+        await Expect(Menu.Secondary).ToBeEnabledAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#disabled-echo")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task set_css_class_updates_buttons_wrapper_popup_and_css_source()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-css-btn").ClickAsync();
+
+        Assert.That(await Menu.PrimaryHasClass("e-success"), Is.True);
+        Assert.That(await Menu.PrimaryHasClass("extra-class"), Is.True);
+        Assert.That(await Menu.SecondaryHasClass("e-success"), Is.True);
+        Assert.That(await Menu.SecondaryHasClass("extra-class"), Is.True);
+        Assert.That(await Menu.WrapperHasClass("e-success"), Is.True);
+        Assert.That(await Menu.WrapperHasClass("extra-class"), Is.True);
+        await Expect(Page.Locator("#css-echo")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+
+        await Page.Locator("#toggle-split-btn").ClickAsync();
+        Assert.That(await Menu.IsPopupOpen(), Is.True);
+        Assert.That(await Menu.PopupHasClass("e-success"), Is.True);
+        Assert.That(await Menu.PopupHasClass("extra-class"), Is.True);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task toggle_method_opens_and_closes_secondary_popup()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#toggle-split-btn").ClickAsync();
+        await Expect(Page.Locator("#toggle-state")).ToHaveTextAsync("toggle called", new() { Timeout = 5000 });
+        Assert.That(await Menu.IsPopupOpen(), Is.True);
+
+        await Page.Locator("#toggle-split-btn").DispatchEventAsync("click");
+        Assert.That(await Menu.IsPopupOpen(), Is.False);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_primary_button()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-split-btn").ClickAsync();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focus called", new() { Timeout = 5000 });
+        await Expect(Menu.Primary).ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task remove_items_methods_remove_popup_items_by_text_and_id()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#remove-schedule-btn").ClickAsync();
+        await Expect(Page.Locator("#remove-state")).ToHaveTextAsync("schedule removed", new() { Timeout = 5000 });
+        await Menu.Secondary.ClickAsync();
+        await Expect(Menu.Item("Schedule visit")).ToHaveCountAsync(0, new() { Timeout = 5000 });
+        await Expect(Menu.Item("Place hold")).ToHaveCountAsync(1, new() { Timeout = 5000 });
+
+        await Page.Locator("#remove-hold-btn").ClickAsync();
+        await Expect(Page.Locator("#remove-state")).ToHaveTextAsync("hold removed", new() { Timeout = 5000 });
+        await Menu.Secondary.ClickAsync();
+        await Expect(Menu.Item("Place hold")).ToHaveCountAsync(0, new() { Timeout = 5000 });
+        await Expect(Menu.Item("Assign nurse")).ToHaveCountAsync(1, new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task select_event_reads_typed_item_payload_and_condition()
+    {
+        await NavigateAndBoot();
+
+        await Menu.Secondary.ClickAsync();
+        await Menu.Item("Assign nurse").ClickAsync();
+
+        await Expect(Page.Locator("#selected-id")).ToHaveTextAsync("assign", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-text")).ToHaveTextAsync("Assign nurse", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-disabled")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#selected-condition")).ToHaveTextAsync("assign selected", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task gather_consumes_split_button_sources()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#set-content-btn").ClickAsync();
+        await Page.Locator("#set-css-btn").ClickAsync();
+        await Page.Locator("#disable-split-btn").ClickAsync();
+        await Page.Locator("#gather-btn").ClickAsync();
+
+        await Expect(Page.Locator("#gather-content")).ToHaveTextAsync("Discharge Review", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-disabled")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-css")).ToHaveTextAsync("e-success extra-class", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#gather-summary")).ToHaveTextAsync("Discharge Review:True:e-success extra-class", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepper.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepper.cs
@@ -74,6 +74,7 @@ public class WhenUsingFusionStepper : PlaywrightTestBase
         await Expect(Page.Locator("#step-changing-active")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changing-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changing-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-cancel")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changed-state")).ToHaveTextAsync("changed", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changed-active")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changed-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
@@ -83,6 +84,7 @@ public class WhenUsingFusionStepper : PlaywrightTestBase
         await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#current-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changing-guard")).ToHaveTextAsync("blocked", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-cancel")).ToHaveTextAsync("true", new() { Timeout = 5000 });
 
         await Stepper.CompleteStep.ClickAsync();
         await Expect(Page.Locator("#step-click-state")).ToHaveTextAsync("clicked", new() { Timeout = 5000 });
@@ -91,6 +93,7 @@ public class WhenUsingFusionStepper : PlaywrightTestBase
         await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("2", new() { Timeout = 5000 });
         await Expect(Page.Locator("#current-step")).ToHaveTextAsync("2", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changing-guard")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-cancel")).ToHaveTextAsync("false", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changed-active")).ToHaveTextAsync("2", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changed-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
         await Expect(Page.Locator("#step-changed-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepper.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepper.cs
@@ -109,4 +109,44 @@ public class WhenUsingFusionStepper : PlaywrightTestBase
 
         AssertNoConsoleErrors();
     }
+
+    [Test]
+    public async Task validation_stepper_renders_validation_state_and_tooltips()
+    {
+        await NavigateAndBoot();
+
+        await Expect(Stepper.ValidationRoot).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await Expect(Stepper.ValidationIntakeStep).ToBeVisibleAsync();
+        await Expect(Stepper.ValidationReviewStep).ToBeVisibleAsync();
+        await Expect(Stepper.ValidationCompleteStep).ToBeVisibleAsync();
+
+        var validationItems = Stepper.ValidationRoot.Locator(".e-step-container");
+        await Expect(validationItems.Nth(0)).ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-step-valid"));
+        await Expect(validationItems.Nth(1)).ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-step-error"));
+        await Expect(validationItems.Nth(2)).Not.ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-step-valid"));
+        await Expect(validationItems.Nth(2)).Not.ToHaveClassAsync(new System.Text.RegularExpressions.Regex("e-step-error"));
+
+        await Expect(Stepper.ValidationRoot.Locator(".e-step-label-optional")).ToBeVisibleAsync();
+
+        await Stepper.ValidationCompleteStep.ClickAsync(new() { Force = true });
+        await Expect(Page.Locator("#validation-active-echo")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#validation-step-click-state")).ToHaveTextAsync("pending", new() { Timeout = 2000 });
+
+        await Stepper.ValidationReviewStep.ClickAsync(new() { Force = true });
+        await Expect(Page.Locator("#validation-step-click-state")).ToHaveTextAsync("clicked", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#validation-step-click-active")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#validation-step-click-previous")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#validation-active-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#validation-current-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+
+        await Stepper.ValidationCompleteStep.ClickAsync(new() { Force = true });
+        await Expect(Page.Locator("#validation-active-echo")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#validation-current-step")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+
+        await Stepper.ValidationCompleteStep.DispatchEventAsync("mouseover");
+        await Expect(Stepper.ValidationTooltip).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await Expect(Stepper.ValidationTooltip).ToContainTextAsync("Complete", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
 }

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepper.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepper.cs
@@ -1,0 +1,112 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionStepper : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionStepper";
+
+    private FusionStepperLocator Stepper => new(Page, "resident-stepper");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForBoot(Path);
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionStepper — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_stepper_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("resident-stepper"));
+        Assert.That(planJson, Does.Contain("\"activeStep\""));
+        Assert.That(planJson, Does.Contain("\"readwrite\""));
+        Assert.That(planJson, Does.Contain("\"nextStep\""));
+        Assert.That(planJson, Does.Contain("\"previousStep\""));
+        Assert.That(planJson, Does.Contain("\"reset\""));
+        Assert.That(planJson, Does.Contain("\"refreshProgressbar\""));
+        Assert.That(planJson, Does.Contain("\"stepChanging\""));
+        Assert.That(planJson, Does.Contain("\"stepClick\""));
+        Assert.That(planJson, Does.Contain("\"stepChanged\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task direct_step_writes_move_the_stepper_both_ways()
+    {
+        await NavigateAndBoot();
+
+        await Stepper.SetCompleteButton.ClickAsync();
+        await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("set complete", new() { Timeout = 5000 });
+
+        await Stepper.SetIntakeButton.ClickAsync();
+        await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("set intake", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task property_writes_commands_and_clicks_update_the_stepper_and_guard_the_transition()
+    {
+        await NavigateAndBoot();
+
+        await Stepper.SetReviewButton.ClickAsync();
+        await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-state")).ToHaveTextAsync("observed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-active")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changed-state")).ToHaveTextAsync("changed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changed-active")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changed-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changed-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Stepper.NextButton.ClickAsync();
+        await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-guard")).ToHaveTextAsync("blocked", new() { Timeout = 5000 });
+
+        await Stepper.CompleteStep.ClickAsync();
+        await Expect(Page.Locator("#step-click-state")).ToHaveTextAsync("clicked", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-click-active")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-click-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changing-guard")).ToHaveTextAsync("allowed", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changed-active")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changed-previous")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#step-changed-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Stepper.PreviousButton.ClickAsync();
+        await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+
+        await Stepper.ResetButton.ClickAsync();
+        await Expect(Page.Locator("#active-step-echo")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#current-step")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#command-state")).ToHaveTextAsync("reset", new() { Timeout = 5000 });
+
+        await Stepper.RefreshButton.ClickAsync();
+        await Expect(Page.Locator("#progress-state")).ToHaveTextAsync("refreshed", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepperLazyWizard.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepperLazyWizard.cs
@@ -34,6 +34,9 @@ public class WhenUsingFusionStepperLazyWizard : PlaywrightTestBase
     private ILocator ErrorFor(string formId, string fieldName) =>
         Page.Locator($"#stepper-wizard-step #{formId} span[data-valmsg-for='{fieldName}']");
 
+    private ILocator StepNumber(int zeroBasedIndex) =>
+        Page.Locator("#stepper-wizard .e-step-container > .e-indicator").Nth(zeroBasedIndex);
+
     [Test]
     public async Task components_index_links_to_the_lazy_wizard()
     {
@@ -52,6 +55,11 @@ public class WhenUsingFusionStepperLazyWizard : PlaywrightTestBase
     public async Task lazy_loaded_steps_gate_navigation_with_framework_validation_and_recover_saved_drafts()
     {
         await NavigateAndLoadIntake();
+
+        await StepNumber(2).ClickAsync(new() { Force = true });
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-intake-form")).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-status")).ToHaveTextAsync("complete care before opening contacts", new() { Timeout = 5000 });
 
         await ClickWhenStable(Page.Locator("#stepper-wizard-next-intake"));
         await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-intake-form")).ToBeVisibleAsync();
@@ -112,6 +120,16 @@ public class WhenUsingFusionStepperLazyWizard : PlaywrightTestBase
         await Expect(Page.Locator("#stepper-wizard-summary-resident")).ToHaveTextAsync("Amina Patel");
         await Expect(Page.Locator("#stepper-wizard-summary-care")).ToHaveTextAsync("Memory Care");
         await Expect(Page.Locator("#stepper-wizard-summary-contact")).ToHaveTextAsync("Mina Patel");
+
+        await StepNumber(1).ClickAsync(new() { Force = true });
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-care-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#memory-assessment-panel")).ToBeVisibleAsync(new() { Timeout = 5000 });
+
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-care"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-contact-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-contact"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-review-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
 
         await ClickWhenStable(Page.Locator("#stepper-wizard-submit"));
         await Expect(ErrorFor("stepper-wizard-review-form", nameof(FusionStepperWizardReviewModel.AdmissionCoordinator)))

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepperLazyWizard.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionStepperLazyWizard.cs
@@ -1,0 +1,127 @@
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using Alis.Reactive;
+using Alis.Reactive.Playwright.Extensions;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models.Components.Fusion.Stepper;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionStepperLazyWizard : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionStepper/Wizard";
+    private const string ComponentsPath = "/Sandbox/Components";
+
+    private async Task NavigateAndLoadIntake()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-intake-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
+    private static string IdFor<TModel>(Expression<Func<TModel, object?>> expr) where TModel : class =>
+        IdGenerator.For(expr);
+
+    private FusionTextBoxLocator TextBox<TModel>(Expression<Func<TModel, object?>> expr) where TModel : class =>
+        new(Page, IdFor(expr));
+
+    private NumericTextBoxLocator NumericTextBox<TModel>(Expression<Func<TModel, object?>> expr) where TModel : class =>
+        new(Page, IdFor(expr));
+
+    private DropDownListLocator DropDown<TModel>(Expression<Func<TModel, object?>> expr) where TModel : class =>
+        new(Page, IdFor(expr));
+
+    private ILocator ErrorFor(string formId, string fieldName) =>
+        Page.Locator($"#stepper-wizard-step #{formId} span[data-valmsg-for='{fieldName}']");
+
+    [Test]
+    public async Task components_index_links_to_the_lazy_wizard()
+    {
+        await NavigateTo(ComponentsPath);
+
+        var card = Page.Locator("a").Filter(new() { HasTextString = "Stepper Lazy Wizard" });
+        await Expect(card).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await card.ClickAsync();
+
+        await Expect(Page).ToHaveURLAsync(new Regex("/Sandbox/Components/FusionStepper/Wizard$"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-intake-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task lazy_loaded_steps_gate_navigation_with_framework_validation_and_recover_saved_drafts()
+    {
+        await NavigateAndLoadIntake();
+
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-intake"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-intake-form")).ToBeVisibleAsync();
+        await Expect(ErrorFor("stepper-wizard-intake-form", nameof(FusionStepperWizardIntakeModel.ResidentName)))
+            .ToContainTextAsync("required", new() { Timeout = 5000 });
+        await Expect(ErrorFor("stepper-wizard-intake-form", nameof(FusionStepperWizardIntakeModel.Age)))
+            .ToContainTextAsync("required", new() { Timeout = 5000 });
+        await Expect(ErrorFor("stepper-wizard-intake-form", nameof(FusionStepperWizardIntakeModel.AdmissionType)))
+            .ToContainTextAsync("required", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+
+        await TextBox<FusionStepperWizardIntakeModel>(m => m.ResidentName).FillAndBlur("Amina Patel");
+        await NumericTextBox<FusionStepperWizardIntakeModel>(m => m.Age).FillAndBlur("82");
+        await DropDown<FusionStepperWizardIntakeModel>(m => m.AdmissionType).Select("Memory Care Evaluation");
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-intake"));
+
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-care-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-status")).ToContainTextAsync("Intake saved for Amina Patel", new() { Timeout = 5000 });
+
+        await ClickWhenStable(Page.Locator("#stepper-wizard-back-care"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-intake-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(TextBox<FusionStepperWizardIntakeModel>(m => m.ResidentName).Input).ToHaveValueAsync("Amina Patel", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("0", new() { Timeout = 5000 });
+
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-intake"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-care-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await DropDown<FusionStepperWizardCareModel>(m => m.CareLevel).Select("Memory Care");
+        await Expect(Page.Locator("#memory-assessment-panel")).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await DropDown<FusionStepperWizardCareModel>(m => m.PrimaryDiagnosis).Select("Alzheimer's");
+        await NumericTextBox<FusionStepperWizardCareModel>(m => m.FallRiskScore).FillAndBlur("7");
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-care"));
+        await Expect(ErrorFor("stepper-wizard-care-form", nameof(FusionStepperWizardCareModel.MemoryAssessment)))
+            .ToContainTextAsync("required for Memory Care", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("1", new() { Timeout = 5000 });
+
+        await TextBox<FusionStepperWizardCareModel>(m => m.MemoryAssessment).FillAndBlur("MoCA 18 with nightly wandering risk");
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-care"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-contact-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+
+        await TextBox<FusionStepperWizardContactModel>(m => m.ResponsibleParty).FillAndBlur("Mina Patel");
+        await TextBox<FusionStepperWizardContactModel>(m => m.Phone).FillAndBlur("555");
+        await TextBox<FusionStepperWizardContactModel>(m => m.Email).FillAndBlur("not-email");
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-contact"));
+        await Expect(ErrorFor("stepper-wizard-contact-form", nameof(FusionStepperWizardContactModel.Phone)))
+            .ToContainTextAsync("123-456-7890", new() { Timeout = 5000 });
+        await Expect(ErrorFor("stepper-wizard-contact-form", nameof(FusionStepperWizardContactModel.Email)))
+            .ToContainTextAsync("valid email", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+
+        await TextBox<FusionStepperWizardContactModel>(m => m.Phone).FillAndBlur("555-142-0188");
+        await TextBox<FusionStepperWizardContactModel>(m => m.Email).FillAndBlur("mina.patel@example.com");
+        await ClickWhenStable(Page.Locator("#stepper-wizard-next-contact"));
+        await Expect(Page.Locator("#stepper-wizard-step #stepper-wizard-review-form")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#stepper-wizard-current")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-summary-resident")).ToHaveTextAsync("Amina Patel");
+        await Expect(Page.Locator("#stepper-wizard-summary-care")).ToHaveTextAsync("Memory Care");
+        await Expect(Page.Locator("#stepper-wizard-summary-contact")).ToHaveTextAsync("Mina Patel");
+
+        await ClickWhenStable(Page.Locator("#stepper-wizard-submit"));
+        await Expect(ErrorFor("stepper-wizard-review-form", nameof(FusionStepperWizardReviewModel.AdmissionCoordinator)))
+            .ToContainTextAsync("required", new() { Timeout = 5000 });
+
+        await TextBox<FusionStepperWizardReviewModel>(m => m.AdmissionCoordinator).FillAndBlur("Nora Jensen");
+        await ClickWhenStable(Page.Locator("#stepper-wizard-submit"));
+        await Expect(Page.Locator("#stepper-wizard-submit-result"))
+            .ToContainTextAsync("Admission packet submitted for Amina Patel", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#stepper-wizard-status")).ToHaveTextAsync("submitted", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionTextArea.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionTextArea.cs
@@ -1,0 +1,131 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionTextArea : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/TextArea";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_TextAreaModel";
+    private const string CareNoteId = Scope + "__CareNote";
+    private const string AutoBlurNoteId = Scope + "__AutoBlurNote";
+
+    private FusionTextAreaLocator CareNote => new(Page, CareNoteId);
+    private FusionTextAreaLocator AutoBlurNote => new(Page, AutoBlurNoteId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#value-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionTextArea — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_textarea_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("\"set\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"input\""));
+        Assert.That(planJson, Does.Contain("\"change\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_value_and_reads_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(CareNote.TextArea).ToHaveValueAsync("Resident prefers morning medication rounds.", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("Resident prefers morning medication rounds.", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task input_event_exposes_value_and_previous_value()
+    {
+        await NavigateAndBoot();
+
+        await CareNote.Fill("Hydration check completed.");
+
+        await Expect(Page.Locator("#input-value")).ToHaveTextAsync("Hydration check completed.", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#input-previous")).ToHaveTextAsync("Resident prefers morning medication rounds.", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task changed_event_exposes_value_previous_value_and_interaction_state()
+    {
+        await NavigateAndBoot();
+
+        await CareNote.FillAndBlur("Hydration check completed.");
+
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("Hydration check completed.", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-previous")).ToHaveTextAsync("Resident prefers morning medication rounds.", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("note entered", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_textarea_and_focus_event_reads_value()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-in-btn").ClickAsync();
+
+        await Expect(CareNote.TextArea).ToBeFocusedAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focused", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-value")).ToHaveTextAsync("Resident prefers morning medication rounds.", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task blur_event_reads_value()
+    {
+        await NavigateAndBoot();
+
+        await CareNote.Focus();
+        await CareNote.Blur();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("blurred", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#blur-value")).ToHaveTextAsync("Resident prefers morning medication rounds.", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusout_method_removes_focus_without_button_click_stealing_focus()
+    {
+        await NavigateAndBoot();
+
+        await AutoBlurNote.Focus();
+
+        await Expect(Page.Locator("#focusout-method-state")).ToHaveTextAsync("focusout called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#autoblur-state")).ToHaveTextAsync("blurred", new() { Timeout = 5000 });
+        await Expect(AutoBlurNote.TextArea).Not.ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_value_condition_reads_current_value()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-note-btn").ClickAsync();
+        await Expect(Page.Locator("#note-warning")).ToHaveTextAsync("care note set", new() { Timeout = 5000 });
+
+        await CareNote.Clear();
+        await Page.Locator("#check-note-btn").ClickAsync();
+        await Expect(Page.Locator("#note-warning")).ToHaveTextAsync("care note required", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionTextBox.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionTextBox.cs
@@ -1,0 +1,141 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionTextBox : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/TextBox";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_TextBoxModel";
+    private const string ResidentNameId = Scope + "__ResidentName";
+    private const string AutoBlurNoteId = Scope + "__AutoBlurNote";
+
+    private FusionTextBoxLocator ResidentName => new(Page, ResidentNameId);
+    private FusionTextBoxLocator AutoBlurNote => new(Page, AutoBlurNoteId);
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#value-echo");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionTextBox — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_textbox_members()
+    {
+        await NavigateAndBoot();
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("\"set\""));
+        Assert.That(planJson, Does.Contain("\"dataBind\""));
+        Assert.That(planJson, Does.Contain("\"addAppendIcon\""));
+        Assert.That(planJson, Does.Contain("\"input\""));
+        Assert.That(planJson, Does.Contain("\"change\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_sets_visible_value_and_reads_value_source()
+    {
+        await NavigateAndBoot();
+
+        await Expect(ResidentName.Input).ToHaveValueAsync("Amina Patel", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#value-echo")).ToHaveTextAsync("Amina Patel", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task domready_adds_append_icon()
+    {
+        await NavigateAndBoot();
+
+        await Expect(ResidentName.Wrapper.Locator(".e-icons.e-search")).ToHaveCountAsync(1);
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task input_event_exposes_value_and_previous_value()
+    {
+        await NavigateAndBoot();
+
+        await ResidentName.Fill("Nora Lee");
+
+        await Expect(Page.Locator("#input-value")).ToHaveTextAsync("Nora Lee", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#input-previous")).ToHaveTextAsync("Amina Patel", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task changed_event_exposes_value_previous_value_and_interaction_state()
+    {
+        await NavigateAndBoot();
+
+        await ResidentName.FillAndBlur("Nora Lee");
+
+        await Expect(Page.Locator("#change-value")).ToHaveTextAsync("Nora Lee", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-previous")).ToHaveTextAsync("Amina Patel", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#change-interacted")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#args-condition")).ToHaveTextAsync("name entered", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusin_method_focuses_textbox_and_focus_event_reads_value()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#focus-in-btn").ClickAsync();
+
+        await Expect(ResidentName.Input).ToBeFocusedAsync(new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("focused", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#focus-value")).ToHaveTextAsync("Amina Patel", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task blur_event_reads_value()
+    {
+        await NavigateAndBoot();
+
+        await ResidentName.Focus();
+        await ResidentName.Blur();
+
+        await Expect(Page.Locator("#focus-state")).ToHaveTextAsync("blurred", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#blur-value")).ToHaveTextAsync("Amina Patel", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task focusout_method_removes_focus_without_button_click_stealing_focus()
+    {
+        await NavigateAndBoot();
+
+        await AutoBlurNote.Focus();
+
+        await Expect(Page.Locator("#focusout-method-state")).ToHaveTextAsync("focusout called", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#autoblur-state")).ToHaveTextAsync("blurred", new() { Timeout = 5000 });
+        await Expect(AutoBlurNote.Input).Not.ToBeFocusedAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task component_value_condition_reads_current_value()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#check-name-btn").ClickAsync();
+        await Expect(Page.Locator("#name-warning")).ToHaveTextAsync("resident name set", new() { Timeout = 5000 });
+
+        await ResidentName.Clear();
+        await Page.Locator("#check-name-btn").ClickAsync();
+        await Expect(Page.Locator("#name-warning")).ToHaveTextAsync("resident name required", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionToolbar.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenUsingFusionToolbar.cs
@@ -1,0 +1,67 @@
+using Alis.Reactive.Playwright.Extensions;
+
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+[TestFixture]
+public class WhenUsingFusionToolbar : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/FusionToolbar";
+
+    private FusionToolbarLocator Toolbar => new(Page, "resident-toolbar");
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateToAndWaitForTextSignal(Path, "#toolbar-disabled", "pending");
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("FusionToolbar — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task plan_json_contains_typed_toolbar_members()
+    {
+        await NavigateAndBoot();
+
+        var planJson = await Page.Locator("#plan-json").TextContentAsync();
+
+        Assert.That(planJson, Does.Contain("\"vendor\": \"fusion\""));
+        Assert.That(planJson, Does.Contain("resident-toolbar"));
+        Assert.That(planJson, Does.Contain("\"disable\""));
+        Assert.That(planJson, Does.Contain("\"clicked\""));
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task clicked_event_exposes_typed_item_metadata()
+    {
+        await NavigateAndBoot();
+
+        await Toolbar.SaveItem.ClickAsync();
+
+        await Expect(Page.Locator("#clicked-state")).ToHaveTextAsync("clicked", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#clicked-id")).ToHaveTextAsync("toolbar-save", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#clicked-text")).ToHaveTextAsync("Save", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#clicked-disabled")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task disable_and_enable_toggle_the_toolbar_root_state()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator("#disable-toolbar-btn").ClickAsync();
+        await Expect(Page.Locator("#toolbar-disabled")).ToHaveTextAsync("true", new() { Timeout = 5000 });
+
+        await Page.Locator("#enable-toolbar-btn").ClickAsync();
+        await Expect(Page.Locator("#toolbar-disabled")).ToHaveTextAsync("false", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Validation/ClientRules/WhenAGridColumnGeneratesNativeValidationFromClientRules.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Validation/ClientRules/WhenAGridColumnGeneratesNativeValidationFromClientRules.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using Alis.Reactive.Fusion.Components;
+using Alis.Reactive.FluentValidator;
+using Alis.Reactive.Validation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Alis.Reactive.PlaywrightTests.Validation.ClientRules;
+
+/// <summary>
+/// The grid column validation emitter translates the SAME <c>ReactiveValidator</c>
+/// client metadata into an EJ2 <c>column.validationRules</c> object. Single-field rules
+/// with an EJ2 equivalent are emitted with their FluentValidation messages; conditional,
+/// cross-field, and exotic rules carry no EJ2 equivalent and stay server-authoritative.
+/// </summary>
+[TestFixture]
+public class WhenAGridColumnGeneratesNativeValidationFromClientRules
+{
+    private static IClientValidationRuleSource RuleSource()
+    {
+        var services = new ServiceCollection();
+        services.AddReactiveFluentValidation(rules =>
+        {
+            rules.Add<BuiltInClientRulesValidator>();
+            rules.Add<ReactiveAssessmentValidator>();
+        });
+        return services.BuildServiceProvider().GetRequiredService<IClientValidationRuleSource>();
+    }
+
+    private static FusionGridFieldValidation<TRow> ValidationFor<TValidator, TRow>()
+        where TValidator : class
+        where TRow : class =>
+        FusionGridValidation.From<TValidator, TRow>(RuleSource());
+
+    [Test]
+    public void string_rules_map_directly_with_their_fluentvalidation_messages()
+    {
+        var validation = ValidationFor<BuiltInClientRulesValidator, BuiltInClientRulesModel>();
+
+        var rules = (IDictionary<string, object>)validation.Field(m => m.Name)!;
+
+        Assert.That(rules.Keys, Is.EquivalentTo(new[] { "required", "minLength", "maxLength", "regex" }));
+
+        var required = (object[])rules["required"];
+        Assert.That(required[0], Is.EqualTo(true));
+        Assert.That(required[1], Is.EqualTo("'Name' is required."));
+
+        var minLength = (object[])rules["minLength"];
+        Assert.That(minLength[0], Is.EqualTo(2));
+        Assert.That(minLength[1], Is.EqualTo("'Name' must be at least 2 characters."));
+
+        var regex = (object[])rules["regex"];
+        Assert.That(regex[0], Is.EqualTo("^[A-Z]+$"));
+    }
+
+    [Test]
+    public void numeric_rules_map_only_where_ej2_has_an_equivalent()
+    {
+        var validation = ValidationFor<BuiltInClientRulesValidator, BuiltInClientRulesModel>();
+
+        var rules = (IDictionary<string, object>)validation.Field(m => m.Score)!;
+
+        // Range -> range, GreaterThanOrEqualTo -> min, LessThanOrEqualTo -> max.
+        // ExclusiveRange, GreaterThan, LessThan, EqualTo, NotEqual: no EJ2 built-in.
+        Assert.That(rules.Keys, Is.EquivalentTo(new[] { "range", "min", "max" }));
+
+        var range = (object[])rules["range"];
+        Assert.That((object[])range[0], Is.EqualTo(new object[] { 1, 5 }));
+        Assert.That(range[1], Is.EqualTo("'Score' must be between 1 and 5."));
+        Assert.That(((object[])rules["min"])[0], Is.EqualTo(2));
+        Assert.That(((object[])rules["max"])[0], Is.EqualTo(8));
+    }
+
+    [Test]
+    public void email_maps_and_rules_without_an_ej2_equivalent_produce_no_client_validation()
+    {
+        var validation = ValidationFor<BuiltInClientRulesValidator, BuiltInClientRulesModel>();
+
+        var email = (IDictionary<string, object>)validation.Field(m => m.Email)!;
+        Assert.That(email.Keys, Is.EquivalentTo(new[] { "email" }));
+
+        // CreditCard and Empty have no EJ2 FormValidator equivalent: server-authoritative.
+        Assert.That(validation.Field(m => m.Card), Is.Null);
+        Assert.That(validation.Field(m => m.EmptyCode), Is.Null);
+    }
+
+    [Test]
+    public void conditional_when_field_rules_are_never_emitted_as_always_on_column_rules()
+    {
+        var validation = ValidationFor<ReactiveAssessmentValidator, AssessmentModel>();
+
+        // Score's only rule is Required under WhenField(IsVeteran): conditional, so skipped.
+        Assert.That(validation.Field(m => m.Score), Is.Null);
+    }
+}


### PR DESCRIPTION
## Summary

Onboards **23 net-new Syncfusion EJ2 components** as typed Fusion vertical slices and substantially extends the **Fusion Grid**. Every component is bound through the DSL with typed events and reactive wiring, demonstrated in a sandbox page, and covered by Playwright behavior tests.

**This PR vs base (`feature/fusion-component-onboarding-skill`): 40 commits · 368 files · +29.8k / −106.**

---

## Components onboarded (23 net-new vertical slices)

Each is a 7-file slice (builder, typed events + event args, `Html` + `Reactive` extensions, sandbox page, Playwright coverage):

- **Inputs (5):** `FusionTextBox` · `FusionTextArea` · `FusionSlider` · `FusionRating` · `FusionOtpInput`
- **Buttons (6):** `FusionButton` · `FusionCheckBox` · `FusionRadioButton` · `FusionDropDownButton` · `FusionSplitButton` · `FusionProgressButton`
- **Selection / lists (4):** `FusionComboBox` · `FusionDropDownTree` · `FusionListView` · `FusionListBox`
- **Navigation / layout (7):** `FusionBreadcrumb` · `FusionCarousel` · `FusionSidebar` · `FusionToolbar` · `FusionMenu` · `FusionContextMenu` · `FusionStepper`
- **Data / viz (1):** `FusionBulletChart`

`FusionStepper` also ships a **lazy-validation wizard** sandbox (with a fix for lazy step-click navigation).

> Scope note: the AI / advanced components (`FusionChipList`, `FusionKanban`, `FusionPivotView`, `FusionMention`, `FusionSmartPasteButton`, `FusionSmartTextArea`, `FusionAIAssistView`) are **not** in this PR — they already landed on the base branch.

## Fusion Grid

- **Typed tooling:** Excel / CSV / PDF export, print, column chooser, autofit — via typed component-method calls
- **Typed cell + dialog editors** driven by row expressions (no stringly field names, no raw template HTML); a typed `DialogForm<TRow>` builder replaces the inline `<script type="text/x-template">` pattern
- **Billing** and **CareOps** senior-living grid boards — server-side filter/sort/page, bulk batch save, chip fast-filters, checkbox bulk selection, frozen + sticky columns, and per-row `NativeActionLink` actions (flag / discharge with confirm); state is per browser session so edits persist across saves and refreshes
- **EJ2-native column validation generated from `ReactiveValidator` metadata** — in-cell editing validates client-side from the *same* FluentValidation client metadata that powers form validation (`FusionGridValidation.From<TValidator, TRow>(...).Field(r => r.X)` reading `IClientValidationRuleSource`). Single source, no second ruleset; conditional/cross-field/exotic rules stay server-authoritative.

## Coverage

- Per-component sandbox pages grouped under a **Fusion Grid** section on the components index
- Playwright behavior suites per component (grid suites reorganized into a `Components/Fusion/Grid/` vertical slice), plus emitter-mapping unit tests for the generated grid validation
- Enrichment passes adding deeper behavior/workflow coverage for Stepper, Carousel, Breadcrumb, BulletChart, Menu, ContextMenu, Sidebar, and the Grid operations
