### PR TITLE
Array-operations DSL: ReactiveArray<T>, value routing, and component integration (grid + chip filter, custom events)

### DIFF
--- a/Alis.Reactive.Assets/runtime/__tests__/array/array-op-count.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/array-op-count.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { evaluateValue } from "../../core/evaluate";
+import type { PlanDocument, Shape, ValueExpression } from "../../types";
+
+const rawShape: Shape = { kind: "raw" };
+const numberShape: Shape = { kind: "number" };
+
+function plan(): PlanDocument {
+  return {
+    version: 3,
+    planId: "Runtime.ArrayDsl.Count",
+    scope: { kind: "root" },
+    types: {},
+    components: {},
+    behaviors: [],
+  };
+}
+
+function count(value: unknown): ValueExpression {
+  return {
+    kind: "array-op",
+    op: "count",
+    source: { kind: "literal", value, shape: rawShape } as ValueExpression,
+    itemShape: rawShape,
+    shape: numberShape,
+  };
+}
+
+describe("array-op count + array-like normalization", () => {
+  it("counts a true JS array", () => {
+    expect(evaluateValue(count([{ id: 1 }, { id: 2 }, { id: 3 }]), plan())).toBe(3);
+  });
+
+  it("normalizes a DOMTokenList (classList) via Array.from before counting", () => {
+    const el = document.createElement("div");
+    el.className = "risk-fall risk-oxygen care-memory";
+    expect(evaluateValue(count(el.classList), plan())).toBe(3);
+  });
+
+  it("normalizes a generic iterable (Set) via Array.from", () => {
+    expect(evaluateValue(count(new Set(["a", "b"])), plan())).toBe(2);
+  });
+
+  it("treats null as an empty array (e.g. EJ2 multiSelect.value when nothing selected)", () => {
+    expect(evaluateValue(count(null), plan())).toBe(0);
+  });
+
+  it("wraps a scalar as a singleton (e.g. ChipList single-select returns a number)", () => {
+    expect(evaluateValue(count(2), plan())).toBe(1);
+  });
+
+  it("throws a fail-fast boundary error for a non-iterable object (e.g. dataset/DOMStringMap)", () => {
+    expect(() => evaluateValue(count({ flag: "x" }), plan())).toThrow(/not iterable/);
+  });
+});

--- a/Alis.Reactive.Assets/runtime/__tests__/array/array-op-filter.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/array-op-filter.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { evaluateValue } from "../../core/evaluate";
+import type { PayloadSource, PlanDocument, Shape, ValidationCondition, ValueExpression } from "../../types";
+
+const stringShape: Shape = { kind: "string" };
+const noneShape: Shape = { kind: "none" };
+const rawShape: Shape = { kind: "raw" };
+const elementSource: PayloadSource = { kind: "payload", scope: "element", type: { kind: "untyped" } };
+
+function plan(): PlanDocument {
+  return {
+    version: 3,
+    planId: "Runtime.ArrayDsl.Filter",
+    scope: { kind: "root" },
+    types: {},
+    components: {},
+    behaviors: [],
+  };
+}
+
+function elementMemberEquals(member: string, expected: string): ValidationCondition {
+  return {
+    kind: "compare",
+    left: {
+      kind: "read",
+      from: elementSource,
+      member,
+      path: [{ kind: "property", name: member }],
+      shape: stringShape,
+      access: { kind: "property" },
+    },
+    op: "eq",
+    right: { kind: "value", value: { kind: "literal", value: expected, shape: stringShape } },
+    shape: stringShape,
+    itemShape: noneShape,
+  };
+}
+
+function elementSelfNotEquals(excluded: string): ValidationCondition {
+  return {
+    kind: "compare",
+    left: {
+      kind: "read",
+      from: elementSource,
+      member: "elementValue",
+      path: [],
+      shape: stringShape,
+      access: { kind: "property" },
+    },
+    op: "neq",
+    right: { kind: "value", value: { kind: "literal", value: excluded, shape: stringShape } },
+    shape: stringShape,
+    itemShape: noneShape,
+  };
+}
+
+function filter(value: unknown, predicate: ValidationCondition, itemShape: Shape = rawShape): ValueExpression {
+  return {
+    kind: "array-op",
+    op: "filter",
+    source: { kind: "literal", value, shape: rawShape } as ValueExpression,
+    predicate,
+    itemShape,
+    shape: { kind: "array", item: itemShape },
+  };
+}
+
+describe("array-op filter (per-element sync predicate via the DI sync-condition leaf)", () => {
+  it("filters object elements by an element-member predicate", () => {
+    const residents = [
+      { id: 1, status: "active" },
+      { id: 2, status: "discharged" },
+      { id: 3, status: "active" },
+    ];
+
+    expect(evaluateValue(filter(residents, elementMemberEquals("status", "active")), plan())).toEqual([
+      { id: 1, status: "active" },
+      { id: 3, status: "active" },
+    ]);
+  });
+
+  it("filters primitive (string[]) elements via the x => x element-self read", () => {
+    const tags = ["fall-risk", "none", "memory-care"];
+
+    expect(evaluateValue(filter(tags, elementSelfNotEquals("none"), stringShape), plan())).toEqual([
+      "fall-risk",
+      "memory-care",
+    ]);
+  });
+
+  it("filters a DOMTokenList after array-like normalization", () => {
+    const el = document.createElement("div");
+    el.className = "risk-fall care-memory plain";
+    // keep only the tokens equal to themselves that are not "plain"
+    expect(evaluateValue(filter(el.classList, elementSelfNotEquals("plain"), stringShape), plan())).toEqual([
+      "risk-fall",
+      "care-memory",
+    ]);
+  });
+});

--- a/Alis.Reactive.Assets/runtime/__tests__/array/array-op-filter.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/array-op-filter.test.ts
@@ -65,6 +65,30 @@ function filter(value: unknown, predicate: ValidationCondition, itemShape: Shape
   };
 }
 
+const numberShape: Shape = { kind: "number" };
+
+function memberCompare(member: string, op: string, value: unknown, shape: Shape): ValidationCondition {
+  return {
+    kind: "compare",
+    left: { kind: "read", from: elementSource, member, path: [{ kind: "property", name: member }], shape, access: { kind: "property" } },
+    op,
+    right: { kind: "value", value: { kind: "literal", value, shape } },
+    shape,
+    itemShape: noneShape,
+  } as unknown as ValidationCondition;
+}
+
+const all = (...terms: ValidationCondition[]): ValidationCondition => ({ kind: "all", terms } as unknown as ValidationCondition);
+const any = (...terms: ValidationCondition[]): ValidationCondition => ({ kind: "any", terms } as unknown as ValidationCondition);
+const not = (term: ValidationCondition): ValidationCondition => ({ kind: "not", term } as unknown as ValidationCondition);
+
+const compoundResidents = [
+  { name: "Ada", status: "active", age: 71 },
+  { name: "Bo", status: "discharged", age: 64 },
+  { name: "Cy", status: "active", age: 25 },
+];
+const names = (v: unknown): string[] => (v as Array<{ name: string }>).map(r => r.name);
+
 describe("array-op filter (per-element sync predicate via the DI sync-condition leaf)", () => {
   it("filters object elements by an element-member predicate", () => {
     const residents = [
@@ -96,5 +120,20 @@ describe("array-op filter (per-element sync predicate via the DI sync-condition 
       "risk-fall",
       "care-memory",
     ]);
+  });
+
+  it("filters by a compound AND predicate (all node) threading element scope to each term", () => {
+    const pred = all(memberCompare("status", "eq", "active", stringShape), memberCompare("age", "gte", 65, numberShape));
+    expect(names(evaluateValue(filter(compoundResidents, pred), plan()))).toEqual(["Ada"]);
+  });
+
+  it("filters by a compound OR predicate (any node)", () => {
+    const pred = any(memberCompare("status", "eq", "active", stringShape), memberCompare("age", "lt", 30, numberShape));
+    expect(names(evaluateValue(filter(compoundResidents, pred), plan()))).toEqual(["Ada", "Cy"]);
+  });
+
+  it("filters by a negated predicate (not node)", () => {
+    const pred = not(memberCompare("status", "eq", "discharged", stringShape));
+    expect(names(evaluateValue(filter(compoundResidents, pred), plan()))).toEqual(["Ada", "Cy"]);
   });
 });

--- a/Alis.Reactive.Assets/runtime/__tests__/array/array-op-ops.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/array-op-ops.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { evaluateValue } from "../../core/evaluate";
+import type { PayloadSource, PlanDocument, Shape, ValidationCondition, ValueExpression } from "../../types";
+
+const stringShape: Shape = { kind: "string" };
+const numberShape: Shape = { kind: "number" };
+const noneShape: Shape = { kind: "none" };
+const rawShape: Shape = { kind: "raw" };
+const elementSource: PayloadSource = { kind: "payload", scope: "element", type: { kind: "untyped" } };
+
+const residents = [
+  { name: "Ada", status: "active", age: 71, balance: 120 },
+  { name: "Bo", status: "discharged", age: 64, balance: 50 },
+  { name: "Cy", status: "active", age: 80, balance: 200 },
+];
+
+function plan(): PlanDocument {
+  return { version: 3, planId: "Runtime.ArrayDsl.Ops", scope: { kind: "root" }, types: {}, components: {}, behaviors: [] };
+}
+
+function source(): ValueExpression {
+  return { kind: "literal", value: residents, shape: rawShape } as ValueExpression;
+}
+
+function memberRead(member: string, shape: Shape): ValueExpression {
+  return {
+    kind: "read",
+    from: elementSource,
+    member,
+    path: [{ kind: "property", name: member }],
+    shape,
+    access: { kind: "property" },
+  };
+}
+
+function compare(member: string, op: string, value: unknown, shape: Shape): ValidationCondition {
+  return {
+    kind: "compare",
+    left: memberRead(member, shape),
+    op,
+    right: { kind: "value", value: { kind: "literal", value, shape } },
+    shape,
+    itemShape: noneShape,
+  } as unknown as ValidationCondition;
+}
+
+function arrayOp(node: Partial<ValueExpression> & { op: string }): ValueExpression {
+  return { kind: "array-op", source: source(), itemShape: rawShape, ...node } as ValueExpression;
+}
+
+describe("array-op ops over an object array (element-member props)", () => {
+  it("map projects each element member", () => {
+    const node = arrayOp({ op: "map", projection: memberRead("name", stringShape), shape: { kind: "array", item: stringShape } });
+    expect(evaluateValue(node, plan())).toEqual(["Ada", "Bo", "Cy"]);
+  });
+
+  it("sum totals a numeric element member", () => {
+    const node = arrayOp({ op: "sum", projection: memberRead("balance", numberShape), shape: numberShape });
+    expect(evaluateValue(node, plan())).toBe(370);
+  });
+
+  it("count with predicate counts matching elements", () => {
+    const node = arrayOp({ op: "count", predicate: compare("status", "eq", "active", stringShape), shape: numberShape });
+    expect(evaluateValue(node, plan())).toBe(2);
+  });
+
+  it("any returns true when an element matches", () => {
+    const node = arrayOp({ op: "any", predicate: compare("age", "gt", 75, numberShape), shape: { kind: "boolean" } });
+    expect(evaluateValue(node, plan())).toBe(true);
+  });
+
+  it("all returns true only when every element matches", () => {
+    const over60 = arrayOp({ op: "all", predicate: compare("age", "gt", 60, numberShape), shape: { kind: "boolean" } });
+    const over70 = arrayOp({ op: "all", predicate: compare("age", "gt", 70, numberShape), shape: { kind: "boolean" } });
+    expect(evaluateValue(over60, plan())).toBe(true);
+    expect(evaluateValue(over70, plan())).toBe(false);
+  });
+
+  it("find returns the first matching element, projected", () => {
+    const node = arrayOp({
+      op: "find",
+      predicate: compare("status", "eq", "active", stringShape),
+      projection: memberRead("name", stringShape),
+      shape: stringShape,
+    });
+    expect(evaluateValue(node, plan())).toBe("Ada");
+  });
+
+  it("find returns null when nothing matches", () => {
+    const node = arrayOp({ op: "find", predicate: compare("status", "eq", "transferred", stringShape), shape: rawShape });
+    expect(evaluateValue(node, plan())).toBeNull();
+  });
+
+  it("orderBy sorts ascending by a key projection", () => {
+    const node = arrayOp({ op: "orderBy", projection: memberRead("age", numberShape), shape: { kind: "array", item: rawShape } });
+    const ordered = evaluateValue(node, plan()) as Array<{ name: string }>;
+    expect(ordered.map(r => r.name)).toEqual(["Bo", "Ada", "Cy"]);
+  });
+
+  it("orderByDescending sorts descending by a key projection", () => {
+    const node = arrayOp({ op: "orderByDescending", projection: memberRead("balance", numberShape), shape: { kind: "array", item: rawShape } });
+    const ordered = evaluateValue(node, plan()) as Array<{ name: string }>;
+    expect(ordered.map(r => r.name)).toEqual(["Cy", "Ada", "Bo"]);
+  });
+
+  it("chains filter -> sum (active residents' balances)", () => {
+    const filtered = arrayOp({
+      op: "filter",
+      predicate: compare("status", "eq", "active", stringShape),
+      shape: { kind: "array", item: rawShape },
+    });
+    const node: ValueExpression = {
+      kind: "array-op",
+      op: "sum",
+      source: filtered,
+      projection: memberRead("balance", numberShape),
+      itemShape: rawShape,
+      shape: numberShape,
+    };
+    // Ada(120) + Cy(200) = 320
+    expect(evaluateValue(node, plan())).toBe(320);
+  });
+});

--- a/Alis.Reactive.Assets/runtime/__tests__/array/array-op-ops.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/array-op-ops.test.ts
@@ -59,9 +59,41 @@ describe("array-op ops over an object array (element-member props)", () => {
     expect(evaluateValue(node, plan())).toBe(370);
   });
 
-  it("count with predicate counts matching elements", () => {
-    const node = arrayOp({ op: "count", predicate: compare("status", "eq", "active", stringShape), shape: numberShape });
+  it("counts a filtered array (filter -> count — the shape Count(predicate) emits)", () => {
+    const filtered = arrayOp({ op: "filter", predicate: compare("status", "eq", "active", stringShape), shape: { kind: "array", item: rawShape } });
+    const node: ValueExpression = { kind: "array-op", op: "count", source: filtered, itemShape: rawShape, shape: numberShape };
     expect(evaluateValue(node, plan())).toBe(2);
+  });
+
+  it("any without a predicate is a non-empty check (true here)", () => {
+    expect(evaluateValue(arrayOp({ op: "any", shape: { kind: "boolean" } }), plan())).toBe(true);
+  });
+
+  it("find returns the whole matching element when no projection is given", () => {
+    const node = arrayOp({ op: "find", predicate: compare("status", "eq", "active", stringShape), shape: rawShape });
+    expect(evaluateValue(node, plan())).toEqual({ name: "Ada", status: "active", age: 71, balance: 120 });
+  });
+
+  it("orderBy places elements with a missing (NaN) key last, deterministically", () => {
+    const withMissing = [{ name: "A", age: 30 }, { name: "B" }, { name: "C", age: 10 }];
+    const node: ValueExpression = {
+      kind: "array-op", op: "orderBy",
+      source: { kind: "literal", value: withMissing, shape: rawShape } as ValueExpression,
+      projection: memberRead("age", numberShape), itemShape: rawShape, shape: { kind: "array", item: rawShape },
+    };
+    const ordered = evaluateValue(node, plan()) as Array<{ name: string }>;
+    expect(ordered.map(r => r.name)).toEqual(["C", "A", "B"]); // 10, 30, missing-last
+  });
+
+  it("orderBy is stable for equal keys (preserves input order)", () => {
+    const ties = [{ name: "A", age: 50 }, { name: "B", age: 50 }, { name: "C", age: 50 }];
+    const node: ValueExpression = {
+      kind: "array-op", op: "orderBy",
+      source: { kind: "literal", value: ties, shape: rawShape } as ValueExpression,
+      projection: memberRead("age", numberShape), itemShape: rawShape, shape: { kind: "array", item: rawShape },
+    };
+    const ordered = evaluateValue(node, plan()) as Array<{ name: string }>;
+    expect(ordered.map(r => r.name)).toEqual(["A", "B", "C"]);
   });
 
   it("any returns true when an element matches", () => {
@@ -120,4 +152,22 @@ describe("array-op ops over an object array (element-member props)", () => {
     // Ada(120) + Cy(200) = 320
     expect(evaluateValue(node, plan())).toBe(320);
   });
+});
+
+describe("array-op ops over an empty source", () => {
+  const empty: ValueExpression = { kind: "literal", value: [], shape: rawShape } as ValueExpression;
+  const op = (node: Partial<ValueExpression> & { op: string }): ValueExpression =>
+    ({ kind: "array-op", source: empty, itemShape: rawShape, ...node } as ValueExpression);
+  const pred = compare("status", "eq", "x", stringShape);
+
+  it("count is 0", () => expect(evaluateValue(op({ op: "count", shape: numberShape }), plan())).toBe(0));
+  it("filter is []", () => expect(evaluateValue(op({ op: "filter", predicate: pred, shape: { kind: "array", item: rawShape } }), plan())).toEqual([]));
+  it("map is []", () => expect(evaluateValue(op({ op: "map", projection: memberRead("name", stringShape), shape: { kind: "array", item: stringShape } }), plan())).toEqual([]));
+  it("sum is 0", () => expect(evaluateValue(op({ op: "sum", projection: memberRead("balance", numberShape), shape: numberShape }), plan())).toBe(0));
+  it("any(predicate) is false", () => expect(evaluateValue(op({ op: "any", predicate: pred, shape: { kind: "boolean" } }), plan())).toBe(false));
+  it("any() is false", () => expect(evaluateValue(op({ op: "any", shape: { kind: "boolean" } }), plan())).toBe(false));
+  // Vacuous truth: All over an empty set is true (matches Array.every). Documented so authors aren't surprised.
+  it("all(predicate) is vacuously true", () => expect(evaluateValue(op({ op: "all", predicate: pred, shape: { kind: "boolean" } }), plan())).toBe(true));
+  it("find is null", () => expect(evaluateValue(op({ op: "find", predicate: pred, shape: rawShape }), plan())).toBeNull());
+  it("orderBy is []", () => expect(evaluateValue(op({ op: "orderBy", projection: memberRead("age", numberShape), shape: { kind: "array", item: rawShape } }), plan())).toEqual([]));
 });

--- a/Alis.Reactive.Assets/runtime/__tests__/array/dom-source.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/dom-source.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { evaluateValue } from "../../core/evaluate";
+import type { PlanDocument, Shape, ValidationCondition, ValueExpression } from "../../types";
+
+const stringShape: Shape = { kind: "string" };
+const numberShape: Shape = { kind: "number" };
+const noneShape: Shape = { kind: "none" };
+
+function plan(): PlanDocument {
+  return { version: 3, planId: "Runtime.ArrayDsl.Dom", scope: { kind: "root" }, types: {}, components: {}, behaviors: [] };
+}
+
+function domRead(elementId: string, member: string): ValueExpression {
+  return {
+    kind: "read",
+    from: { kind: "dom", element: elementId },
+    member,
+    path: [{ kind: "property", name: member }],
+    shape: noneShape,
+    access: { kind: "property" },
+  } as ValueExpression;
+}
+
+function count(source: ValueExpression, predicate?: ValidationCondition): ValueExpression {
+  return { kind: "array-op", op: "count", source, predicate, itemShape: noneShape, shape: numberShape } as ValueExpression;
+}
+
+function selfStartsWith(prefix: string): ValidationCondition {
+  return {
+    kind: "compare",
+    left: { kind: "read", from: { kind: "payload", scope: "element", type: { kind: "untyped" } }, member: "elementValue", path: [], shape: stringShape, access: { kind: "property" } },
+    op: "starts-with",
+    right: { kind: "value", value: { kind: "literal", value: prefix, shape: stringShape } },
+    shape: stringShape,
+    itemShape: noneShape,
+  } as unknown as ValidationCondition;
+}
+
+describe("DOM element source — array ops over live DOM collections", () => {
+  it("counts the CSS classes of a DOM element (classList DOMTokenList)", () => {
+    document.body.innerHTML = `<div id="card" class="risk-fall care-memory plain"></div>`;
+    expect(evaluateValue(count(domRead("card", "classList")), plan())).toBe(3);
+  });
+
+  it("filters classList tokens by prefix and counts (operate on DOM element members)", () => {
+    document.body.innerHTML = `<div id="card" class="risk-fall risk-oxygen care-memory"></div>`;
+    expect(evaluateValue(count(domRead("card", "classList"), selfStartsWith("risk-")), plan())).toBe(2);
+  });
+
+  it("counts child elements (children HTMLCollection)", () => {
+    document.body.innerHTML = `<ul id="list"><li>a</li><li>b</li><li>c</li></ul>`;
+    expect(evaluateValue(count(domRead("list", "children")), plan())).toBe(3);
+  });
+
+  it("throws a clear boundary error when the DOM element is absent", () => {
+    document.body.innerHTML = "";
+    expect(() => evaluateValue(count(domRead("missing", "classList")), plan())).toThrow(/dom source element "missing" not found/);
+  });
+});

--- a/Alis.Reactive.Assets/runtime/__tests__/array/dom-source.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/dom-source.test.ts
@@ -21,8 +21,15 @@ function domRead(elementId: string, member: string): ValueExpression {
   } as ValueExpression;
 }
 
-function count(source: ValueExpression, predicate?: ValidationCondition): ValueExpression {
-  return { kind: "array-op", op: "count", source, predicate, itemShape: noneShape, shape: numberShape } as ValueExpression;
+function count(source: ValueExpression): ValueExpression {
+  return { kind: "array-op", op: "count", source, itemShape: noneShape, shape: numberShape } as ValueExpression;
+}
+
+function filterByPrefix(source: ValueExpression, prefix: string): ValueExpression {
+  return {
+    kind: "array-op", op: "filter", source, predicate: selfStartsWith(prefix),
+    itemShape: noneShape, shape: { kind: "array", item: stringShape },
+  } as ValueExpression;
 }
 
 function selfStartsWith(prefix: string): ValidationCondition {
@@ -42,9 +49,9 @@ describe("DOM element source — array ops over live DOM collections", () => {
     expect(evaluateValue(count(domRead("card", "classList")), plan())).toBe(3);
   });
 
-  it("filters classList tokens by prefix and counts (operate on DOM element members)", () => {
+  it("filters classList tokens by prefix and counts (filter -> count over DOM element members)", () => {
     document.body.innerHTML = `<div id="card" class="risk-fall risk-oxygen care-memory"></div>`;
-    expect(evaluateValue(count(domRead("card", "classList"), selfStartsWith("risk-")), plan())).toBe(2);
+    expect(evaluateValue(count(filterByPrefix(domRead("card", "classList"), "risk-")), plan())).toBe(2);
   });
 
   it("counts child elements (children HTMLCollection)", () => {

--- a/Alis.Reactive.Assets/runtime/__tests__/array/element-method.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/element-method.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { evaluateValue } from "../../core/evaluate";
+import type { PlanDocument, Shape, ValueExpression } from "../../types";
+
+const stringShape: Shape = { kind: "string" };
+const numberShape: Shape = { kind: "number" };
+const rawShape: Shape = { kind: "raw" };
+const elementSource = { kind: "payload", scope: "element", type: { kind: "untyped" } } as const;
+
+function plan(): PlanDocument {
+  return { version: 3, planId: "Runtime.ArrayDsl.ElementMethod", scope: { kind: "root" }, types: {}, components: {}, behaviors: [] };
+}
+
+function literal(value: unknown, shape: Shape): ValueExpression {
+  return { kind: "literal", value, shape } as ValueExpression;
+}
+
+function elementMember(member: string, shape: Shape): ValueExpression {
+  return { kind: "read", from: elementSource, member, path: [{ kind: "property", name: member }], shape, access: { kind: "property" } } as ValueExpression;
+}
+
+// An element method call: receiverPath ("" = the element itself, or "address" for a nested owner)
+// + the method name; path encodes the receiver traversal + method, access is a method with args.
+function elementMethod(receiverPath: string, method: string, shape: Shape, args: ValueExpression[] = []): ValueExpression {
+  const full = receiverPath ? `${receiverPath}.${method}` : method;
+  const path = full.split(".").map(name => ({ kind: "property", name }));
+  return { kind: "read", from: elementSource, member: method, path, shape, access: { kind: "method", args } } as unknown as ValueExpression;
+}
+
+function mapOp(value: unknown, projection: ValueExpression, itemResultShape: Shape): ValueExpression {
+  return {
+    kind: "array-op", op: "map",
+    source: { kind: "literal", value, shape: rawShape } as ValueExpression,
+    projection, itemShape: rawShape, shape: { kind: "array", item: itemResultShape },
+  } as ValueExpression;
+}
+
+describe("per-element method calls (RuntimePath.call at the element scope)", () => {
+  it("calls an argless method on each element (Date.getDay via fn.apply)", () => {
+    const dates = [new Date(2026, 8, 14), new Date(2026, 8, 16)];
+    const node = mapOp(dates, elementMethod("", "getDay", numberShape), numberShape);
+    expect(evaluateValue(node, plan())).toEqual(dates.map(d => d.getDay()));
+  });
+
+  it("binds `this` to the element when calling a custom method", () => {
+    const items: any[] = [
+      { score: 7, double() { return this.score * 2; } },
+      { score: 3, double() { return this.score * 2; } },
+    ];
+    const node = mapOp(items, elementMethod("", "double", numberShape), numberShape);
+    expect(evaluateValue(node, plan())).toEqual([14, 6]);
+  });
+
+  it("passes a constant argument to the method", () => {
+    const items: any[] = [{ greeting: "hi", say(suffix: string) { return this.greeting + suffix; } }];
+    const node = mapOp(items, elementMethod("", "say", stringShape, [literal("!", stringShape)]), stringShape);
+    expect(evaluateValue(node, plan())).toEqual(["hi!"]);
+  });
+
+  it("passes an element-member read as a method argument", () => {
+    const items: any[] = [{ base: 10, bonus: 5, add(b: number) { return this.base + b; } }];
+    const node = mapOp(items, elementMethod("", "add", numberShape, [elementMember("bonus", numberShape)]), numberShape);
+    expect(evaluateValue(node, plan())).toEqual([15]);
+  });
+
+  it("calls a method on a nested owner, binding `this` to that owner", () => {
+    const items: any[] = [{ address: { city: "NYC", getCity() { return this.city; } } }];
+    const node = mapOp(items, elementMethod("address", "getCity", stringShape), stringShape);
+    expect(evaluateValue(node, plan())).toEqual(["NYC"]);
+  });
+
+  it("surfaces a boundary error when the named member is not a function", () => {
+    const items: any[] = [{ notAFn: 42 }];
+    const node = mapOp(items, elementMethod("", "notAFn", numberShape), numberShape);
+    expect(() => evaluateValue(node, plan())).toThrow(/not a function/);
+  });
+});

--- a/Alis.Reactive.Assets/runtime/__tests__/array/element-scope.test.ts
+++ b/Alis.Reactive.Assets/runtime/__tests__/array/element-scope.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { evaluateValue } from "../../core/evaluate";
+import { ExecutionContext } from "../../domain/execution-context";
+import type { PayloadSource, PlanDocument, ValueExpression } from "../../types";
+
+const elementSource: PayloadSource = {
+  kind: "payload",
+  scope: "element",
+  type: { kind: "untyped" },
+};
+
+function plan(): PlanDocument {
+  return {
+    version: 3,
+    planId: "Runtime.ArrayDsl.ElementScope",
+    scope: { kind: "root" },
+    types: {},
+    components: {},
+    behaviors: [],
+  };
+}
+
+describe("element scope", () => {
+  it("resolves the top of the element stack and stays immutable across pushes", () => {
+    const base = ExecutionContext.empty();
+    const outer = base.withElement({ id: "outer" });
+    const inner = outer.withElement({ id: "inner" });
+
+    expect(inner.resolvePayload(elementSource)).toEqual({ id: "inner" });
+    // Immutable: pushing inner did not mutate outer.
+    expect(outer.resolvePayload(elementSource)).toEqual({ id: "outer" });
+    // No element pushed yet -> undefined, not a throw.
+    expect(base.resolvePayload(elementSource)).toBeUndefined();
+  });
+
+  it("reads a member of the current object element", () => {
+    const read: ValueExpression = {
+      kind: "read",
+      from: elementSource,
+      member: "status",
+      path: [{ kind: "property", name: "status" }],
+      shape: { kind: "string" },
+      access: { kind: "property" },
+    };
+
+    const value = evaluateValue(read, plan(), {
+      element: [{ status: "active", age: 71 }],
+    });
+
+    expect(value).toBe("active");
+  });
+
+  it("reads the element itself (x => x) for a primitive element via the elementValue sentinel", () => {
+    const read: ValueExpression = {
+      kind: "read",
+      from: elementSource,
+      member: "elementValue",
+      path: [],
+      shape: { kind: "string" },
+      access: { kind: "property" },
+    };
+
+    expect(evaluateValue(read, plan(), { element: ["peanuts"] })).toBe("peanuts");
+  });
+
+  it("applies the declared shape to a primitive element read", () => {
+    const read: ValueExpression = {
+      kind: "read",
+      from: elementSource,
+      member: "elementValue",
+      path: [],
+      shape: { kind: "number" },
+      access: { kind: "property" },
+    };
+
+    expect(evaluateValue(read, plan(), { element: ["42"] })).toBe(42);
+  });
+});

--- a/Alis.Reactive.Assets/runtime/conditions/conditions.ts
+++ b/Alis.Reactive.Assets/runtime/conditions/conditions.ts
@@ -1,53 +1,22 @@
 // conditions.ts — V3 ConditionGraph evaluation.
-// Uses SHARED resolver for value resolution.
-// ConditionGraph is a discriminated union: compare, all, any, not, confirm.
-// ValidationCondition is the sync subset: compare, all, any, not.
+// The SYNC subset (compare/all/any/not) lives in ./sync-condition, a DI leaf that
+// receives the value-evaluator as a parameter (so it never imports core/evaluate). This
+// module keeps the public entry points and owns the async lane: confirm is the only term
+// that crosses to async, so full ConditionGraph evaluation may return a Promise.
 
 import type {
   ConditionGraph,
-  CompareCondition,
-  CollectionItemCompareCondition,
-  EqualityCompareOp,
-  EqualityCompareCondition,
-  MembershipCompareCondition,
-  MembershipCompareOp,
-  OrderedCompareOp,
-  OrderedCompareCondition,
   PlanDocument,
-  RangeCompareCondition,
-  RegexCompareCondition,
-  Shape,
-  TextLengthCompareCondition,
-  TextCompareOp,
-  TextCompareCondition,
-  UnaryCompareOp,
-  ValueExpression,
+  ExecContext,
   ValidationCondition,
 } from "../types";
-import type { ExecContext } from "../types";
 import { scope } from "../core/trace";
 import { assertNever } from "../core/assert-never";
-import { applyShape, toString } from "../core/shape-convert";
 import { evaluateValue } from "../core/evaluate";
 import { ExecutionContext } from "../domain/execution-context";
-import { RuntimeShape } from "../domain/runtime-shape";
+import { evaluateSyncCondition, evaluateCompare } from "./sync-condition";
 
 const log = scope("conditions");
-
-type TextOperand =
-  | { readonly kind: "text"; readonly value: string }
-  | { readonly kind: "missing" };
-
-interface ComparisonLeft {
-  readonly raw: unknown;
-  readonly shaped: unknown;
-}
-
-type OrderedConditionValue =
-  | { readonly kind: "number"; readonly value: number }
-  | { readonly kind: "text"; readonly value: string }
-  | { readonly kind: "boolean"; readonly value: boolean }
-  | { readonly kind: "missing" };
 
 interface AlisBrowserApi {
   readonly alis?: {
@@ -55,13 +24,9 @@ interface AlisBrowserApi {
   };
 }
 
-const missingText: TextOperand = { kind: "missing" };
-const missingOrderedConditionValue: OrderedConditionValue = { kind: "missing" };
-const noRightOperandTrace = { kind: "none" } as const;
-
-/** Sync condition evaluation for validation conditions. */
+/** Sync condition evaluation for validation conditions (compare/all/any/not). */
 export function evaluateCondition(condition: ValidationCondition, plan: PlanDocument, ctx?: ExecContext): boolean {
-  return evaluateConditionSync(condition, plan, ExecutionContext.from(ctx));
+  return evaluateSyncCondition(condition, plan, ExecutionContext.from(ctx), evaluateValue);
 }
 
 /** Current-lane condition evaluation. Crosses to async only when a reached term requires it. */
@@ -73,25 +38,6 @@ export function evaluateConditionInCurrentLane(
   return evaluateConditionInLane(condition, plan, ExecutionContext.from(ctx));
 }
 
-function evaluateConditionSync(
-  condition: ValidationCondition,
-  plan: PlanDocument,
-  context: ExecutionContext,
-): boolean {
-  switch (condition.kind) {
-    case "compare":
-      return evaluateCompare(condition, plan, context);
-    case "all":
-      return condition.terms.every(term => evaluateConditionSync(term, plan, context));
-    case "any":
-      return condition.terms.some(term => evaluateConditionSync(term, plan, context));
-    case "not":
-      return !evaluateConditionSync(condition.term, plan, context);
-    default:
-      return assertNever(condition, "condition kind");
-  }
-}
-
 function evaluateConditionInLane(
   condition: ConditionGraph,
   plan: PlanDocument,
@@ -99,7 +45,7 @@ function evaluateConditionInLane(
 ): boolean | Promise<boolean> {
   switch (condition.kind) {
     case "compare":
-      return evaluateCompare(condition, plan, context);
+      return evaluateCompare(condition, plan, context, evaluateValue);
     case "all":
       return evaluateAllInLane(condition.terms, plan, context, 0);
     case "any":
@@ -172,303 +118,4 @@ async function evaluateConfirmCondition(message: string): Promise<boolean> {
   const accepted = await confirmFn(message);
   log.debug("confirm.result", { accepted, message });
   return accepted;
-}
-
-// -- Compare evaluation --
-
-function evaluateCompare(condition: CompareCondition, plan: PlanDocument, context: ExecutionContext): boolean {
-  const left = resolveComparisonLeft(condition, plan, context);
-
-  switch (condition.op) {
-    case "is-null":
-    case "not-null":
-    case "is-empty":
-    case "not-empty":
-    case "truthy":
-    case "falsy":
-      traceCompare(condition, left, noRightOperandTrace);
-      return unaryMatches(condition.op, left);
-
-    case "eq":
-    case "neq": {
-      const right = resolveRightValue(condition, plan, context, condition.shape);
-      traceCompare(condition, left, right);
-      return equalityMatches(condition.op, left, right);
-    }
-
-    case "gt":
-    case "gte":
-    case "lt":
-    case "lte": {
-      const right = resolveRightValue(condition, plan, context, condition.shape);
-      traceCompare(condition, left, right);
-      return orderedComparisonMatches(condition.op, left.shaped, right);
-    }
-
-    case "in":
-    case "not-in": {
-      const right = resolveMembershipItems(condition, plan, context);
-      traceCompare(condition, left, right);
-      return membershipMatches(condition.op, left, right);
-    }
-
-    case "between": {
-      const [lower, upper] = resolveRangeBounds(condition, plan, context);
-      traceCompare(condition, left, [lower, upper]);
-      return inclusiveRangeContains(lower, upper, left.shaped);
-    }
-
-    case "array-contains": {
-      const right = resolveRightValue(condition, plan, context, condition.itemShape);
-      const items = shapeCollectionItems(left.shaped, condition.itemShape);
-      traceCompare(condition, left, right);
-      return items !== undefined && items.includes(right);
-    }
-
-    case "contains":
-      return evaluateTextComparison(condition.op, left, textOperand(condition), condition);
-
-    case "starts-with":
-      return evaluateTextComparison(condition.op, left, textOperand(condition), condition);
-
-    case "ends-with":
-      return evaluateTextComparison(condition.op, left, textOperand(condition), condition);
-
-    case "matches":
-      return evaluateRegexComparison(left, textOperand(condition), condition);
-
-    case "min-length":
-      return evaluateMinimumLengthComparison(left, minimumTextLength(condition), condition);
-
-    default:
-      return assertNever(condition, "compare condition");
-  }
-}
-
-function resolveComparisonLeft(condition: CompareCondition, plan: PlanDocument, context: ExecutionContext): ComparisonLeft {
-  const raw = evaluateValue(condition.left, plan, context.raw);
-  const shaped = applyShape(raw, condition.shape);
-  return { raw, shaped };
-}
-
-type ScalarRightCondition =
-  | EqualityCompareCondition
-  | OrderedCompareCondition
-  | CollectionItemCompareCondition;
-
-type TextRightCondition =
-  | TextCompareCondition
-  | RegexCompareCondition;
-
-function traceCompare(condition: CompareCondition, left: ComparisonLeft, right: unknown): void {
-  log.trace("compare", { op: condition.op, left: left.shaped, right });
-}
-
-function resolveRightValue(
-  condition: ScalarRightCondition,
-  plan: PlanDocument,
-  context: ExecutionContext,
-  shape: Shape,
-): unknown {
-  const raw = evaluateValue(condition.right.value, plan, context.raw);
-  return applyShape(raw, shape);
-}
-
-function resolveMembershipItems(
-  condition: MembershipCompareCondition,
-  plan: PlanDocument,
-  context: ExecutionContext,
-): unknown[] {
-  return condition.right.value.items.map(item =>
-    resolveShapedComparisonItem(item, plan, context, condition.shape));
-}
-
-function resolveRangeBounds(
-  condition: RangeCompareCondition,
-  plan: PlanDocument,
-  context: ExecutionContext,
-): [unknown, unknown] {
-  const [lower, upper] = condition.right.value.items;
-  return [
-    resolveShapedComparisonItem(lower, plan, context, condition.shape),
-    resolveShapedComparisonItem(upper, plan, context, condition.shape),
-  ];
-}
-
-function resolveShapedComparisonItem(
-  producer: ValueExpression,
-  plan: PlanDocument,
-  context: ExecutionContext,
-  shape: Shape,
-): unknown {
-  return applyShape(evaluateValue(producer, plan, context.raw), shape);
-}
-
-function textOperand(condition: TextRightCondition): string {
-  return condition.right.value.value;
-}
-
-function minimumTextLength(condition: TextLengthCompareCondition): number {
-  return condition.right.value.value;
-}
-
-function unaryMatches(op: UnaryCompareOp, left: ComparisonLeft): boolean {
-  switch (op) {
-    case "is-null":
-      return isMissingValue(left.raw);
-    case "not-null":
-      return !isMissingValue(left.raw);
-    case "is-empty":
-      return isEmpty(left.raw);
-    case "not-empty":
-      return !isEmpty(left.raw);
-    case "truthy":
-      return !!left.shaped;
-    case "falsy":
-      return !left.shaped;
-    default:
-      return assertNever(op, "unary comparison operator");
-  }
-}
-
-function equalityMatches(op: EqualityCompareOp, left: ComparisonLeft, right: unknown): boolean {
-  const valuesAreEqual = left.shaped === right;
-  if (op === "eq") return valuesAreEqual;
-
-  return !valuesAreEqual;
-}
-
-function membershipMatches(op: MembershipCompareOp, left: ComparisonLeft, values: readonly unknown[]): boolean {
-  const collectionContainsLeft = values.includes(left.shaped);
-  if (op === "in") return collectionContainsLeft;
-
-  return !collectionContainsLeft;
-}
-
-function shapeCollectionItems(value: unknown, itemShape: Shape): unknown[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-
-  return RuntimeShape.from(itemShape).applyEach(value);
-}
-
-function evaluateTextComparison(
-  op: TextCompareOp,
-  left: ComparisonLeft,
-  right: string,
-  condition: CompareCondition,
-): boolean {
-  traceCompare(condition, left, right);
-
-  switch (op) {
-    case "contains":
-      return textOp(left.shaped, right, (source, operand) => source.includes(operand));
-    case "starts-with":
-      return textOp(left.shaped, right, (source, operand) => source.startsWith(operand));
-    case "ends-with":
-      return textOp(left.shaped, right, (source, operand) => source.endsWith(operand));
-    default:
-      return assertNever(op, "text comparison operator");
-  }
-}
-
-function evaluateRegexComparison(left: ComparisonLeft, pattern: string, condition: CompareCondition): boolean {
-  traceCompare(condition, left, pattern);
-
-  const leftText = asText(left.shaped);
-  if (leftText.kind === "missing") return false;
-
-  return new RegExp(pattern).test(leftText.value);
-}
-
-function evaluateMinimumLengthComparison(left: ComparisonLeft, minimumLength: number, condition: CompareCondition): boolean {
-  traceCompare(condition, left, minimumLength);
-
-  const leftText = asText(left.shaped);
-  return leftText.kind === "text" && leftText.value.length >= minimumLength;
-}
-
-function orderedComparisonMatches(op: OrderedCompareOp, left: unknown, right: unknown): boolean {
-  const comparison = compareOrderedValues(left, right);
-  if (comparison === undefined) return false;
-
-  switch (op) {
-    case "gt":
-      return comparison > 0;
-    case "gte":
-      return comparison >= 0;
-    case "lt":
-      return comparison < 0;
-    case "lte":
-      return comparison <= 0;
-    default:
-      assertNever(op, "ordered comparison operator");
-  }
-}
-
-function inclusiveRangeContains(lower: unknown, upper: unknown, value: unknown): boolean {
-  const boundsCanBeOrdered = compareOrderedValues(lower, upper) !== undefined;
-  if (!boundsCanBeOrdered) return false;
-
-  const lowerComparison = compareOrderedValues(value, lower);
-  const upperComparison = compareOrderedValues(value, upper);
-  if (lowerComparison === undefined || upperComparison === undefined) return false;
-
-  return lowerComparison >= 0 && upperComparison <= 0;
-}
-
-function compareOrderedValues(left: unknown, right: unknown): number | undefined {
-  const leftValue = toOrderedConditionValue(left);
-  const rightValue = toOrderedConditionValue(right);
-
-  switch (leftValue.kind) {
-    case "number":
-      return rightValue.kind === "number" ? leftValue.value - rightValue.value : undefined;
-    case "text":
-      if (rightValue.kind !== "text") return undefined;
-      if (leftValue.value === rightValue.value) return 0;
-      return leftValue.value > rightValue.value ? 1 : -1;
-    case "boolean":
-      return rightValue.kind === "boolean"
-        ? booleanRank(leftValue.value) - booleanRank(rightValue.value)
-        : undefined;
-    case "missing":
-      return undefined;
-    default:
-      return assertNever(leftValue, "ordered condition value");
-  }
-}
-
-function toOrderedConditionValue(value: unknown): OrderedConditionValue {
-  if (typeof value === "number" && Number.isFinite(value)) return { kind: "number", value };
-  if (typeof value === "string") return { kind: "text", value };
-  if (typeof value === "boolean") return { kind: "boolean", value };
-
-  return missingOrderedConditionValue;
-}
-
-function booleanRank(value: boolean): number {
-  return value ? 1 : 0;
-}
-
-function textOp(left: unknown, right: string, predicate: (source: string, operand: string) => boolean): boolean {
-  const leftText = asText(left);
-  return leftText.kind === "text" && predicate(leftText.value, right);
-}
-
-function isEmpty(value: unknown): boolean {
-  const valueIsEmptyText = value === "";
-  const valueIsMissing = isMissingValue(value);
-  const valueIsEmptyCollection = Array.isArray(value) && value.length === 0;
-  return valueIsEmptyText || valueIsMissing || valueIsEmptyCollection;
-}
-
-function asText(value: unknown): TextOperand {
-  if (isMissingValue(value)) return missingText;
-  const result = toString(value);
-  if (result.ok) return { kind: "text", value: result.value };
-  return missingText;
-}
-
-function isMissingValue(value: unknown): boolean {
-  return value === null || value === undefined;
 }

--- a/Alis.Reactive.Assets/runtime/conditions/sync-condition.ts
+++ b/Alis.Reactive.Assets/runtime/conditions/sync-condition.ts
@@ -1,0 +1,393 @@
+// conditions/sync-condition.ts — pure SYNC condition evaluation (compare/all/any/not).
+//
+// Leaf module: it receives the value-evaluator by dependency injection (evalValue) and
+// imports NOTHING from core/evaluate. This breaks the would-be cycle
+// evaluate -> conditions -> evaluate (design §14.1): core/evaluate imports this leaf and
+// passes its own evaluator to evaluate per-element array-op predicates, while
+// conditions.ts delegates its sync subset here, passing evaluateValue. There is still one
+// value resolver — the injected evalValue is always evaluateValue.
+
+import type {
+  CompareCondition,
+  CollectionItemCompareCondition,
+  EqualityCompareOp,
+  EqualityCompareCondition,
+  MembershipCompareCondition,
+  MembershipCompareOp,
+  OrderedCompareOp,
+  OrderedCompareCondition,
+  PlanDocument,
+  RangeCompareCondition,
+  RegexCompareCondition,
+  Shape,
+  TextLengthCompareCondition,
+  TextCompareOp,
+  TextCompareCondition,
+  UnaryCompareOp,
+  ValueExpression,
+  ValidationCondition,
+  ExecContext,
+} from "../types";
+import { scope } from "../core/trace";
+import { assertNever } from "../core/assert-never";
+import { applyShape, toString } from "../core/shape-convert";
+import { ExecutionContext } from "../domain/execution-context";
+import { RuntimeShape } from "../domain/runtime-shape";
+
+const log = scope("conditions");
+
+/** Value resolver injected by the caller — always core/evaluate's evaluateValue. */
+export type ValueEvaluator = (expression: ValueExpression, plan: PlanDocument, ctx?: ExecContext) => unknown;
+
+type TextOperand =
+  | { readonly kind: "text"; readonly value: string }
+  | { readonly kind: "missing" };
+
+interface ComparisonLeft {
+  readonly raw: unknown;
+  readonly shaped: unknown;
+}
+
+type OrderedConditionValue =
+  | { readonly kind: "number"; readonly value: number }
+  | { readonly kind: "text"; readonly value: string }
+  | { readonly kind: "boolean"; readonly value: boolean }
+  | { readonly kind: "missing" };
+
+const missingText: TextOperand = { kind: "missing" };
+const missingOrderedConditionValue: OrderedConditionValue = { kind: "missing" };
+const noRightOperandTrace = { kind: "none" } as const;
+
+/** Evaluate the sync condition subset (compare/all/any/not). Confirm is not part of this subset. */
+export function evaluateSyncCondition(
+  condition: ValidationCondition,
+  plan: PlanDocument,
+  context: ExecutionContext,
+  evalValue: ValueEvaluator,
+): boolean {
+  switch (condition.kind) {
+    case "compare":
+      return evaluateCompare(condition, plan, context, evalValue);
+    case "all":
+      return condition.terms.every(term => evaluateSyncCondition(term, plan, context, evalValue));
+    case "any":
+      return condition.terms.some(term => evaluateSyncCondition(term, plan, context, evalValue));
+    case "not":
+      return !evaluateSyncCondition(condition.term, plan, context, evalValue);
+    default:
+      return assertNever(condition, "condition kind");
+  }
+}
+
+// -- Compare evaluation (always synchronous; shared by the async lane in conditions.ts) --
+
+export function evaluateCompare(
+  condition: CompareCondition,
+  plan: PlanDocument,
+  context: ExecutionContext,
+  evalValue: ValueEvaluator,
+): boolean {
+  const left = resolveComparisonLeft(condition, plan, context, evalValue);
+
+  switch (condition.op) {
+    case "is-null":
+    case "not-null":
+    case "is-empty":
+    case "not-empty":
+    case "truthy":
+    case "falsy":
+      traceCompare(condition, left, noRightOperandTrace);
+      return unaryMatches(condition.op, left);
+
+    case "eq":
+    case "neq": {
+      const right = resolveRightValue(condition, plan, context, condition.shape, evalValue);
+      traceCompare(condition, left, right);
+      return equalityMatches(condition.op, left, right);
+    }
+
+    case "gt":
+    case "gte":
+    case "lt":
+    case "lte": {
+      const right = resolveRightValue(condition, plan, context, condition.shape, evalValue);
+      traceCompare(condition, left, right);
+      return orderedComparisonMatches(condition.op, left.shaped, right);
+    }
+
+    case "in":
+    case "not-in": {
+      const right = resolveMembershipItems(condition, plan, context, evalValue);
+      traceCompare(condition, left, right);
+      return membershipMatches(condition.op, left, right);
+    }
+
+    case "between": {
+      const [lower, upper] = resolveRangeBounds(condition, plan, context, evalValue);
+      traceCompare(condition, left, [lower, upper]);
+      return inclusiveRangeContains(lower, upper, left.shaped);
+    }
+
+    case "array-contains": {
+      const right = resolveRightValue(condition, plan, context, condition.itemShape, evalValue);
+      const items = shapeCollectionItems(left.shaped, condition.itemShape);
+      traceCompare(condition, left, right);
+      return items !== undefined && items.includes(right);
+    }
+
+    case "contains":
+      return evaluateTextComparison(condition.op, left, textOperand(condition), condition);
+
+    case "starts-with":
+      return evaluateTextComparison(condition.op, left, textOperand(condition), condition);
+
+    case "ends-with":
+      return evaluateTextComparison(condition.op, left, textOperand(condition), condition);
+
+    case "matches":
+      return evaluateRegexComparison(left, textOperand(condition), condition);
+
+    case "min-length":
+      return evaluateMinimumLengthComparison(left, minimumTextLength(condition), condition);
+
+    default:
+      return assertNever(condition, "compare condition");
+  }
+}
+
+function resolveComparisonLeft(
+  condition: CompareCondition,
+  plan: PlanDocument,
+  context: ExecutionContext,
+  evalValue: ValueEvaluator,
+): ComparisonLeft {
+  const raw = evalValue(condition.left, plan, context.raw);
+  const shaped = applyShape(raw, condition.shape);
+  return { raw, shaped };
+}
+
+type ScalarRightCondition =
+  | EqualityCompareCondition
+  | OrderedCompareCondition
+  | CollectionItemCompareCondition;
+
+type TextRightCondition =
+  | TextCompareCondition
+  | RegexCompareCondition;
+
+function traceCompare(condition: CompareCondition, left: ComparisonLeft, right: unknown): void {
+  log.trace("compare", { op: condition.op, left: left.shaped, right });
+}
+
+function resolveRightValue(
+  condition: ScalarRightCondition,
+  plan: PlanDocument,
+  context: ExecutionContext,
+  shape: Shape,
+  evalValue: ValueEvaluator,
+): unknown {
+  const raw = evalValue(condition.right.value, plan, context.raw);
+  return applyShape(raw, shape);
+}
+
+function resolveMembershipItems(
+  condition: MembershipCompareCondition,
+  plan: PlanDocument,
+  context: ExecutionContext,
+  evalValue: ValueEvaluator,
+): unknown[] {
+  return condition.right.value.items.map(item =>
+    resolveShapedComparisonItem(item, plan, context, condition.shape, evalValue));
+}
+
+function resolveRangeBounds(
+  condition: RangeCompareCondition,
+  plan: PlanDocument,
+  context: ExecutionContext,
+  evalValue: ValueEvaluator,
+): [unknown, unknown] {
+  const [lower, upper] = condition.right.value.items;
+  return [
+    resolveShapedComparisonItem(lower, plan, context, condition.shape, evalValue),
+    resolveShapedComparisonItem(upper, plan, context, condition.shape, evalValue),
+  ];
+}
+
+function resolveShapedComparisonItem(
+  producer: ValueExpression,
+  plan: PlanDocument,
+  context: ExecutionContext,
+  shape: Shape,
+  evalValue: ValueEvaluator,
+): unknown {
+  return applyShape(evalValue(producer, plan, context.raw), shape);
+}
+
+function textOperand(condition: TextRightCondition): string {
+  return condition.right.value.value;
+}
+
+function minimumTextLength(condition: TextLengthCompareCondition): number {
+  return condition.right.value.value;
+}
+
+function unaryMatches(op: UnaryCompareOp, left: ComparisonLeft): boolean {
+  switch (op) {
+    case "is-null":
+      return isMissingValue(left.raw);
+    case "not-null":
+      return !isMissingValue(left.raw);
+    case "is-empty":
+      return isEmpty(left.raw);
+    case "not-empty":
+      return !isEmpty(left.raw);
+    case "truthy":
+      return !!left.shaped;
+    case "falsy":
+      return !left.shaped;
+    default:
+      return assertNever(op, "unary comparison operator");
+  }
+}
+
+function equalityMatches(op: EqualityCompareOp, left: ComparisonLeft, right: unknown): boolean {
+  const valuesAreEqual = left.shaped === right;
+  if (op === "eq") return valuesAreEqual;
+
+  return !valuesAreEqual;
+}
+
+function membershipMatches(op: MembershipCompareOp, left: ComparisonLeft, values: readonly unknown[]): boolean {
+  const collectionContainsLeft = values.includes(left.shaped);
+  if (op === "in") return collectionContainsLeft;
+
+  return !collectionContainsLeft;
+}
+
+function shapeCollectionItems(value: unknown, itemShape: Shape): unknown[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  return RuntimeShape.from(itemShape).applyEach(value);
+}
+
+function evaluateTextComparison(
+  op: TextCompareOp,
+  left: ComparisonLeft,
+  right: string,
+  condition: CompareCondition,
+): boolean {
+  traceCompare(condition, left, right);
+
+  switch (op) {
+    case "contains":
+      return textOp(left.shaped, right, (source, operand) => source.includes(operand));
+    case "starts-with":
+      return textOp(left.shaped, right, (source, operand) => source.startsWith(operand));
+    case "ends-with":
+      return textOp(left.shaped, right, (source, operand) => source.endsWith(operand));
+    default:
+      return assertNever(op, "text comparison operator");
+  }
+}
+
+function evaluateRegexComparison(left: ComparisonLeft, pattern: string, condition: CompareCondition): boolean {
+  traceCompare(condition, left, pattern);
+
+  const leftText = asText(left.shaped);
+  if (leftText.kind === "missing") return false;
+
+  return new RegExp(pattern).test(leftText.value);
+}
+
+function evaluateMinimumLengthComparison(left: ComparisonLeft, minimumLength: number, condition: CompareCondition): boolean {
+  traceCompare(condition, left, minimumLength);
+
+  const leftText = asText(left.shaped);
+  return leftText.kind === "text" && leftText.value.length >= minimumLength;
+}
+
+function orderedComparisonMatches(op: OrderedCompareOp, left: unknown, right: unknown): boolean {
+  const comparison = compareOrderedValues(left, right);
+  if (comparison === undefined) return false;
+
+  switch (op) {
+    case "gt":
+      return comparison > 0;
+    case "gte":
+      return comparison >= 0;
+    case "lt":
+      return comparison < 0;
+    case "lte":
+      return comparison <= 0;
+    default:
+      return assertNever(op, "ordered comparison operator");
+  }
+}
+
+function inclusiveRangeContains(lower: unknown, upper: unknown, value: unknown): boolean {
+  const boundsCanBeOrdered = compareOrderedValues(lower, upper) !== undefined;
+  if (!boundsCanBeOrdered) return false;
+
+  const lowerComparison = compareOrderedValues(value, lower);
+  const upperComparison = compareOrderedValues(value, upper);
+  if (lowerComparison === undefined || upperComparison === undefined) return false;
+
+  return lowerComparison >= 0 && upperComparison <= 0;
+}
+
+function compareOrderedValues(left: unknown, right: unknown): number | undefined {
+  const leftValue = toOrderedConditionValue(left);
+  const rightValue = toOrderedConditionValue(right);
+
+  switch (leftValue.kind) {
+    case "number":
+      return rightValue.kind === "number" ? leftValue.value - rightValue.value : undefined;
+    case "text":
+      if (rightValue.kind !== "text") return undefined;
+      if (leftValue.value === rightValue.value) return 0;
+      return leftValue.value > rightValue.value ? 1 : -1;
+    case "boolean":
+      return rightValue.kind === "boolean"
+        ? booleanRank(leftValue.value) - booleanRank(rightValue.value)
+        : undefined;
+    case "missing":
+      return undefined;
+    default:
+      return assertNever(leftValue, "ordered condition value");
+  }
+}
+
+function toOrderedConditionValue(value: unknown): OrderedConditionValue {
+  if (typeof value === "number" && Number.isFinite(value)) return { kind: "number", value };
+  if (typeof value === "string") return { kind: "text", value };
+  if (typeof value === "boolean") return { kind: "boolean", value };
+
+  return missingOrderedConditionValue;
+}
+
+function booleanRank(value: boolean): number {
+  return value ? 1 : 0;
+}
+
+function textOp(left: unknown, right: string, predicate: (source: string, operand: string) => boolean): boolean {
+  const leftText = asText(left);
+  return leftText.kind === "text" && predicate(leftText.value, right);
+}
+
+function isEmpty(value: unknown): boolean {
+  const valueIsEmptyText = value === "";
+  const valueIsMissing = isMissingValue(value);
+  const valueIsEmptyCollection = Array.isArray(value) && value.length === 0;
+  return valueIsEmptyText || valueIsMissing || valueIsEmptyCollection;
+}
+
+function asText(value: unknown): TextOperand {
+  if (isMissingValue(value)) return missingText;
+  const result = toString(value);
+  if (result.ok) return { kind: "text", value: result.value };
+  return missingText;
+}
+
+function isMissingValue(value: unknown): boolean {
+  return value === null || value === undefined;
+}

--- a/Alis.Reactive.Assets/runtime/core/evaluate.ts
+++ b/Alis.Reactive.Assets/runtime/core/evaluate.ts
@@ -6,7 +6,7 @@ import type {
   PlanDocument, ValueExpression, ExecContext, ReadExpression, RuntimeObjectSource,
   ObjectPropertyReadExpression, ObjectMethodReadExpression,
   UrlParameterReadExpression, PayloadPathReadExpression, WholePayloadReadExpression,
-  WholeElementReadExpression,
+  WholeElementReadExpression, ArrayOperationExpression,
 } from "../types";
 import { RuntimePlan } from "../domain/runtime-plan";
 import { applyShape } from "./shape-convert";
@@ -50,6 +50,9 @@ class ValueEvaluation {
         return RuntimeValue
           .declared(expression.items.map(item => this.evaluate(item)), expression.shape)
           .usingDeclaredShape();
+
+      case "array-op":
+        return this.evaluateArrayOp(expression);
 
       default:
         assertNever(expression, "value expression kind");
@@ -101,6 +104,34 @@ class ValueEvaluation {
     }
     return result;
   }
+
+  private evaluateArrayOp(expression: ArrayOperationExpression): unknown {
+    const items = normalizeToArray(this.evaluate(expression.source), expression.op);
+    switch (expression.op) {
+      case "count":
+        return items.length;
+      default:
+        return assertNever(expression.op, "array-op kind");
+    }
+  }
+}
+
+/**
+ * Normalize an array-op source to a JS array at the input boundary.
+ * Browser/EJ2 JS APIs return an underdetermined union (Array | array-like | iterable
+ * | scalar | null) that the C# T[] type cannot constrain at authoring time. This is an
+ * external-boundary normalization — the same category as getElementById returning null —
+ * not a plan validator or fallback. DOMStringMap (dataset) has no Symbol.iterator and
+ * fails fast at the throw, keeping it in the plugin escape hatch's domain.
+ */
+function normalizeToArray(value: unknown, label: string): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value === null || value === undefined) return [];
+  if (typeof value === "number" || typeof value === "string") return [value];
+  if (typeof value === "object" && Symbol.iterator in (value as object)) {
+    return Array.from(value as Iterable<unknown>);
+  }
+  throw new Error(`[alis] array-op source is not iterable: ${label} (got ${typeof value})`);
 }
 
 function isObjectRead(expression: ReadExpression): expression is ObjectReadExpression {

--- a/Alis.Reactive.Assets/runtime/core/evaluate.ts
+++ b/Alis.Reactive.Assets/runtime/core/evaluate.ts
@@ -114,9 +114,9 @@ class ValueEvaluation {
     const items = normalizeToArray(this.evaluate(expression.source), expression.op);
     switch (expression.op) {
       case "count":
-        return expression.predicate === undefined
-          ? items.length
-          : items.filter(item => this.elementMatches(expression.predicate, item)).length;
+        // Count is unconditional length; Count(predicate) compiles to filter -> count (ReactiveArray.cs),
+        // so the count node never carries a predicate.
+        return items.length;
       case "filter":
         return this.shapedArray(items.filter(item => this.elementMatches(expression.predicate, item)), expression);
       case "map":
@@ -142,9 +142,10 @@ class ValueEvaluation {
   }
 
   private findElement(expression: ArrayOperationExpression, items: unknown[]): unknown {
-    const found = expression.predicate === undefined
-      ? items[0]
-      : items.find(item => this.elementMatches(expression.predicate, item));
+    if (expression.predicate === undefined) {
+      throw new Error("[alis] array-op 'find' requires a predicate");
+    }
+    const found = items.find(item => this.elementMatches(expression.predicate, item));
     if (found === undefined) return null;
     return expression.projection === undefined ? found : this.project(expression.projection, found);
   }
@@ -210,7 +211,15 @@ function toNumber(value: unknown): number {
 
 /** Deterministic ordering of sort keys: numeric when both numbers, else lexicographic. */
 function compareKeys(a: unknown, b: unknown): number {
-  if (typeof a === "number" && typeof b === "number") return a - b;
+  if (typeof a === "number" && typeof b === "number") {
+    const aFinite = Number.isFinite(a);
+    const bFinite = Number.isFinite(b);
+    if (aFinite && bFinite) return a - b;
+    // Non-finite keys (NaN/Infinity from a missing or non-numeric field) sort last,
+    // deterministically — never feed NaN to Array.sort (engine-defined behavior).
+    if (aFinite === bFinite) return 0;
+    return aFinite ? -1 : 1;
+  }
   const left = String(a);
   const right = String(b);
   return left < right ? -1 : left > right ? 1 : 0;

--- a/Alis.Reactive.Assets/runtime/core/evaluate.ts
+++ b/Alis.Reactive.Assets/runtime/core/evaluate.ts
@@ -15,6 +15,7 @@ import { RuntimeValue, applyShapeWhenPresent } from "../domain/runtime-value";
 import { RuntimePath } from "../domain/runtime-path";
 import { ExecutionContext } from "../domain/execution-context";
 import { RuntimeObject } from "../domain/runtime-object";
+import { evaluateSyncCondition } from "../conditions/sync-condition";
 
 type ObjectReadExpression = ObjectPropertyReadExpression | ObjectMethodReadExpression;
 type PayloadReadExpression = PayloadPathReadExpression | WholePayloadReadExpression | WholeElementReadExpression;
@@ -25,12 +26,13 @@ export function evaluateValue(expression: ValueExpression, plan: PlanDocument, c
 
 class ValueEvaluation {
   private constructor(
+    private readonly document: PlanDocument,
     private readonly plan: RuntimePlan,
     private readonly context: ExecutionContext,
   ) {}
 
   static from(plan: PlanDocument, ctx?: ExecContext): ValueEvaluation {
-    return new ValueEvaluation(RuntimePlan.from(plan), ExecutionContext.from(ctx));
+    return new ValueEvaluation(plan, RuntimePlan.from(plan), ExecutionContext.from(ctx));
   }
 
   evaluate(expression: ValueExpression): unknown {
@@ -110,9 +112,21 @@ class ValueEvaluation {
     switch (expression.op) {
       case "count":
         return items.length;
+      case "filter": {
+        const matches = items.filter(item => this.elementMatches(expression.predicate, item));
+        return RuntimeValue.declared(matches, expression.shape).usingDeclaredShape();
+      }
       default:
         return assertNever(expression.op, "array-op kind");
     }
+  }
+
+  /** Evaluate a per-element predicate against the element scope (immediate lane, sync subset). */
+  private elementMatches(predicate: ArrayOperationExpression["predicate"], item: unknown): boolean {
+    if (predicate === undefined) {
+      throw new Error("[alis] array-op predicate is required for this operation");
+    }
+    return evaluateSyncCondition(predicate, this.document, this.context.withElement(item), evaluateValue);
   }
 }
 

--- a/Alis.Reactive.Assets/runtime/core/evaluate.ts
+++ b/Alis.Reactive.Assets/runtime/core/evaluate.ts
@@ -6,7 +6,7 @@ import type {
   PlanDocument, ValueExpression, ExecContext, ReadExpression, RuntimeObjectSource,
   ObjectPropertyReadExpression, ObjectMethodReadExpression,
   UrlParameterReadExpression, PayloadPathReadExpression, WholePayloadReadExpression,
-  WholeElementReadExpression, ArrayOperationExpression,
+  WholeElementReadExpression, ArrayOperationExpression, DomPropertyReadExpression,
 } from "../types";
 import { RuntimePlan } from "../domain/runtime-plan";
 import { applyShape } from "./shape-convert";
@@ -70,6 +70,9 @@ class ValueEvaluation {
     }
     if (isPayloadRead(expression)) {
       return readFromPayload(expression, this.context.resolvePayload(expression.from));
+    }
+    if (isDomRead(expression)) {
+      return readFromDom(expression);
     }
 
     return assertNever(expression, "read expression");
@@ -223,6 +226,20 @@ function isUrlRead(expression: ReadExpression): expression is UrlParameterReadEx
 
 function isPayloadRead(expression: ReadExpression): expression is PayloadReadExpression {
   return expression.from.kind === "payload";
+}
+
+function isDomRead(expression: ReadExpression): expression is DomPropertyReadExpression {
+  return expression.from.kind === "dom";
+}
+
+/** Read a member off a DOM element resolved by id — same RuntimePath primitive, no contract. */
+function readFromDom(expression: DomPropertyReadExpression): unknown {
+  const element = document.getElementById(expression.from.element);
+  if (element === null) {
+    throw new Error(`[alis] dom source element "${expression.from.element}" not found`);
+  }
+  const raw = RuntimePath.from(expression.path).read(element);
+  return applyShapeWhenPresent(raw, expression.shape);
 }
 
 /** Read a query parameter from URL source. */

--- a/Alis.Reactive.Assets/runtime/core/evaluate.ts
+++ b/Alis.Reactive.Assets/runtime/core/evaluate.ts
@@ -7,6 +7,7 @@ import type {
   ObjectPropertyReadExpression, ObjectMethodReadExpression,
   UrlParameterReadExpression, PayloadPathReadExpression, WholePayloadReadExpression,
   WholeElementReadExpression, ArrayOperationExpression, DomPropertyReadExpression,
+  ElementMethodReadExpression,
 } from "../types";
 import { RuntimePlan } from "../domain/runtime-plan";
 import { applyShape } from "./shape-convert";
@@ -18,7 +19,7 @@ import { RuntimeObject } from "../domain/runtime-object";
 import { evaluateSyncCondition } from "../conditions/sync-condition";
 
 type ObjectReadExpression = ObjectPropertyReadExpression | ObjectMethodReadExpression;
-type PayloadReadExpression = PayloadPathReadExpression | WholePayloadReadExpression | WholeElementReadExpression;
+type PayloadReadExpression = PayloadPathReadExpression | WholePayloadReadExpression | WholeElementReadExpression | ElementMethodReadExpression;
 
 export function evaluateValue(expression: ValueExpression, plan: PlanDocument, ctx?: ExecContext): unknown {
   return ValueEvaluation.from(plan, ctx).evaluate(expression);
@@ -69,6 +70,9 @@ class ValueEvaluation {
       return readFromUrl(expression, this.plan.urlParameters());
     }
     if (isPayloadRead(expression)) {
+      if (isElementMethodRead(expression)) {
+        return this.readElementMethod(expression);
+      }
       return readFromPayload(expression, this.context.resolvePayload(expression.from));
     }
     if (isDomRead(expression)) {
@@ -100,6 +104,19 @@ class ValueEvaluation {
       default:
         assertNever(expression.access, "value read access");
     }
+  }
+
+  /**
+   * Invoke a method on the current element (element scope) — the same RuntimePath.call engine
+   * (fn.apply(owner, args)) that component/plugin method reads use. Args are full value
+   * expressions evaluated in the current element context. A non-function member is a true
+   * external-boundary error, surfaced by RuntimePath.call.
+   */
+  private readElementMethod(expression: ElementMethodReadExpression): unknown {
+    const root = this.context.resolvePayload(expression.from);
+    const args = expression.access.args.map(arg => this.evaluate(arg));
+    const raw = RuntimePath.from(expression.path).call(root, args, `element method "${expression.member}"`);
+    return applyShapeWhenPresent(raw, expression.shape);
   }
 
   private evaluateObject(fields: Record<string, ValueExpression>): Record<string, unknown> {
@@ -235,6 +252,10 @@ function isUrlRead(expression: ReadExpression): expression is UrlParameterReadEx
 
 function isPayloadRead(expression: ReadExpression): expression is PayloadReadExpression {
   return expression.from.kind === "payload";
+}
+
+function isElementMethodRead(expression: PayloadReadExpression): expression is ElementMethodReadExpression {
+  return expression.access.kind === "method";
 }
 
 function isDomRead(expression: ReadExpression): expression is DomPropertyReadExpression {

--- a/Alis.Reactive.Assets/runtime/core/evaluate.ts
+++ b/Alis.Reactive.Assets/runtime/core/evaluate.ts
@@ -111,14 +111,50 @@ class ValueEvaluation {
     const items = normalizeToArray(this.evaluate(expression.source), expression.op);
     switch (expression.op) {
       case "count":
-        return items.length;
-      case "filter": {
-        const matches = items.filter(item => this.elementMatches(expression.predicate, item));
-        return RuntimeValue.declared(matches, expression.shape).usingDeclaredShape();
-      }
+        return expression.predicate === undefined
+          ? items.length
+          : items.filter(item => this.elementMatches(expression.predicate, item)).length;
+      case "filter":
+        return this.shapedArray(items.filter(item => this.elementMatches(expression.predicate, item)), expression);
+      case "map":
+        return this.shapedArray(items.map(item => this.project(expression.projection, item)), expression);
+      case "sum":
+        return items.reduce<number>(
+          (total, item) => total + toNumber(this.projectedOrSelf(expression.projection, item)), 0);
+      case "any":
+        return expression.predicate === undefined
+          ? items.length > 0
+          : items.some(item => this.elementMatches(expression.predicate, item));
+      case "all":
+        return items.every(item => this.elementMatches(expression.predicate, item));
+      case "find":
+        return this.findElement(expression, items);
+      case "orderBy":
+        return this.shapedArray(this.ordered(items, expression.projection, false), expression);
+      case "orderByDescending":
+        return this.shapedArray(this.ordered(items, expression.projection, true), expression);
       default:
         return assertNever(expression.op, "array-op kind");
     }
+  }
+
+  private findElement(expression: ArrayOperationExpression, items: unknown[]): unknown {
+    const found = expression.predicate === undefined
+      ? items[0]
+      : items.find(item => this.elementMatches(expression.predicate, item));
+    if (found === undefined) return null;
+    return expression.projection === undefined ? found : this.project(expression.projection, found);
+  }
+
+  private ordered(items: unknown[], key: ArrayOperationExpression["projection"], descending: boolean): unknown[] {
+    if (key === undefined) throw new Error("[alis] array-op orderBy requires a key projection");
+    const decorated = items.map(item => ({ item, sortKey: this.inElement(item).evaluate(key) }));
+    decorated.sort((a, b) => compareKeys(a.sortKey, b.sortKey) * (descending ? -1 : 1));
+    return decorated.map(entry => entry.item);
+  }
+
+  private shapedArray(result: unknown[], expression: ArrayOperationExpression): unknown {
+    return RuntimeValue.declared(result, expression.shape).usingDeclaredShape();
   }
 
   /** Evaluate a per-element predicate against the element scope (immediate lane, sync subset). */
@@ -127,6 +163,21 @@ class ValueEvaluation {
       throw new Error("[alis] array-op predicate is required for this operation");
     }
     return evaluateSyncCondition(predicate, this.document, this.context.withElement(item), evaluateValue);
+  }
+
+  private project(projection: ArrayOperationExpression["projection"], item: unknown): unknown {
+    if (projection === undefined) {
+      throw new Error("[alis] array-op projection is required for this operation");
+    }
+    return this.inElement(item).evaluate(projection);
+  }
+
+  private projectedOrSelf(projection: ArrayOperationExpression["projection"], item: unknown): unknown {
+    return projection === undefined ? item : this.inElement(item).evaluate(projection);
+  }
+
+  private inElement(item: unknown): ValueEvaluation {
+    return new ValueEvaluation(this.document, this.plan, this.context.withElement(item));
   }
 }
 
@@ -146,6 +197,20 @@ function normalizeToArray(value: unknown, label: string): unknown[] {
     return Array.from(value as Iterable<unknown>);
   }
   throw new Error(`[alis] array-op source is not iterable: ${label} (got ${typeof value})`);
+}
+
+/** Coerce a projected value to a number for sum; non-finite contributes 0. */
+function toNumber(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Deterministic ordering of sort keys: numeric when both numbers, else lexicographic. */
+function compareKeys(a: unknown, b: unknown): number {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  const left = String(a);
+  const right = String(b);
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function isObjectRead(expression: ReadExpression): expression is ObjectReadExpression {

--- a/Alis.Reactive.Assets/runtime/core/evaluate.ts
+++ b/Alis.Reactive.Assets/runtime/core/evaluate.ts
@@ -6,6 +6,7 @@ import type {
   PlanDocument, ValueExpression, ExecContext, ReadExpression, RuntimeObjectSource,
   ObjectPropertyReadExpression, ObjectMethodReadExpression,
   UrlParameterReadExpression, PayloadPathReadExpression, WholePayloadReadExpression,
+  WholeElementReadExpression,
 } from "../types";
 import { RuntimePlan } from "../domain/runtime-plan";
 import { applyShape } from "./shape-convert";
@@ -16,7 +17,7 @@ import { ExecutionContext } from "../domain/execution-context";
 import { RuntimeObject } from "../domain/runtime-object";
 
 type ObjectReadExpression = ObjectPropertyReadExpression | ObjectMethodReadExpression;
-type PayloadReadExpression = PayloadPathReadExpression | WholePayloadReadExpression;
+type PayloadReadExpression = PayloadPathReadExpression | WholePayloadReadExpression | WholeElementReadExpression;
 
 export function evaluateValue(expression: ValueExpression, plan: PlanDocument, ctx?: ExecContext): unknown {
   return ValueEvaluation.from(plan, ctx).evaluate(expression);
@@ -126,7 +127,7 @@ function readFromUrl(
 function readFromPayload(
   expression: PayloadReadExpression, root: unknown,
 ): unknown {
-  const raw = readsWholePayload(expression)
+  const raw = readsWholePayload(expression) || readsWholeElement(expression)
     ? root
     : RuntimePath.from(expression.path).read(root);
 
@@ -135,4 +136,8 @@ function readFromPayload(
 
 function readsWholePayload(expression: PayloadReadExpression): expression is WholePayloadReadExpression {
   return expression.member === "responseBody";
+}
+
+function readsWholeElement(expression: PayloadReadExpression): expression is WholeElementReadExpression {
+  return expression.member === "elementValue";
 }

--- a/Alis.Reactive.Assets/runtime/domain/execution-context.ts
+++ b/Alis.Reactive.Assets/runtime/domain/execution-context.ts
@@ -44,6 +44,12 @@ export class ExecutionContext {
     return new ExecutionContext({ ...this.asAvailable(), response });
   }
 
+  /** Push an array element onto the element scope stack for per-element evaluation. */
+  withElement(item: unknown): ExecutionContext {
+    const current = this.asAvailable();
+    return new ExecutionContext({ ...current, element: [...(current.element ?? []), item] });
+  }
+
   resolvePayload(source: PayloadSource): unknown {
     const values = this.requireValues(source);
     switch (source.scope) {
@@ -57,6 +63,10 @@ export class ExecutionContext {
         return values.request;
       case "local":
         return values.local;
+      case "element": {
+        const stack = values.element;
+        return stack === undefined ? undefined : stack[stack.length - 1];
+      }
       default: {
         const _: never = source.scope;
         throw new Error(`[alis] unknown payload scope: "${_}"`);

--- a/Alis.Reactive.Assets/runtime/types/context.ts
+++ b/Alis.Reactive.Assets/runtime/types/context.ts
@@ -23,4 +23,10 @@ export interface ExecContext {
    * Resolved by PayloadSource with scope "local". Not currently used.
    */
   readonly local?: Record<string, unknown>;
+  /**
+   * Element scope stack for array operations — the innermost (top) entry is the
+   * current element under iteration. Grown by ExecutionContext.withElement(item).
+   * Resolved by PayloadSource with scope "element" (reads top of stack).
+   */
+  readonly element?: readonly unknown[];
 }

--- a/Alis.Reactive.Assets/runtime/types/plan.ts
+++ b/Alis.Reactive.Assets/runtime/types/plan.ts
@@ -816,12 +816,14 @@ export interface ArrayExpression {
 }
 
 export type ArrayOp =
-  | "count";
+  | "count"
+  | "filter";
 
 export interface ArrayOperationExpression {
   kind: "array-op";
   op: ArrayOp;
   source: ValueExpression;
+  predicate?: ValidationCondition;
   itemShape: Shape;
   shape: Shape;
 }

--- a/Alis.Reactive.Assets/runtime/types/plan.ts
+++ b/Alis.Reactive.Assets/runtime/types/plan.ts
@@ -361,7 +361,8 @@ export type Source =
   | ComponentSource
   | PayloadSource
   | UrlSource
-  | PluginSource;
+  | PluginSource
+  | DomSource;
 
 export type RuntimeObjectSource =
   | ComponentSource
@@ -383,6 +384,11 @@ export interface ComponentSource {
 
 export interface UrlSource {
   kind: "url";
+}
+
+export interface DomSource {
+  kind: "dom";
+  element: string;
 }
 
 export interface PluginSource {
@@ -710,7 +716,8 @@ export type ReadExpression =
   | UrlParameterReadExpression
   | PayloadPathReadExpression
   | WholePayloadReadExpression
-  | WholeElementReadExpression;
+  | WholeElementReadExpression
+  | DomPropertyReadExpression;
 
 export interface LiteralExpression {
   kind: "literal";
@@ -786,6 +793,15 @@ export interface WholeElementReadExpression {
   from: PayloadSource;
   member: "elementValue";
   path: EmptyPath;
+  shape: Shape;
+  access: PropertyValueReadAccess;
+}
+
+export interface DomPropertyReadExpression {
+  kind: "read";
+  from: DomSource;
+  member: string;
+  path: StructuredPath;
   shape: Shape;
   access: PropertyValueReadAccess;
 }

--- a/Alis.Reactive.Assets/runtime/types/plan.ts
+++ b/Alis.Reactive.Assets/runtime/types/plan.ts
@@ -717,7 +717,8 @@ export type ReadExpression =
   | PayloadPathReadExpression
   | WholePayloadReadExpression
   | WholeElementReadExpression
-  | DomPropertyReadExpression;
+  | DomPropertyReadExpression
+  | ElementMethodReadExpression;
 
 export interface LiteralExpression {
   kind: "literal";
@@ -804,6 +805,15 @@ export interface DomPropertyReadExpression {
   path: StructuredPath;
   shape: Shape;
   access: PropertyValueReadAccess;
+}
+
+export interface ElementMethodReadExpression {
+  kind: "read";
+  from: PayloadSource;
+  member: string;
+  path: StructuredPath;
+  shape: Shape;
+  access: MethodValueReadAccess;
 }
 
 export type ValueReadAccess =

--- a/Alis.Reactive.Assets/runtime/types/plan.ts
+++ b/Alis.Reactive.Assets/runtime/types/plan.ts
@@ -817,13 +817,21 @@ export interface ArrayExpression {
 
 export type ArrayOp =
   | "count"
-  | "filter";
+  | "filter"
+  | "map"
+  | "sum"
+  | "any"
+  | "all"
+  | "find"
+  | "orderBy"
+  | "orderByDescending";
 
 export interface ArrayOperationExpression {
   kind: "array-op";
   op: ArrayOp;
   source: ValueExpression;
   predicate?: ValidationCondition;
+  projection?: ValueExpression;
   itemShape: Shape;
   shape: Shape;
 }

--- a/Alis.Reactive.Assets/runtime/types/plan.ts
+++ b/Alis.Reactive.Assets/runtime/types/plan.ts
@@ -701,7 +701,8 @@ export type ValueExpression =
   | LiteralExpression
   | ReadExpression
   | ObjectExpression
-  | ArrayExpression;
+  | ArrayExpression
+  | ArrayOperationExpression;
 
 export type ReadExpression =
   | ObjectPropertyReadExpression
@@ -811,6 +812,17 @@ export interface ObjectExpression {
 export interface ArrayExpression {
   kind: "array";
   items: ValueExpression[];
+  shape: Shape;
+}
+
+export type ArrayOp =
+  | "count";
+
+export interface ArrayOperationExpression {
+  kind: "array-op";
+  op: ArrayOp;
+  source: ValueExpression;
+  itemShape: Shape;
   shape: Shape;
 }
 

--- a/Alis.Reactive.Assets/runtime/types/plan.ts
+++ b/Alis.Reactive.Assets/runtime/types/plan.ts
@@ -397,7 +397,8 @@ export type PayloadScope =
   | "error"
   | "request"
   | "dispatch"
-  | "local";
+  | "local"
+  | "element";
 
 export interface PayloadSource {
   kind: "payload";
@@ -707,7 +708,8 @@ export type ReadExpression =
   | ObjectMethodReadExpression
   | UrlParameterReadExpression
   | PayloadPathReadExpression
-  | WholePayloadReadExpression;
+  | WholePayloadReadExpression
+  | WholeElementReadExpression;
 
 export interface LiteralExpression {
   kind: "literal";
@@ -773,6 +775,15 @@ export interface WholePayloadReadExpression {
   kind: "read";
   from: PayloadSource;
   member: "responseBody";
+  path: EmptyPath;
+  shape: Shape;
+  access: PropertyValueReadAccess;
+}
+
+export interface WholeElementReadExpression {
+  kind: "read";
+  from: PayloadSource;
+  member: "elementValue";
   path: EmptyPath;
   shape: Shape;
   access: PropertyValueReadAccess;

--- a/Alis.Reactive.Fusion/Components/FusionAutoComplete/FusionAutoCompleteExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionAutoComplete/FusionAutoCompleteExtensions.cs
@@ -91,6 +91,21 @@ namespace Alis.Reactive.Fusion.Components
         }
 
         /// <summary>
+        /// Replaces the data source with a typed array source — including a client-side
+        /// <see cref="Alis.Reactive.Builders.Arrays.ReactiveArray{T}"/> transform via <c>AsSource()</c>.
+        /// Routes any array value into the suggestion list with no HTTP round-trip.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TElement">The item element type carried by the source.</typeparam>
+        /// <param name="source">The typed array source.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionAutoComplete, TModel> SetDataSource<TModel, TElement>(
+            this ComponentRef<FusionAutoComplete, TModel> self,
+            TypedSource<TElement[]> source)
+            where TModel : class
+            => self.EmitSet(DataSourceProperty, source.ToValueExpression());
+
+        /// <summary>
         /// Flushes pending property changes to the component in the browser.
         /// </summary>
         /// <remarks>

--- a/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipItem.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionChipItem.cs
@@ -1,0 +1,17 @@
+namespace Alis.Reactive.Fusion.Components
+{
+    /// <summary>
+    /// A selected chip's bound data, as returned in <c>getSelectedChips().data</c> (proven in
+    /// <c>@syncfusion/ej2-buttons</c> <c>chip-list.js</c>: <c>selectedItems.data.push(this.chips[index])</c>).
+    /// Each element is the chip model the developer bound, so the array DSL can operate on the
+    /// selection by member — e.g. <c>p.From(payload, x =&gt; x.Selection.Data).Where(c =&gt; c.Value == "memory")</c>.
+    /// </summary>
+    public sealed class FusionChipItem
+    {
+        /// <summary>The chip's display text (<c>data[i].text</c>).</summary>
+        public string Text { get; set; } = "";
+
+        /// <summary>The chip's bound value (<c>data[i].value</c>).</summary>
+        public string Value { get; set; } = "";
+    }
+}

--- a/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionSelectedChips.cs
+++ b/Alis.Reactive.Fusion/Components/FusionChipList/Events/FusionSelectedChips.cs
@@ -1,8 +1,30 @@
+using System;
+
 namespace Alis.Reactive.Fusion.Components
 {
+    /// <summary>
+    /// The result of <c>ChipList.getSelectedChips()</c> for a multiple-selection chip list. Mirrors
+    /// the shipped shape <c>{ texts, Indexes, data, elements }</c> (chip-list.js). <see cref="Data"/>
+    /// carries the selected chip objects, so the array DSL can filter/aggregate the selection by
+    /// member; <see cref="Texts"/> carries the selected display strings.
+    /// </summary>
     public sealed class FusionSelectedChips
     {
-        public string[] Texts { get; set; } = System.Array.Empty<string>();
-        public int[] Indexes { get; set; } = System.Array.Empty<int>();
+        /// <summary>The selected chips' display text (<c>texts</c>).</summary>
+        public string[] Texts { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// The selected chips' bound data objects (<c>data</c>) — the array DSL source for
+        /// operating on the selection by member (text/value).
+        /// </summary>
+        public FusionChipItem[] Data { get; set; } = Array.Empty<FusionChipItem>();
+
+        /// <summary>
+        /// The selected chips' indexes. NOTE: Syncfusion emits this key as <c>Indexes</c> (capital I,
+        /// chip-list.js), so the camelCased read path resolves to empty. Reading the selected indexes
+        /// requires a read-path name override (a framework capability, recorded as follow-up). Use
+        /// <see cref="Data"/>/<see cref="Texts"/> until then.
+        /// </summary>
+        public int[] Indexes { get; set; } = Array.Empty<int>();
     }
 }

--- a/Alis.Reactive.Fusion/Components/FusionDropDownList/FusionDropDownListExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionDropDownList/FusionDropDownListExtensions.cs
@@ -87,6 +87,21 @@ namespace Alis.Reactive.Fusion.Components
             return self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, sourcePath));
         }
 
+        /// <summary>
+        /// Replaces the data source with a typed array source — including a client-side
+        /// <see cref="Alis.Reactive.Builders.Arrays.ReactiveArray{T}"/> transform via <c>AsSource()</c>.
+        /// Routes any array value into the option list with no HTTP round-trip.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TElement">The item element type carried by the source.</typeparam>
+        /// <param name="source">The typed array source.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionDropDownList, TModel> SetDataSource<TModel, TElement>(
+            this ComponentRef<FusionDropDownList, TModel> self,
+            TypedSource<TElement[]> source)
+            where TModel : class
+            => self.EmitSet(DataSourceProperty, source.ToValueExpression());
+
         /// <summary>Flushes pending property changes to the component in the browser.</summary>
         /// <remarks>
         /// Call after <see cref="SetDataSource{TModel,TSource}"/> or

--- a/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionGrid/FusionGridExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
 using Alis.Reactive.PlanModel;
 
 namespace Alis.Reactive.Fusion.Components
@@ -78,6 +79,39 @@ namespace Alis.Reactive.Fusion.Components
             var sourcePath = ExpressionPathHelper.ToEventPath(path);
             return self.EmitSet(DataSourceProperty, ValueExpression.Read(PayloadSource.Event(), sourcePath));
         }
+
+        /// <summary>
+        /// Replaces the grid data source with a typed array source — including a client-side
+        /// <see cref="Alis.Reactive.Builders.Arrays.ReactiveArray{T}"/> transform exposed via
+        /// <c>AsSource()</c>. Routes any array value (component member, plugin, event payload,
+        /// or a filtered/sorted array) into the grid's data source with no HTTP round-trip.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TElement">The row element type carried by the source.</typeparam>
+        /// <param name="self">The grid component reference.</param>
+        /// <param name="source">The typed array source.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionGrid, TModel> SetDataSource<TModel, TElement>(
+            this ComponentRef<FusionGrid, TModel> self,
+            TypedSource<TElement[]> source)
+            where TModel : class
+            => self.EmitSet(DataSourceProperty, source.ToValueExpression());
+
+        /// <summary>
+        /// Reads the grid's current rows as a typed array source — the read counterpart of the
+        /// typed-array <c>SetDataSource</c> overload. Feed it to <c>p.From(...)</c> to
+        /// filter/sort/aggregate the rows already on screen, then rebind, without re-fetching
+        /// from the server.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TRow">The row element type.</typeparam>
+        /// <param name="self">The grid component reference.</param>
+        /// <returns>A typed source over the grid's current data.</returns>
+        public static TypedComponentSource<TRow[]> Data<TModel, TRow>(
+            this ComponentRef<FusionGrid, TModel> self)
+            where TModel : class
+            where TRow : class
+            => self.Read(ComponentProperty<TRow[]>.Named("dataSource"));
 
         /// <summary>
         /// Triggers a grid refresh. Call after <see cref="SetDataSource{TModel, TResponse}"/>

--- a/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionKanban/FusionKanbanExtensions.cs
@@ -94,6 +94,20 @@ namespace Alis.Reactive.Fusion.Components
             return self.EmitCall(DataBindMethod);
         }
 
+        /// <summary>
+        /// Replaces the board data source with a typed array source — including a client-side
+        /// <see cref="Alis.Reactive.Builders.Arrays.ReactiveArray{T}"/> transform via <c>AsSource()</c>.
+        /// Routes any card array into the board with no HTTP round-trip, then data-binds.
+        /// </summary>
+        public static ComponentRef<FusionKanban, TModel> SetDataSource<TModel, TElement>(
+            this ComponentRef<FusionKanban, TModel> self,
+            TypedSource<TElement[]> source)
+            where TModel : class
+        {
+            self.EmitSet(DataSourceProperty, source.ToValueExpression());
+            return self.EmitCall(DataBindMethod);
+        }
+
         public static ComponentRef<FusionKanban, TModel> AddCard<TModel, TResponse>(
             this ComponentRef<FusionKanban, TModel> self,
             ResponseBody<TResponse> source,

--- a/Alis.Reactive.Fusion/Components/FusionMultiColumnComboBox/FusionMultiColumnComboBoxExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMultiColumnComboBox/FusionMultiColumnComboBoxExtensions.cs
@@ -87,6 +87,21 @@ namespace Alis.Reactive.Fusion.Components
             return self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, sourcePath));
         }
 
+        /// <summary>
+        /// Replaces the data source with a typed array source — including a client-side
+        /// <see cref="Alis.Reactive.Builders.Arrays.ReactiveArray{T}"/> transform via <c>AsSource()</c>.
+        /// Routes any array value into the option list with no HTTP round-trip.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TElement">The item element type carried by the source.</typeparam>
+        /// <param name="source">The typed array source.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionMultiColumnComboBox, TModel> SetDataSource<TModel, TElement>(
+            this ComponentRef<FusionMultiColumnComboBox, TModel> self,
+            TypedSource<TElement[]> source)
+            where TModel : class
+            => self.EmitSet(DataSourceProperty, source.ToValueExpression());
+
         /// <summary>Flushes pending property changes to the component in the browser.</summary>
         /// <returns>The component reference for method chaining.</returns>
         public static ComponentRef<FusionMultiColumnComboBox, TModel> DataBind<TModel>(

--- a/Alis.Reactive.Fusion/Components/FusionMultiSelect/FusionMultiSelectExtensions.cs
+++ b/Alis.Reactive.Fusion/Components/FusionMultiSelect/FusionMultiSelectExtensions.cs
@@ -72,6 +72,21 @@ namespace Alis.Reactive.Fusion.Components
             return self.EmitSet(DataSourceProperty, ValueExpression.Read(source.Scope, sourcePath));
         }
 
+        /// <summary>
+        /// Replaces the data source with a typed array source — including a client-side
+        /// <see cref="Alis.Reactive.Builders.Arrays.ReactiveArray{T}"/> transform via <c>AsSource()</c>.
+        /// Routes any array value into the option list with no HTTP round-trip.
+        /// </summary>
+        /// <typeparam name="TModel">The view model type.</typeparam>
+        /// <typeparam name="TElement">The item element type carried by the source.</typeparam>
+        /// <param name="source">The typed array source.</param>
+        /// <returns>The component reference for method chaining.</returns>
+        public static ComponentRef<FusionMultiSelect, TModel> SetDataSource<TModel, TElement>(
+            this ComponentRef<FusionMultiSelect, TModel> self,
+            TypedSource<TElement[]> source)
+            where TModel : class
+            => self.EmitSet(DataSourceProperty, source.ToValueExpression());
+
         /// <summary>Flushes pending property changes to the component in the browser.</summary>
         /// <returns>The component reference for method chaining.</returns>
         public static ComponentRef<FusionMultiSelect, TModel> DataBind<TModel>(

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ArrayGridController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ArrayGridController.cs
@@ -1,0 +1,42 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    /// <summary>
+    /// ArrayGrid sandbox — the array DSL routed into a component data source. A roster loads once
+    /// over HTTP; a client-side <c>ReactiveArray</c> transform (filter/sort over element members)
+    /// feeds the grid via <c>SetDataSource(TypedSource&lt;T[]&gt;)</c>, and re-filtering the rows
+    /// already on screen reads the grid's own <c>dataSource</c> member — no HTTP round-trip.
+    /// URL: /Sandbox/Components/ArrayGrid.
+    /// </summary>
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/ArrayGrid")]
+    public class ArrayGridController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/ArrayGrid/Index.cshtml",
+                new ArrayGridModel());
+        }
+
+        /// <summary>The resident roster the grid binds to (the object array the DSL transforms).</summary>
+        [HttpGet("Residents")]
+        public IActionResult Residents()
+        {
+            return Ok(new ResidentRosterResponse
+            {
+                Residents = new[]
+                {
+                    new ResidentRow { Name = "Ada", Status = "active",     Age = 71, Balance = 1200 },
+                    new ResidentRow { Name = "Bo",  Status = "discharged", Age = 64, Balance = 500 },
+                    new ResidentRow { Name = "Cy",  Status = "active",     Age = 80, Balance = 2000 },
+                    new ResidentRow { Name = "Di",  Status = "critical",   Age = 90, Balance = 3000 },
+                    new ResidentRow { Name = "Ed",  Status = "active",     Age = 55, Balance = 800 },
+                },
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ChipFilterController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Fusion/ChipFilterController.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Fusion
+{
+    /// <summary>
+    /// ChipFilter sandbox — multi-select chips drive the array DSL and a server-side grid filter.
+    /// The chip selection is broadcast as a custom event whose payload carries the selected chip
+    /// objects; the array DSL counts/guards them by member, and their texts gather into a POST that
+    /// filters the resident grid. URL: /Sandbox/Components/ChipFilter.
+    /// </summary>
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/ChipFilter")]
+    public class ChipFilterController : Controller
+    {
+        private static readonly CareResident[] All =
+        {
+            new CareResident { Name = "Ada", CareLevel = "Memory Care" },
+            new CareResident { Name = "Bo",  CareLevel = "Assisted" },
+            new CareResident { Name = "Cy",  CareLevel = "Memory Care" },
+            new CareResident { Name = "Di",  CareLevel = "Skilled Nursing" },
+            new CareResident { Name = "Ed",  CareLevel = "Independent" },
+            new CareResident { Name = "Fay", CareLevel = "Assisted" },
+            new CareResident { Name = "Gus", CareLevel = "Memory Care" },
+        };
+
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Fusion/ChipFilter/Index.cshtml",
+                new ChipFilterModel());
+        }
+
+        /// <summary>The full roster shown on load.</summary>
+        [HttpGet("Residents")]
+        public IActionResult Residents() => Ok(new CareResidentResponse { Residents = All });
+
+        /// <summary>Filters the roster by the selected care levels (the chip texts).</summary>
+        [HttpPost("Filter")]
+        public IActionResult Filter([FromBody] CareFilterRequest? request)
+        {
+            var levels = request?.CareLevels ?? Array.Empty<string>();
+            var residents = levels.Length == 0
+                ? All
+                : All.Where(r => levels.Contains(r.CareLevel)).ToArray();
+            return Ok(new CareResidentResponse { Residents = residents });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ArrayOpsController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ArrayOpsController.cs
@@ -30,5 +30,22 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
                 "~/Areas/Sandbox/Views/Components/Native/ArrayOps/Index.cshtml",
                 new ArrayOpsModel());
         }
+
+        /// <summary>Resident roster the array DSL operates on (the object array source).</summary>
+        [HttpGet("Residents")]
+        public IActionResult Residents()
+        {
+            return Ok(new ResidentRosterResponse
+            {
+                Residents = new[]
+                {
+                    new ResidentRow { Name = "Ada",  Status = "active",     Age = 71, Balance = 1200 },
+                    new ResidentRow { Name = "Bo",   Status = "discharged", Age = 64, Balance = 500 },
+                    new ResidentRow { Name = "Cy",   Status = "active",     Age = 80, Balance = 2000 },
+                    new ResidentRow { Name = "Di",   Status = "critical",   Age = 90, Balance = 3000 },
+                    new ResidentRow { Name = "Ed",   Status = "active",     Age = 55, Balance = 800 },
+                },
+            });
+        }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ArrayOpsController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ArrayOpsController.cs
@@ -1,0 +1,34 @@
+using Alis.Reactive.Native.Components;
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
+{
+    /// <summary>
+    /// ArrayOps sandbox — demonstrates the deterministic array-operations DSL:
+    /// a NativeCheckList Changed event delivers e.Value (string[]); the plan counts it
+    /// via an array-op node and writes the result to a display element. URL:
+    /// /Sandbox/Components/ArrayOps.
+    /// </summary>
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/ArrayOps")]
+    public class ArrayOpsController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            ViewBag.ActivityItems = new[]
+            {
+                new RadioButtonItem("PhysicalTherapy", "Physical Therapy"),
+                new RadioButtonItem("OccupationalTherapy", "Occupational Therapy"),
+                new RadioButtonItem("SpeechTherapy", "Speech Therapy"),
+                new RadioButtonItem("SocialActivities", "Social Activities"),
+                new RadioButtonItem("DiningProgram", "Dining Program"),
+            };
+
+            return View(
+                "~/Areas/Sandbox/Views/Components/Native/ArrayOps/Index.cshtml",
+                new ArrayOpsModel());
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/DomOpsController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/DomOpsController.cs
@@ -1,0 +1,19 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
+{
+    /// <summary>
+    /// DomOps sandbox — the array DSL over native DOM. A DOM element resolved by getElementById
+    /// is a JS object; its classList/children are array-likes the runtime normalizes, so the same
+    /// array ops apply. URL: /Sandbox/Components/DomOps.
+    /// </summary>
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/DomOps")]
+    public class DomOpsController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index() =>
+            View("~/Areas/Sandbox/Views/Components/Native/DomOps/Index.cshtml", new DomOpsModel());
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ShiftReportController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ShiftReportController.cs
@@ -1,0 +1,41 @@
+using Alis.Reactive.SandboxApp.Areas.Sandbox.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
+{
+    /// <summary>
+    /// ShiftReport sandbox — the array DSL operating on a CUSTOM event payload. A button loads the
+    /// alert roster over HTTP, then broadcasts it as the <c>shift-report</c> custom event whose
+    /// payload carries <c>ResidentAlert[]</c>; the listener runs filter/aggregate/find over the
+    /// payload's element members. URL: /Sandbox/Components/ShiftReport.
+    /// </summary>
+    [Area("Sandbox")]
+    [Route("Sandbox/Components/ShiftReport")]
+    public class ShiftReportController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index()
+        {
+            return View(
+                "~/Areas/Sandbox/Views/Components/Native/ShiftReport/Index.cshtml",
+                new ShiftReportModel());
+        }
+
+        /// <summary>The alert roster that seeds the custom event payload's array.</summary>
+        [HttpGet("Alerts")]
+        public IActionResult Alerts()
+        {
+            return Ok(new AlertsResponse
+            {
+                Alerts = new[]
+                {
+                    new ResidentAlert { Resident = "Maple", Severity = "critical", Priority = 9, Acknowledged = false },
+                    new ResidentAlert { Resident = "Birch", Severity = "stable",   Priority = 2, Acknowledged = true },
+                    new ResidentAlert { Resident = "Cedar", Severity = "critical", Priority = 7, Acknowledged = true },
+                    new ResidentAlert { Resident = "Aspen", Severity = "urgent",   Priority = 5, Acknowledged = false },
+                    new ResidentAlert { Resident = "Oak",   Severity = "critical", Priority = 4, Acknowledged = false },
+                },
+            });
+        }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ShiftReportController.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Controllers/Components/Native/ShiftReportController.cs
@@ -37,5 +37,22 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Controllers.Components.Native
                 },
             });
         }
+
+        /// <summary>A roster where every critical alert is acknowledged — exercises the clear (Else) guard.</summary>
+        [HttpGet("AlertsAllClear")]
+        public IActionResult AlertsAllClear()
+        {
+            return Ok(new AlertsResponse
+            {
+                Alerts = new[]
+                {
+                    new ResidentAlert { Resident = "Maple", Severity = "critical", Priority = 9, Acknowledged = true },
+                    new ResidentAlert { Resident = "Birch", Severity = "stable",   Priority = 2, Acknowledged = true },
+                    new ResidentAlert { Resident = "Cedar", Severity = "critical", Priority = 7, Acknowledged = true },
+                    new ResidentAlert { Resident = "Aspen", Severity = "urgent",   Priority = 5, Acknowledged = true },
+                    new ResidentAlert { Resident = "Oak",   Severity = "critical", Priority = 4, Acknowledged = true },
+                },
+            });
+        }
     }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ArrayGridModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ArrayGridModel.cs
@@ -1,0 +1,12 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>
+    /// Model for the ArrayGrid sandbox: a non-input FusionGrid whose data source is driven by a
+    /// client-side <c>ReactiveArray</c> transform — the array DSL routed into a component's
+    /// <c>dataSource</c> member via <c>SetDataSource(TypedSource&lt;T[]&gt;)</c>. Reuses
+    /// <see cref="ResidentRosterResponse"/> / <see cref="ResidentRow"/> as the roster.
+    /// </summary>
+    public class ArrayGridModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ArrayOpsModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ArrayOpsModel.cs
@@ -5,4 +5,19 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
     {
         public string[]? SelectedActivities { get; set; }
     }
+
+    /// <summary>HTTP response for the resident roster — the object array the DSL operates on.</summary>
+    public class ResidentRosterResponse
+    {
+        public ResidentRow[] Residents { get; set; } = System.Array.Empty<ResidentRow>();
+    }
+
+    /// <summary>A resident element with members the per-element predicates/selectors read.</summary>
+    public class ResidentRow
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public int Age { get; set; }
+        public int Balance { get; set; }
+    }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ArrayOpsModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ArrayOpsModel.cs
@@ -1,0 +1,8 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>Model for the ArrayOps sandbox: a multi-select of care activities.</summary>
+    public class ArrayOpsModel
+    {
+        public string[]? SelectedActivities { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ChipFilterModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ChipFilterModel.cs
@@ -1,0 +1,38 @@
+using System;
+using Alis.Reactive.Fusion.Components;
+
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>Model for the ChipFilter sandbox: multi-select chips as a filter over a resident grid.</summary>
+    public sealed class ChipFilterModel
+    {
+    }
+
+    /// <summary>
+    /// Custom event payload carrying the chip selection. <see cref="FusionSelectedChips.Data"/> is the
+    /// array of selected chip objects the array DSL operates on.
+    /// </summary>
+    public sealed class ChipFilterPayload
+    {
+        public FusionSelectedChips Selection { get; set; } = new FusionSelectedChips();
+    }
+
+    /// <summary>The resident roster (and filtered result) bound to the grid.</summary>
+    public sealed class CareResidentResponse
+    {
+        public CareResident[] Residents { get; set; } = Array.Empty<CareResident>();
+    }
+
+    /// <summary>A resident with a care level matching the chip texts.</summary>
+    public sealed class CareResident
+    {
+        public string Name { get; set; } = "";
+        public string CareLevel { get; set; } = "";
+    }
+
+    /// <summary>POST body for the server-side care-level filter.</summary>
+    public sealed class CareFilterRequest
+    {
+        public string[]? CareLevels { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/DomOpsModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/DomOpsModel.cs
@@ -1,0 +1,7 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>Model for the DomOps sandbox: array operations over native DOM collections.</summary>
+    public class DomOpsModel
+    {
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/DomOpsModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/DomOpsModel.cs
@@ -4,4 +4,14 @@ namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
     public class DomOpsModel
     {
     }
+
+    /// <summary>
+    /// Typed stub for a DOM child element, so the DSL lambda <c>x =&gt; x.GetAttribute("data-risk")</c>
+    /// type-checks in C#. At runtime the element is the live DOM node; the DSL calls its getAttribute
+    /// via RuntimePath.call. The stub bodies are never executed.
+    /// </summary>
+    public sealed class DomChild
+    {
+        public string? GetAttribute(string name) => null;
+    }
 }

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ShiftReportModel.cs
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Models/ShiftReportModel.cs
@@ -1,0 +1,32 @@
+namespace Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+{
+    /// <summary>Model for the ShiftReport sandbox: operating on a custom event payload's array.</summary>
+    public sealed class ShiftReportModel
+    {
+    }
+
+    /// <summary>
+    /// A developer-defined custom event payload that carries an array of objects. The
+    /// <c>shift-report</c> custom event delivers this; the array DSL operates on
+    /// <see cref="Alerts"/> by element members in the handler.
+    /// </summary>
+    public sealed class ShiftReportPayload
+    {
+        public ResidentAlert[] Alerts { get; set; } = System.Array.Empty<ResidentAlert>();
+    }
+
+    /// <summary>HTTP response that seeds the custom event payload's array.</summary>
+    public sealed class AlertsResponse
+    {
+        public ResidentAlert[] Alerts { get; set; } = System.Array.Empty<ResidentAlert>();
+    }
+
+    /// <summary>An alert element with members the per-element predicates/selectors read.</summary>
+    public sealed class ResidentAlert
+    {
+        public string Resident { get; set; } = string.Empty;
+        public string Severity { get; set; } = string.Empty;
+        public int Priority { get; set; }
+        public bool Acknowledged { get; set; }
+    }
+}

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ArrayGrid/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ArrayGrid/Index.cshtml
@@ -1,0 +1,66 @@
+@model ArrayGridModel
+@using Alis.Reactive
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@using Syncfusion.EJ2.Grids
+@{
+    ViewData["Title"] = "ArrayGrid";
+
+    var plan = Html.ReactivePlan<ArrayGridModel>();
+
+    // First-class value routing: an array value flows into a component's dataSource member the
+    // same way any value flows to any member. The roster loads once over HTTP, then a client-side
+    // ReactiveArray transform (OrderBy over the Name element member) routes straight into the grid
+    // via SetDataSource(TypedSource<T[]>). No per-row plumbing, no hand-written JS.
+    Html.On(plan, t => t.DomReady(p =>
+        p.Get("/Sandbox/Components/ArrayGrid/Residents")
+         .Response(r => r.OnSuccess<ResidentRosterResponse>((json, s) =>
+         {
+             var roster = p.From(json.Read(x => x.Residents));
+             s.Component<FusionGrid>("roster-grid")
+                 .SetDataSource(roster.OrderBy(x => x.Name).AsSource());
+             s.Element("grid-status").SetText("roster loaded");
+         }))));
+
+    // Re-filter the rows ALREADY on screen: read the grid's own dataSource member, keep the
+    // active residents, rebind. Entirely client-side over element members — no server call.
+    Html.NativeButton("show-active-btn", "Show Active Only")
+        .Reactive(plan, evt => evt.Click, (args, p) =>
+        {
+            var current = p.From(p.Component<FusionGrid>("roster-grid").Data<ArrayGridModel, ResidentRow>());
+            p.Component<FusionGrid>("roster-grid")
+                .SetDataSource(current.Where(x => x.Status == "active").OrderBy(x => x.Name).AsSource())
+                .Refresh();
+            p.Element("grid-status").SetText("active only");
+        });
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">ArrayGrid &mdash; client-side transform into a grid data source</native-heading>
+    <native-text color="Secondary">
+        The array DSL is just value routing: <code>p.From(roster).Where(x =&gt; x.Status == "active").OrderBy(x =&gt; x.Name).AsSource()</code>
+        flows into the grid's <code>dataSource</code> member via <code>SetDataSource(TypedSource&lt;T[]&gt;)</code>.
+        The filter runs in the plan over element members &mdash; no HTTP round-trip, no per-row code.
+    </native-text>
+
+    <native-card><native-card-body>
+        @(Html.FusionGrid(plan, "roster-grid", b => b
+            .Columns(new List<GridColumn>
+            {
+                new GridColumn { Field = "name", HeaderText = "Name", Width = "160" },
+                new GridColumn { Field = "status", HeaderText = "Status", Width = "130" },
+                new GridColumn { Field = "age", HeaderText = "Age", Width = "80" },
+                new GridColumn { Field = "balance", HeaderText = "Balance", Width = "110" },
+            })))
+
+        <div class="mt-4 flex items-center gap-3">
+            @(Html.NativeButton("show-active-btn", "Show Active Only")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"))
+            <span class="font-mono text-sm">Status: <span id="grid-status" class="text-text-muted">&mdash;</span></span>
+        </div>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ChipFilter/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Fusion/ChipFilter/Index.cshtml
@@ -1,0 +1,94 @@
+@model ChipFilterModel
+@using Alis.Reactive
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.Fusion.Components
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@using Syncfusion.EJ2.Buttons
+@using Syncfusion.EJ2.Grids
+@{
+    ViewData["Title"] = "ChipFilter";
+
+    var plan = Html.ReactivePlan<ChipFilterModel>();
+
+    var careChips = new List<ChipCollection>
+    {
+        new() { Text = "Independent", Value = "independent" },
+        new() { Text = "Assisted", Value = "assisted" },
+        new() { Text = "Memory Care", Value = "memory" },
+        new() { Text = "Skilled Nursing", Value = "skilled" },
+    };
+
+    // The chip selection is broadcast as a custom event; p.From(payload, x => x.Selection.Data) yields
+    // a ReactiveArray of the selected chip OBJECTS, operated on by member (Count, Any-by-Value guard).
+    // The selected texts then gather into a POST that filters the grid server-side.
+    Html.On(plan, t => t.CustomEvent<ChipFilterPayload>("filters-applied", (payload, p) =>
+    {
+        var selected = p.From(payload, x => x.Selection.Data);
+
+        p.Element("filter-count").SetText(selected.Count());
+
+        p.When(selected.Any(c => c.Value == "memory")).Truthy()
+         .Then(then => then.Element("memory-on").Show())
+         .Else(els => els.Element("memory-off").Show());
+
+        p.Post("/Sandbox/Components/ChipFilter/Filter")
+         .Gather(g => g.FromEvent(payload, x => x.Selection.Texts, "careLevels"))
+         .Response(r => r.OnSuccess<CareResidentResponse>((json, s) =>
+         {
+             s.Component<FusionGrid>("care-grid").SetDataSource(json, x => x.Residents);
+             s.Element("filter-status").SetText("filtered");
+         }));
+    }));
+
+    // Initial load: all residents.
+    Html.On(plan, t => t.DomReady(p =>
+        p.Get("/Sandbox/Components/ChipFilter/Residents")
+         .Response(r => r.OnSuccess<CareResidentResponse>((json, s) =>
+         {
+             s.Component<FusionGrid>("care-grid").SetDataSource(json, x => x.Residents);
+             s.Element("filter-status").SetText("all residents");
+         }))));
+
+    // Apply: read the chip selection and broadcast it.
+    Html.NativeButton("apply-filters-btn", "Apply Filters")
+        .Reactive(plan, evt => evt.Click, (args, p) =>
+            p.DispatchWith<ChipFilterPayload>("filters-applied", b =>
+                b.Set(x => x.Selection, p.Component<FusionChipList>("care-filters").SelectedChips())));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">ChipFilter &mdash; multi-select chips as a filter</native-heading>
+    <native-text color="Secondary">
+        Pick care levels, then <strong>Apply</strong>. The array DSL operates on the selected chip
+        <em>objects</em> &mdash; <code>p.From(payload, x =&gt; x.Selection.Data).Any(c =&gt; c.Value == "memory")</code>
+        &mdash; and the selected texts filter the grid server-side. No plugin, no hand-written JS.
+    </native-text>
+
+    <native-card><native-card-body>
+        @(Html.FusionChipList(plan, "care-filters", b => b
+            .Chips(careChips)
+            .Selection(Selection.Multiple)))
+
+        <div class="mt-4 flex items-center gap-3">
+            @(Html.NativeButton("apply-filters-btn", "Apply Filters")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"))
+        </div>
+
+        <native-vstack gap="Xs" class="font-mono text-sm my-3">
+            <p>Care levels selected: <span id="filter-count">&mdash;</span></p>
+            <p id="memory-on" hidden class="text-amber-600">&#9679; Memory Care included</p>
+            <p id="memory-off" hidden class="text-text-muted">&#9675; Memory Care not included</p>
+            <p>Status: <span id="filter-status" class="text-text-muted">&mdash;</span></p>
+        </native-vstack>
+
+        @(Html.FusionGrid(plan, "care-grid", b => b
+            .Columns(new List<GridColumn>
+            {
+                new GridColumn { Field = "name", HeaderText = "Resident", Width = "160" },
+                new GridColumn { Field = "careLevel", HeaderText = "Care Level", Width = "180" },
+            })))
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ArrayOps/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ArrayOps/Index.cshtml
@@ -1,0 +1,41 @@
+@model ArrayOpsModel
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@{
+    ViewData["Title"] = "ArrayOps";
+
+    var plan = Html.ReactivePlan<ArrayOpsModel>();
+    var activityItems = (RadioButtonItem[])ViewBag.ActivityItems;
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">ArrayOps</native-heading>
+    <native-text color="Secondary">
+        Deterministic array DSL. The NativeCheckList <code>Changed</code> event delivers
+        <code>e.Value</code> (a <code>string[]</code>); <code>p.From(args, e =&gt; e.Value).Count()</code>
+        compiles to a plan <code>array-op</code> node that the runtime evaluates and writes to a
+        display element. No plugin, no hand-written JS.
+    </native-text>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Activity Selection</native-heading>
+        <native-text color="Secondary">
+            Toggle activities — the selected count updates on every change.
+        </native-text>
+
+        @{ Html.InputField(plan, m => m.SelectedActivities, o => o.Label("Activities"))
+            .NativeCheckList(b => b
+                .Items(activityItems)
+                .Reactive(plan, evt => evt.Changed, (args, p) =>
+                {
+                    var count = p.From(args, e => e.Value).Count();
+                    p.Element("selected-count").SetText(count);
+                })); }
+
+        <p class="font-mono text-sm mt-2">
+            Selected count: <span id="selected-count" class="text-text-muted">&mdash;</span>
+        </p>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ArrayOps/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ArrayOps/Index.cshtml
@@ -1,4 +1,5 @@
 @model ArrayOpsModel
+@using Alis.Reactive
 @using Alis.Reactive.Native.Extensions
 @using Alis.Reactive.Native.Components
 @{
@@ -6,21 +7,59 @@
 
     var plan = Html.ReactivePlan<ArrayOpsModel>();
     var activityItems = (RadioButtonItem[])ViewBag.ActivityItems;
+
+    // COMPLEX: load a resident roster, then operate on the object array deterministically —
+    // filter by element members, aggregate, find, and guard — all compiled to plan nodes.
+    // This is a deterministic replacement for the ArrayManager plugin: no plugin, no JS.
+    Html.On(plan, t => t.DomReady(p =>
+        p.Get("/Sandbox/Components/ArrayOps/Residents")
+         .Response(r => r.OnSuccess<ResidentRosterResponse>((json, s) =>
+         {
+             var residents = p.From(json.Read(x => x.Residents));
+
+             s.Element("res-total").SetText(residents.Count());
+             s.Element("res-active").SetText(residents.Count(x => x.Status == "active"));
+             s.Element("res-active-seniors").SetText(residents.Count(x => x.Status == "active" && x.Age >= 65));
+             s.Element("res-active-age-sum").SetText(residents.Where(x => x.Status == "active").Sum(x => x.Age));
+             s.Element("res-oldest-active").SetText(
+                 residents.Where(x => x.Status == "active").OrderByDescending(x => x.Age).Find(x => true, x => x.Name));
+
+             s.When(residents.Any(x => x.Status == "critical")).Truthy()
+              .Then(then => then.Element("res-critical-yes").Show())
+              .Else(els => els.Element("res-critical-no").Show());
+         }))));
 }
 
 <native-vstack gap="Lg">
     <native-heading level="H1">ArrayOps</native-heading>
     <native-text color="Secondary">
-        Deterministic array DSL. The NativeCheckList <code>Changed</code> event delivers
-        <code>e.Value</code> (a <code>string[]</code>); <code>p.From(args, e =&gt; e.Value).Count()</code>
-        compiles to a plan <code>array-op</code> node that the runtime evaluates and writes to a
-        display element. No plugin, no hand-written JS.
+        Deterministic array DSL. Each operation is captured from a C# lambda and compiled to a
+        plan <code>array-op</code> node; the runtime evaluates predicates and selectors against the
+        element scope. No plugin, no hand-written JS.
     </native-text>
 
     <native-card><native-card-body>
-        <native-heading level="H2">Activity Selection</native-heading>
+        <native-heading level="H2">Resident roster — operate on the object array</native-heading>
         <native-text color="Secondary">
-            Toggle activities — the selected count updates on every change.
+            Loaded via HTTP, then filtered/aggregated by element members in the plan
+            (e.g. <code>residents.Where(x =&gt; x.Status == "active").Sum(x =&gt; x.Age)</code>).
+        </native-text>
+        <native-vstack gap="Sm" class="font-mono text-sm">
+            <p>Total residents: <span id="res-total">&mdash;</span></p>
+            <p>Active: <span id="res-active">&mdash;</span></p>
+            <p>Active seniors (65+): <span id="res-active-seniors">&mdash;</span></p>
+            <p>Total age of active: <span id="res-active-age-sum">&mdash;</span></p>
+            <p>Oldest active: <span id="res-oldest-active">&mdash;</span></p>
+            <p id="res-critical-yes" hidden class="text-red-600">&#9888; Critical resident present</p>
+            <p id="res-critical-no" hidden class="text-green-600">No critical residents</p>
+        </native-vstack>
+    </native-card-body></native-card>
+
+    <native-card><native-card-body>
+        <native-heading level="H2">Activity selection (live count)</native-heading>
+        <native-text color="Secondary">
+            The NativeCheckList <code>Changed</code> event delivers <code>e.Value</code> (a
+            <code>string[]</code>); <code>p.From(args, e =&gt; e.Value).Count()</code> updates on every change.
         </native-text>
 
         @{ Html.InputField(plan, m => m.SelectedActivities, o => o.Label("Activities"))
@@ -32,9 +71,7 @@
                     p.Element("selected-count").SetText(count);
                 })); }
 
-        <p class="font-mono text-sm mt-2">
-            Selected count: <span id="selected-count" class="text-text-muted">&mdash;</span>
-        </p>
+        <p class="font-mono text-sm mt-2">Selected count: <span id="selected-count">&mdash;</span></p>
     </native-card-body></native-card>
 </native-vstack>
 

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/DomOps/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/DomOps/Index.cshtml
@@ -20,6 +20,11 @@
         p.When(p.FromDom("dom-card", "classList").Any(x => x == "care-memory")).Truthy()
          .Then(then => then.Element("dom-memory-yes").Show())
          .Else(els => els.Element("dom-memory-no").Show());
+
+        // Per-element METHOD call: each list child is a live DOM element; call its getAttribute
+        // method per element and count those flagged high-risk. RuntimePath.call at the element scope.
+        p.Element("dom-high-risk-count").SetText(
+            p.FromDom<DomChild>("risk-list", "children").Count(x => x.GetAttribute("data-risk") == "high"));
     }));
 
     // Mutate the DOM, then re-run a DOM array op on the updated element — same tick.
@@ -42,11 +47,17 @@
     <native-card><native-card-body>
         <div id="dom-card" class="risk-fall risk-oxygen care-memory"></div>
         <ul id="dom-list" hidden><li>Physio</li><li>Dining</li><li>Social</li></ul>
+        <ul id="risk-list" hidden>
+            <li data-risk="high">Mrs. A</li>
+            <li data-risk="low">Mr. B</li>
+            <li data-risk="high">Ms. C</li>
+        </ul>
 
         <native-vstack gap="Sm" class="font-mono text-sm">
             <p>Total classes: <span id="dom-total-classes">&mdash;</span></p>
             <p>Risk flags (class starts with "risk-"): <span id="dom-risk-count">&mdash;</span></p>
             <p>List children: <span id="dom-child-count">&mdash;</span></p>
+            <p>High-risk children (per-element <code>getAttribute</code>): <span id="dom-high-risk-count">&mdash;</span></p>
             <p id="dom-memory-yes" hidden class="text-amber-600">Memory-care class present</p>
             <p id="dom-memory-no" hidden class="text-green-600">No memory-care class</p>
         </native-vstack>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/DomOps/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/DomOps/Index.cshtml
@@ -1,0 +1,59 @@
+@model DomOpsModel
+@using Alis.Reactive
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@{
+    ViewData["Title"] = "DomOps";
+
+    var plan = Html.ReactivePlan<DomOpsModel>();
+
+    // The array DSL over native DOM: a DOM element resolved by getElementById is a JS object;
+    // classList (DOMTokenList) and children (HTMLCollection) are array-likes the runtime
+    // normalizes, so filter/count/any apply. No plugin, no hand-written JS.
+    Html.On(plan, t => t.DomReady(p =>
+    {
+        p.Element("dom-total-classes").SetText(p.FromDom("dom-card", "classList").Count());
+        p.Element("dom-risk-count").SetText(
+            p.FromDom("dom-card", "classList").Where(x => x.StartsWith("risk-")).Count());
+        p.Element("dom-child-count").SetText(p.FromDom("dom-list", "children").Count());
+
+        p.When(p.FromDom("dom-card", "classList").Any(x => x == "care-memory")).Truthy()
+         .Then(then => then.Element("dom-memory-yes").Show())
+         .Else(els => els.Element("dom-memory-no").Show());
+    }));
+
+    // Mutate the DOM, then re-run a DOM array op on the updated element — same tick.
+    Html.NativeButton("dom-add-risk-btn", "Add Risk Flag")
+        .Reactive(plan, evt => evt.Click, (args, p) =>
+        {
+            p.Element("dom-card").AddClass("risk-extra");
+            p.Element("dom-risk-count").SetText(
+                p.FromDom("dom-card", "classList").Where(x => x.StartsWith("risk-")).Count());
+        });
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">DomOps</native-heading>
+    <native-text color="Secondary">
+        The array DSL over native DOM. <code>p.FromDom("dom-card", "classList").Where(x =&gt; x.StartsWith("risk-")).Count()</code>
+        reads a DOM element by id, normalizes its DOMTokenList, and counts — deterministically, in the plan.
+    </native-text>
+
+    <native-card><native-card-body>
+        <div id="dom-card" class="risk-fall risk-oxygen care-memory"></div>
+        <ul id="dom-list" hidden><li>Physio</li><li>Dining</li><li>Social</li></ul>
+
+        <native-vstack gap="Sm" class="font-mono text-sm">
+            <p>Total classes: <span id="dom-total-classes">&mdash;</span></p>
+            <p>Risk flags (class starts with "risk-"): <span id="dom-risk-count">&mdash;</span></p>
+            <p>List children: <span id="dom-child-count">&mdash;</span></p>
+            <p id="dom-memory-yes" hidden class="text-amber-600">Memory-care class present</p>
+            <p id="dom-memory-no" hidden class="text-green-600">No memory-care class</p>
+        </native-vstack>
+
+        @(Html.NativeButton("dom-add-risk-btn", "Add Risk Flag")
+            .CssClass("mt-3 rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"))
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ShiftReport/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ShiftReport/Index.cshtml
@@ -35,6 +35,14 @@
              .Response(r => r.OnSuccess<AlertsResponse>((json, s) =>
                  s.DispatchWith<ShiftReportPayload>("shift-report", b =>
                      b.Set(x => x.Alerts, json.Read(x => x.Alerts))))));
+
+    // Same custom event, a roster where every critical alert is acknowledged — drives the Else guard.
+    Html.NativeButton("clear-report-btn", "Generate Clear Report")
+        .Reactive(plan, evt => evt.Click, (args, p) =>
+            p.Get("/Sandbox/Components/ShiftReport/AlertsAllClear")
+             .Response(r => r.OnSuccess<AlertsResponse>((json, s) =>
+                 s.DispatchWith<ShiftReportPayload>("shift-report", b =>
+                     b.Set(x => x.Alerts, json.Read(x => x.Alerts))))));
 }
 
 <native-vstack gap="Lg">
@@ -47,8 +55,12 @@
     </native-text>
 
     <native-card><native-card-body>
-        @(Html.NativeButton("load-report-btn", "Generate Shift Report")
-            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"))
+        <div class="flex items-center gap-3">
+            @(Html.NativeButton("load-report-btn", "Generate Shift Report")
+                .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"))
+            @(Html.NativeButton("clear-report-btn", "Generate Clear Report")
+                .CssClass("rounded-md bg-secondary px-4 py-2 text-sm font-medium text-white hover:bg-secondary/90 transition-colors"))
+        </div>
 
         <native-vstack gap="Xs" class="font-mono text-sm mt-4">
             <p>Total alerts: <span id="alert-total">&mdash;</span></p>

--- a/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ShiftReport/Index.cshtml
+++ b/Alis.Reactive.SandboxApp/Areas/Sandbox/Views/Components/Native/ShiftReport/Index.cshtml
@@ -1,0 +1,64 @@
+@model ShiftReportModel
+@using Alis.Reactive
+@using Alis.Reactive.Native.Extensions
+@using Alis.Reactive.Native.Components
+@using Alis.Reactive.SandboxApp.Areas.Sandbox.Models
+@{
+    ViewData["Title"] = "ShiftReport";
+
+    var plan = Html.ReactivePlan<ShiftReportModel>();
+
+    // A CUSTOM event whose payload carries an array of objects (ResidentAlert[]). The handler runs
+    // the array DSL over the payload's elements BY THEIR MEMBERS — count, filter, aggregate, find,
+    // and a guard — all compiled to plan nodes. No plugin, no hand-written JS.
+    Html.On(plan, t => t.CustomEvent<ShiftReportPayload>("shift-report", (payload, p) =>
+    {
+        var alerts = p.From(payload, x => x.Alerts);
+
+        p.Element("alert-total").SetText(alerts.Count());
+        p.Element("critical-count").SetText(alerts.Count(a => a.Severity == "critical"));
+        p.Element("critical-priority-sum").SetText(
+            alerts.Where(a => a.Severity == "critical").Sum(a => a.Priority));
+        p.Element("top-critical").SetText(
+            alerts.Where(a => a.Severity == "critical").OrderByDescending(a => a.Priority).Find(a => true, a => a.Resident));
+
+        p.When(alerts.Any(a => a.Severity == "critical" && !a.Acknowledged)).Truthy()
+         .Then(then => then.Element("unack-warning").Show())
+         .Else(els => els.Element("unack-clear").Show());
+    }));
+
+    // Load the alert roster, then broadcast it as the custom event payload — the array travels in
+    // the payload. A real app might broadcast on a SignalR push; here a button stands in.
+    Html.NativeButton("load-report-btn", "Generate Shift Report")
+        .Reactive(plan, evt => evt.Click, (args, p) =>
+            p.Get("/Sandbox/Components/ShiftReport/Alerts")
+             .Response(r => r.OnSuccess<AlertsResponse>((json, s) =>
+                 s.DispatchWith<ShiftReportPayload>("shift-report", b =>
+                     b.Set(x => x.Alerts, json.Read(x => x.Alerts))))));
+}
+
+<native-vstack gap="Lg">
+    <native-heading level="H1">ShiftReport &mdash; operate on a custom event payload array</native-heading>
+    <native-text color="Secondary">
+        The custom event <code>shift-report</code> carries <code>ResidentAlert[]</code>. Its handler runs the
+        array DSL over the payload's element members, e.g.
+        <code>alerts.Where(a =&gt; a.Severity == "critical").OrderByDescending(a =&gt; a.Priority).Find(...)</code>.
+        Deterministic, in the plan &mdash; no plugin, no JS.
+    </native-text>
+
+    <native-card><native-card-body>
+        @(Html.NativeButton("load-report-btn", "Generate Shift Report")
+            .CssClass("rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"))
+
+        <native-vstack gap="Xs" class="font-mono text-sm mt-4">
+            <p>Total alerts: <span id="alert-total">&mdash;</span></p>
+            <p>Critical: <span id="critical-count">&mdash;</span></p>
+            <p>Critical priority sum: <span id="critical-priority-sum">&mdash;</span></p>
+            <p>Top critical (by priority): <span id="top-critical">&mdash;</span></p>
+            <p id="unack-warning" hidden class="text-red-600">&#9888; Unacknowledged critical alert present</p>
+            <p id="unack-clear" hidden class="text-green-600">All critical alerts acknowledged</p>
+        </native-vstack>
+    </native-card-body></native-card>
+</native-vstack>
+
+@Html.RenderPlan(plan)

--- a/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
+++ b/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
@@ -9,8 +9,8 @@ namespace Alis.Reactive.Builders.Arrays
     /// Compiles a captured per-element lambda into the closed plan-node algebra. A predicate
     /// becomes a SYNC <see cref="ConditionGraph"/> (compare/all/any/not) whose leaves read the
     /// element scope; reads rooted at the lambda parameter become element reads, everything else
-    /// is evaluated to a literal. Anything outside the whitelist throws at C# build time — the
-    /// same discipline as <c>ExpressionPathHelper</c>, and what keeps the DSL deterministic.
+    /// is evaluated to a literal. Anything outside the supported set throws at plan render time
+    /// (when the Razor view is first requested) — keeping the captured DSL deterministic.
     /// </summary>
     internal static class ElementExpressionCompiler
     {
@@ -34,7 +34,7 @@ namespace Alis.Reactive.Builders.Arrays
         /// <summary>
         /// Compiles a per-element value selector (<c>x =&gt; x.Balance</c>, <c>x =&gt; x</c>) to a
         /// value expression read against the element scope. v1 supports element member reads and
-        /// the element itself; richer projections (object init, arithmetic) throw at build time.
+        /// the element itself; richer projections (object init, arithmetic) throw at plan render time.
         /// </summary>
         internal static ValueExpression CompileProjection(LambdaExpression projection)
         {
@@ -109,9 +109,13 @@ namespace Alis.Reactive.Builders.Arrays
             // member's declared type, not from a literal. C# already forbids cross-category
             // comparisons, so this keeps a literal-on-left predicate (e.g. 65 < x.Age) shaped by
             // the member, not the literal.
-            var memberOperand = ReferencesParameter(left, element) ? left
-                : ReferencesParameter(right, element) ? right
-                : left;
+            Expression memberOperand;
+            if (ReferencesParameter(left, element)) memberOperand = left;
+            else if (ReferencesParameter(right, element)) memberOperand = right;
+            else throw new InvalidOperationException(
+                "Array predicate comparison must reference the element on at least one side; " +
+                "comparing two constants is a developer mistake. Got: " + binary);
+
             var shape = Shape.FromClrType(memberOperand.Type);
 
             return ConditionGraph.Compare(

--- a/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
+++ b/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
@@ -61,12 +61,20 @@ namespace Alis.Reactive.Builders.Arrays
                 return ConditionGraph.Not(CompileCondition(Unwrap(unary.Operand), element));
 
             if (body is MethodCallExpression call && call.Object != null && TryStringOperator(call, out var textOp))
+            {
+                var argument = Unwrap(call.Arguments[0]);
+                if (ReferencesParameter(argument, element))
+                    throw new InvalidOperationException(
+                        "String operation arguments (Contains/StartsWith/EndsWith) must be constants or captured " +
+                        "values, not element-scope reads — the runtime text operand requires a literal. Got: " + argument);
+
                 return ConditionGraph.Compare(
                     textOp,
                     ComparisonOperands.Binary(
                         CompileValue(Unwrap(call.Object), element),
-                        CompileValue(Unwrap(call.Arguments[0]), element),
+                        CompileValue(argument, element),
                         Shape.String));
+            }
 
             if (body.Type == typeof(bool))
                 return ConditionGraph.Compare(
@@ -167,7 +175,7 @@ namespace Alis.Reactive.Builders.Arrays
 
         private static bool TryStringOperator(MethodCallExpression call, out CompareOperator op)
         {
-            if (call.Object != null && call.Object.Type == typeof(string) && call.Arguments.Count == 1)
+            if (call.Object?.Type == typeof(string) && call.Arguments.Count == 1)
             {
                 switch (call.Method.Name)
                 {

--- a/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
+++ b/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
@@ -101,7 +101,19 @@ namespace Alis.Reactive.Builders.Arrays
         {
             var left = Unwrap(binary.Left);
             var right = Unwrap(binary.Right);
-            var shape = Shape.FromClrType(left.Type);
+
+            // The runtime coerces BOTH operands to one Shape before comparing (sync-condition
+            // applies condition.shape to each side, then ===), so the comparison Shape must come
+            // from the typed member operand — never positionally from whichever side is written
+            // first. This mirrors ConditionSourceBuilder, which derives its single shape from the
+            // member's declared type, not from a literal. C# already forbids cross-category
+            // comparisons, so this keeps a literal-on-left predicate (e.g. 65 < x.Age) shaped by
+            // the member, not the literal.
+            var memberOperand = ReferencesParameter(left, element) ? left
+                : ReferencesParameter(right, element) ? right
+                : left;
+            var shape = Shape.FromClrType(memberOperand.Type);
+
             return ConditionGraph.Compare(
                 CompareOperatorFor(binary.NodeType),
                 ComparisonOperands.Binary(CompileValue(left, element), CompileValue(right, element), shape));

--- a/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
+++ b/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
@@ -14,6 +14,16 @@ namespace Alis.Reactive.Builders.Arrays
     /// </summary>
     internal static class ElementExpressionCompiler
     {
+        // Pure, deterministic, side-effect-free element methods only. A per-element method call is a
+        // value projection, so it must not mutate; side-effecting methods (e.g. grid Row.setCellValue)
+        // belong in a per-element reaction (foreach), not a projection. Grow this set deliberately.
+        private static readonly HashSet<string> WhitelistedMethods = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "getDay", "getMonth", "getFullYear", "getDate", "getHours", "getMinutes", "getSeconds", "getTime",
+            "toUpperCase", "toLowerCase", "trim",
+            "getAttribute", "hasAttribute",
+        };
+
         internal static ConditionGraph CompilePredicate(LambdaExpression predicate)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
@@ -107,6 +117,24 @@ namespace Alis.Reactive.Builders.Arrays
                 return path.Length == 0
                     ? ValueExpression.ReadWholeElement(shape)
                     : ValueExpression.ReadPayload(PayloadSource.Element(), path, shape);
+            }
+
+            // Per-element method call (x => x.GetDay(), x => x.Address.GetFormatted()) — the receiver must
+            // be rooted at the element; the method must be whitelisted (pure). Reuses the RuntimePath.call engine.
+            if (node is MethodCallExpression call && call.Object != null && TryElementPath(call.Object, element, out var receiverPath))
+            {
+                var methodName = CamelCase(call.Method.Name);
+                if (!WhitelistedMethods.Contains(methodName))
+                    throw new InvalidOperationException(
+                        "Element method '" + methodName + "' is not whitelisted for the array DSL. Whitelist a PURE, " +
+                        "deterministic method in ElementExpressionCompiler.WhitelistedMethods, or use a server-side " +
+                        "projection. Side-effecting per-element calls need a reaction, not a projection. Got: " + node);
+
+                var methodArgs = new List<ValueExpression>();
+                foreach (var arg in call.Arguments)
+                    methodArgs.Add(CompileValue(Unwrap(arg), element));
+
+                return ValueExpression.InvokeElement(receiverPath, methodName, Shape.FromClrType(node.Type), methodArgs);
             }
 
             if (ReferencesParameter(node, element))

--- a/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
+++ b/Alis.Reactive/Builders/Arrays/ElementExpressionCompiler.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Builders.Arrays
+{
+    /// <summary>
+    /// Compiles a captured per-element lambda into the closed plan-node algebra. A predicate
+    /// becomes a SYNC <see cref="ConditionGraph"/> (compare/all/any/not) whose leaves read the
+    /// element scope; reads rooted at the lambda parameter become element reads, everything else
+    /// is evaluated to a literal. Anything outside the whitelist throws at C# build time — the
+    /// same discipline as <c>ExpressionPathHelper</c>, and what keeps the DSL deterministic.
+    /// </summary>
+    internal static class ElementExpressionCompiler
+    {
+        internal static ConditionGraph CompilePredicate(LambdaExpression predicate)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return CompileCondition(Unwrap(predicate.Body), predicate.Parameters[0]);
+        }
+
+        /// <summary>
+        /// Compiles a per-element value selector (<c>x =&gt; x.Balance</c>, <c>x =&gt; x</c>) to a
+        /// value expression read against the element scope. v1 supports element member reads and
+        /// the element itself; richer projections (object init, arithmetic) throw at build time.
+        /// </summary>
+        internal static ValueExpression CompileProjection(LambdaExpression projection)
+        {
+            if (projection == null) throw new ArgumentNullException(nameof(projection));
+
+            return CompileValue(Unwrap(projection.Body), projection.Parameters[0]);
+        }
+
+        private static ConditionGraph CompileCondition(Expression body, ParameterExpression element)
+        {
+            if (body is BinaryExpression binary)
+            {
+                switch (binary.NodeType)
+                {
+                    case ExpressionType.AndAlso:
+                        return ConditionGraph.All(
+                            CompileCondition(Unwrap(binary.Left), element),
+                            CompileCondition(Unwrap(binary.Right), element));
+                    case ExpressionType.OrElse:
+                        return ConditionGraph.Any(
+                            CompileCondition(Unwrap(binary.Left), element),
+                            CompileCondition(Unwrap(binary.Right), element));
+                    case ExpressionType.Equal:
+                    case ExpressionType.NotEqual:
+                    case ExpressionType.GreaterThan:
+                    case ExpressionType.GreaterThanOrEqual:
+                    case ExpressionType.LessThan:
+                    case ExpressionType.LessThanOrEqual:
+                        return CompileComparison(binary, element);
+                }
+            }
+
+            if (body is UnaryExpression unary && unary.NodeType == ExpressionType.Not)
+                return ConditionGraph.Not(CompileCondition(Unwrap(unary.Operand), element));
+
+            if (body is MethodCallExpression call && call.Object != null && TryStringOperator(call, out var textOp))
+                return ConditionGraph.Compare(
+                    textOp,
+                    ComparisonOperands.Binary(
+                        CompileValue(Unwrap(call.Object), element),
+                        CompileValue(Unwrap(call.Arguments[0]), element),
+                        Shape.String));
+
+            if (body.Type == typeof(bool))
+                return ConditionGraph.Compare(
+                    CompareOperator.Truthy,
+                    ComparisonOperands.Unary(CompileValue(body, element), Shape.Boolean));
+
+            throw new InvalidOperationException(
+                "Array predicate supports comparisons (== != > >= < <=), logical (&& || !), " +
+                "string Contains/StartsWith/EndsWith, and boolean members. Unsupported node: " +
+                body.NodeType + " (" + body + ").");
+        }
+
+        private static ConditionGraph CompileComparison(BinaryExpression binary, ParameterExpression element)
+        {
+            var left = Unwrap(binary.Left);
+            var right = Unwrap(binary.Right);
+            var shape = Shape.FromClrType(left.Type);
+            return ConditionGraph.Compare(
+                CompareOperatorFor(binary.NodeType),
+                ComparisonOperands.Binary(CompileValue(left, element), CompileValue(right, element), shape));
+        }
+
+        private static ValueExpression CompileValue(Expression expression, ParameterExpression element)
+        {
+            var node = Unwrap(expression);
+
+            if (TryElementPath(node, element, out var path))
+            {
+                var shape = Shape.FromClrType(node.Type);
+                return path.Length == 0
+                    ? ValueExpression.ReadWholeElement(shape)
+                    : ValueExpression.ReadPayload(PayloadSource.Element(), path, shape);
+            }
+
+            if (ReferencesParameter(node, element))
+                throw new InvalidOperationException(
+                    "Element selector must be a member access (x => x.Field, x => x.A.B) or the element " +
+                    "itself (x => x). Object-init and arithmetic projections are not supported in v1. Got: " + node);
+
+            // Parameter-free: a constant or captured value — evaluate it to a literal.
+            var value = Expression.Lambda(node).Compile().DynamicInvoke();
+            return ValueExpression.LiteralFromValue(value);
+        }
+
+        private static bool ReferencesParameter(Expression expression, ParameterExpression element)
+        {
+            var finder = new ParameterUsageVisitor(element);
+            finder.Visit(expression);
+            return finder.Found;
+        }
+
+        private sealed class ParameterUsageVisitor : ExpressionVisitor
+        {
+            private readonly ParameterExpression _parameter;
+
+            internal ParameterUsageVisitor(ParameterExpression parameter) => _parameter = parameter;
+
+            internal bool Found { get; private set; }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if (node == _parameter) Found = true;
+                return base.VisitParameter(node);
+            }
+        }
+
+        private static bool TryElementPath(Expression expression, ParameterExpression element, out string path)
+        {
+            var segments = new List<string>();
+            var current = Unwrap(expression);
+            while (current is MemberExpression member && member.Expression != null)
+            {
+                segments.Insert(0, CamelCase(member.Member.Name));
+                current = Unwrap(member.Expression);
+            }
+
+            if (current == element)
+            {
+                path = string.Join(".", segments);
+                return true;
+            }
+
+            path = string.Empty;
+            return false;
+        }
+
+        private static CompareOperator CompareOperatorFor(ExpressionType nodeType) =>
+            nodeType switch
+            {
+                ExpressionType.Equal => CompareOperator.Eq,
+                ExpressionType.NotEqual => CompareOperator.Neq,
+                ExpressionType.GreaterThan => CompareOperator.Gt,
+                ExpressionType.GreaterThanOrEqual => CompareOperator.Gte,
+                ExpressionType.LessThan => CompareOperator.Lt,
+                ExpressionType.LessThanOrEqual => CompareOperator.Lte,
+                _ => throw new InvalidOperationException("Unsupported comparison node: " + nodeType),
+            };
+
+        private static bool TryStringOperator(MethodCallExpression call, out CompareOperator op)
+        {
+            if (call.Object != null && call.Object.Type == typeof(string) && call.Arguments.Count == 1)
+            {
+                switch (call.Method.Name)
+                {
+                    case "Contains": op = CompareOperator.Contains; return true;
+                    case "StartsWith": op = CompareOperator.StartsWith; return true;
+                    case "EndsWith": op = CompareOperator.EndsWith; return true;
+                }
+            }
+
+            op = CompareOperator.Eq;
+            return false;
+        }
+
+        private static Expression Unwrap(Expression expression)
+        {
+            while (expression is UnaryExpression unary &&
+                   (unary.NodeType == ExpressionType.Convert || unary.NodeType == ExpressionType.ConvertChecked))
+            {
+                expression = unary.Operand;
+            }
+
+            return expression;
+        }
+
+        private static string CamelCase(string name) =>
+            string.IsNullOrEmpty(name) ? name : char.ToLowerInvariant(name[0]) + name.Substring(1);
+    }
+}

--- a/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
+++ b/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using Alis.Reactive.Builders.Conditions;
 using Alis.Reactive.PlanModel;
 
 namespace Alis.Reactive.Builders.Arrays
@@ -97,6 +98,14 @@ namespace Alis.Reactive.Builders.Arrays
                 ValueExpression.ArrayFind(_source, Predicate(predicate), Projection(selector), _elementShape, fieldShape));
         }
 
+        /// <summary>
+        /// Exposes the composed array as a typed source so the transformed array can bind to a
+        /// component data source wherever a <see cref="TypedSource{T}"/> is accepted (e.g. a
+        /// <c>SetDataSource(TypedSource&lt;T[]&gt;)</c> overload) — without an HTTP round-trip. The
+        /// underlying value is the same array-op expression the runtime already evaluates.
+        /// </summary>
+        public TypedSource<TElement[]> AsSource() => new ReactiveArraySource<TElement>(_source);
+
         private static ConditionGraph Predicate(Expression<Func<TElement, bool>> predicate)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
@@ -108,5 +117,18 @@ namespace Alis.Reactive.Builders.Arrays
             if (selector == null) throw new ArgumentNullException(nameof(selector));
             return ElementExpressionCompiler.CompileProjection(selector);
         }
+    }
+
+    /// <summary>An array-op result exposed as a typed source for component data-source binding.</summary>
+    internal sealed class ReactiveArraySource<TElement> : TypedSource<TElement[]>
+    {
+        private readonly ValueExpression _value;
+
+        internal ReactiveArraySource(ValueExpression value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        internal override ValueExpression ToValueExpression() => _value;
     }
 }

--- a/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
+++ b/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
@@ -47,10 +47,24 @@ namespace Alis.Reactive.Builders.Arrays
         public ReactiveArray<TElement> OrderByDescending<TKey>(Expression<Func<TElement, TKey>> key) =>
             Order(key, descending: true);
 
-        private ReactiveArray<TElement> Order<TKey>(Expression<Func<TElement, TKey>> key, bool descending) =>
-            new ReactiveArray<TElement>(
+        private ReactiveArray<TElement> Order<TKey>(Expression<Func<TElement, TKey>> key, bool descending)
+        {
+            // A sort key must coerce to a comparable scalar. A non-scalar key (object/collection)
+            // serializes as Shape.Any, and the runtime would fall back to lexicographic
+            // String(value) order — every element becomes "[object Object]", silently wrong.
+            // Reject it where it is authored rather than mis-sorting in the browser.
+            var keyKind = Shape.FromClrType(typeof(TKey)).Kind;
+            var keyIsSortableScalar = keyKind is "string" or "number" or "boolean" or "date" or "nullable";
+            if (!keyIsSortableScalar)
+                throw new InvalidOperationException(
+                    "OrderBy key must project to a scalar (string, number, date, bool, enum), not '" +
+                    typeof(TKey).Name + "'. Project a scalar field, e.g. .OrderBy(x => x.StartDate), " +
+                    "not .OrderBy(x => x.Address).");
+
+            return new ReactiveArray<TElement>(
                 ValueExpression.ArrayOrderBy(_source, Projection(key), _elementShape, descending),
                 _elementShape);
+        }
 
         /// <summary>Counts all elements.</summary>
         public ReactiveValue<int> Count() =>

--- a/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
+++ b/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
@@ -1,0 +1,28 @@
+using System;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Builders.Arrays
+{
+    /// <summary>
+    /// A typed, deferred array transform. Operators capture authoring intent and compile to
+    /// plan-JSON <c>array-op</c> nodes — nothing executes on the server. Deliberately NOT
+    /// <see cref="System.Collections.IEnumerable"/>/<c>IQueryable</c>, so LINQ extension methods
+    /// are not candidates (no collision) and lambdas are captured, not invoked.
+    /// </summary>
+    /// <typeparam name="TElement">The element type, carried through transforms.</typeparam>
+    public sealed class ReactiveArray<TElement>
+    {
+        private readonly ValueExpression _source;
+        private readonly Shape _elementShape;
+
+        internal ReactiveArray(ValueExpression source, Shape elementShape)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            _elementShape = elementShape ?? throw new ArgumentNullException(nameof(elementShape));
+        }
+
+        /// <summary>Counts the elements of the source array.</summary>
+        public ReactiveValue<int> Count() =>
+            new ReactiveValue<int>(ValueExpression.ArrayCount(_source, _elementShape));
+    }
+}

--- a/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
+++ b/Alis.Reactive/Builders/Arrays/ReactiveArray.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq.Expressions;
 using Alis.Reactive.PlanModel;
 
 namespace Alis.Reactive.Builders.Arrays
@@ -7,7 +8,8 @@ namespace Alis.Reactive.Builders.Arrays
     /// A typed, deferred array transform. Operators capture authoring intent and compile to
     /// plan-JSON <c>array-op</c> nodes — nothing executes on the server. Deliberately NOT
     /// <see cref="System.Collections.IEnumerable"/>/<c>IQueryable</c>, so LINQ extension methods
-    /// are not candidates (no collision) and lambdas are captured, not invoked.
+    /// are not candidates (no collision) and lambdas are captured, not invoked. Per-element
+    /// predicates and selectors read the element scope; chains compose (filter then sum, etc.).
     /// </summary>
     /// <typeparam name="TElement">The element type, carried through transforms.</typeparam>
     public sealed class ReactiveArray<TElement>
@@ -21,8 +23,90 @@ namespace Alis.Reactive.Builders.Arrays
             _elementShape = elementShape ?? throw new ArgumentNullException(nameof(elementShape));
         }
 
-        /// <summary>Counts the elements of the source array.</summary>
+        /// <summary>Keeps only the elements that match the per-element predicate.</summary>
+        public ReactiveArray<TElement> Where(Expression<Func<TElement, bool>> predicate) =>
+            new ReactiveArray<TElement>(
+                ValueExpression.ArrayFilter(_source, Predicate(predicate), _elementShape),
+                _elementShape);
+
+        /// <summary>Projects each element through a per-element selector.</summary>
+        public ReactiveArray<TResult> Select<TResult>(Expression<Func<TElement, TResult>> selector)
+        {
+            var resultShape = Shape.FromClrType(typeof(TResult));
+            return new ReactiveArray<TResult>(
+                ValueExpression.ArrayMap(_source, Projection(selector), _elementShape, resultShape),
+                resultShape);
+        }
+
+        /// <summary>Orders elements ascending by a per-element key.</summary>
+        public ReactiveArray<TElement> OrderBy<TKey>(Expression<Func<TElement, TKey>> key) =>
+            Order(key, descending: false);
+
+        /// <summary>Orders elements descending by a per-element key.</summary>
+        public ReactiveArray<TElement> OrderByDescending<TKey>(Expression<Func<TElement, TKey>> key) =>
+            Order(key, descending: true);
+
+        private ReactiveArray<TElement> Order<TKey>(Expression<Func<TElement, TKey>> key, bool descending) =>
+            new ReactiveArray<TElement>(
+                ValueExpression.ArrayOrderBy(_source, Projection(key), _elementShape, descending),
+                _elementShape);
+
+        /// <summary>Counts all elements.</summary>
         public ReactiveValue<int> Count() =>
             new ReactiveValue<int>(ValueExpression.ArrayCount(_source, _elementShape));
+
+        /// <summary>Counts the elements that match the predicate.</summary>
+        public ReactiveValue<int> Count(Expression<Func<TElement, bool>> predicate) =>
+            Where(predicate).Count();
+
+        /// <summary>True when the array is non-empty.</summary>
+        public ReactiveValue<bool> Any() =>
+            new ReactiveValue<bool>(ValueExpression.ArrayAny(_source, predicate: null, _elementShape));
+
+        /// <summary>True when any element matches the predicate.</summary>
+        public ReactiveValue<bool> Any(Expression<Func<TElement, bool>> predicate) =>
+            new ReactiveValue<bool>(ValueExpression.ArrayAny(_source, Predicate(predicate), _elementShape));
+
+        /// <summary>True when every element matches the predicate.</summary>
+        public ReactiveValue<bool> All(Expression<Func<TElement, bool>> predicate) =>
+            new ReactiveValue<bool>(ValueExpression.ArrayAll(_source, Predicate(predicate), _elementShape));
+
+        /// <summary>Sums an integer per-element selector.</summary>
+        public ReactiveValue<int> Sum(Expression<Func<TElement, int>> selector) =>
+            new ReactiveValue<int>(ValueExpression.ArraySum(_source, Projection(selector), _elementShape));
+
+        /// <summary>Sums a decimal per-element selector.</summary>
+        public ReactiveValue<decimal> Sum(Expression<Func<TElement, decimal>> selector) =>
+            new ReactiveValue<decimal>(ValueExpression.ArraySum(_source, Projection(selector), _elementShape));
+
+        /// <summary>Sums a double per-element selector.</summary>
+        public ReactiveValue<double> Sum(Expression<Func<TElement, double>> selector) =>
+            new ReactiveValue<double>(ValueExpression.ArraySum(_source, Projection(selector), _elementShape));
+
+        /// <summary>Returns the first element matching the predicate (or null when none match).</summary>
+        public ReactiveValue<TElement> Find(Expression<Func<TElement, bool>> predicate) =>
+            new ReactiveValue<TElement>(
+                ValueExpression.ArrayFind(_source, Predicate(predicate), projection: null, _elementShape, _elementShape));
+
+        /// <summary>Returns a per-element field of the first element matching the predicate.</summary>
+        public ReactiveValue<TField> Find<TField>(
+            Expression<Func<TElement, bool>> predicate, Expression<Func<TElement, TField>> selector)
+        {
+            var fieldShape = Shape.FromClrType(typeof(TField));
+            return new ReactiveValue<TField>(
+                ValueExpression.ArrayFind(_source, Predicate(predicate), Projection(selector), _elementShape, fieldShape));
+        }
+
+        private static ConditionGraph Predicate(Expression<Func<TElement, bool>> predicate)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            return ElementExpressionCompiler.CompilePredicate(predicate);
+        }
+
+        private static ValueExpression Projection<TValue>(Expression<Func<TElement, TValue>> selector)
+        {
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+            return ElementExpressionCompiler.CompileProjection(selector);
+        }
     }
 }

--- a/Alis.Reactive/Builders/Arrays/ReactiveValue.cs
+++ b/Alis.Reactive/Builders/Arrays/ReactiveValue.cs
@@ -6,8 +6,9 @@ namespace Alis.Reactive.Builders.Arrays
 {
     /// <summary>
     /// A scalar value produced by an array operation (count, sum, any, find, ...). It is a
-    /// <see cref="TypedSource{TValue}"/>, so it plugs into every place a source is accepted —
-    /// <c>SetText</c>, <c>When</c>, dispatch payloads, and gather — with no new overloads.
+    /// <see cref="TypedSource{TValue}"/>, so it plugs into the places that accept the base
+    /// <c>TypedSource&lt;T&gt;</c> — <c>SetText</c>, <c>When</c>, and dispatch payloads — with no new
+    /// overloads. (Gather intake is typed to component/plugin sources, not the base source.)
     /// </summary>
     public sealed class ReactiveValue<TValue> : TypedSource<TValue>
     {

--- a/Alis.Reactive/Builders/Arrays/ReactiveValue.cs
+++ b/Alis.Reactive/Builders/Arrays/ReactiveValue.cs
@@ -1,0 +1,23 @@
+using System;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Builders.Arrays
+{
+    /// <summary>
+    /// A scalar value produced by an array operation (count, sum, any, find, ...). It is a
+    /// <see cref="TypedSource{TValue}"/>, so it plugs into every place a source is accepted —
+    /// <c>SetText</c>, <c>When</c>, dispatch payloads, and gather — with no new overloads.
+    /// </summary>
+    public sealed class ReactiveValue<TValue> : TypedSource<TValue>
+    {
+        private readonly ValueExpression _value;
+
+        internal ReactiveValue(ValueExpression value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        internal override ValueExpression ToValueExpression() => _value;
+    }
+}

--- a/Alis.Reactive/Builders/PipelineBuilder.Arrays.cs
+++ b/Alis.Reactive/Builders/PipelineBuilder.Arrays.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq.Expressions;
+using Alis.Reactive.Builders.Arrays;
+using Alis.Reactive.Builders.Conditions;
+using Alis.Reactive.PlanModel;
+
+namespace Alis.Reactive.Builders
+{
+    public partial class PipelineBuilder<TModel> where TModel : class
+    {
+        /// <summary>
+        /// Begins a typed array transform over a component/method array source, e.g.
+        /// <c>p.From(p.Component&lt;FusionMultiSelect&gt;(m =&gt; m.Tags).Value())</c>.
+        /// </summary>
+        public ReactiveArray<TElement> From<TElement>(TypedSource<TElement[]> source) =>
+            new ReactiveArray<TElement>(source.ToValueExpression(), Shape.FromClrType(typeof(TElement)));
+
+        /// <summary>
+        /// Begins a typed array transform over a <c>.Reactive()</c> event-payload array, e.g.
+        /// <c>p.From(args, e =&gt; e.Data)</c> where <c>e.Data</c> is <c>T[]</c>. The element type
+        /// flows through the chain; the lambda is captured into a plan read, never invoked.
+        /// </summary>
+        public ReactiveArray<TElement> From<TArgs, TElement>(TArgs args, Expression<Func<TArgs, TElement[]>> selector)
+        {
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+
+            var source = PayloadTypedSource<TArgs, TElement[]>.FromEvent(selector);
+            return new ReactiveArray<TElement>(source.ToValueExpression(), Shape.FromClrType(typeof(TElement)));
+        }
+    }
+}

--- a/Alis.Reactive/Builders/PipelineBuilder.Arrays.cs
+++ b/Alis.Reactive/Builders/PipelineBuilder.Arrays.cs
@@ -27,5 +27,18 @@ namespace Alis.Reactive.Builders
             var source = PayloadTypedSource<TArgs, TElement[]>.FromEvent(selector);
             return new ReactiveArray<TElement>(source.ToValueExpression(), Shape.FromClrType(typeof(TElement)));
         }
+
+        /// <summary>
+        /// Begins a typed array transform over a DOM element's array-like member (e.g.
+        /// <c>p.FromDom("resident-card", "classList")</c>). The element is resolved by
+        /// getElementById and the member read with RuntimePath; array-like collections
+        /// (DOMTokenList, HTMLCollection, NodeList) are normalized at the array-op boundary.
+        /// </summary>
+        public ReactiveArray<string> FromDom(string elementId, string member) =>
+            new ReactiveArray<string>(ValueExpression.ReadDom(elementId, member, Shape.None), Shape.String);
+
+        /// <summary>DOM array-like member of a declared element type (e.g. child elements).</summary>
+        public ReactiveArray<TElement> FromDom<TElement>(string elementId, string member) =>
+            new ReactiveArray<TElement>(ValueExpression.ReadDom(elementId, member, Shape.None), Shape.FromClrType(typeof(TElement)));
     }
 }

--- a/Alis.Reactive/PlanModel/PlanTerms.cs
+++ b/Alis.Reactive/PlanModel/PlanTerms.cs
@@ -401,6 +401,7 @@ namespace Alis.Reactive.PlanModel
                 { "request", new PayloadScope("request") },
                 { "dispatch", new PayloadScope("dispatch") },
                 { "local", new PayloadScope("local") },
+                { "element", new PayloadScope("element") },
             };
 
         private PayloadScope(string value) : base(value, nameof(value)) { }
@@ -411,6 +412,7 @@ namespace Alis.Reactive.PlanModel
         internal static PayloadScope Request => Known["request"];
         internal static PayloadScope Dispatch => Known["dispatch"];
         internal static PayloadScope Local => Known["local"];
+        internal static PayloadScope Element => Known["element"];
         internal static IReadOnlyCollection<string> Values => Known.Keys;
 
         internal static PayloadScope From(string value)

--- a/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
+++ b/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
@@ -547,7 +547,8 @@ namespace Alis.Reactive.PlanModel
                 "ObjectMethodReadExpression",
                 "UrlParameterReadExpression",
                 "PayloadPathReadExpression",
-                "WholePayloadReadExpression"));
+                "WholePayloadReadExpression",
+                "WholeElementReadExpression"));
 
             contract.Declare(Interface("LiteralExpression")
                 .Requires("kind", Literal("literal"))
@@ -605,6 +606,14 @@ namespace Alis.Reactive.PlanModel
                 .Requires("kind", Literal("read"))
                 .Requires("from", "PayloadSource")
                 .Requires("member", Literal("responseBody"))
+                .Requires("path", "EmptyPath")
+                .Requires("shape", "Shape")
+                .Requires("access", "PropertyValueReadAccess"));
+
+            contract.Declare(Interface("WholeElementReadExpression")
+                .Requires("kind", Literal("read"))
+                .Requires("from", "PayloadSource")
+                .Requires("member", Literal("elementValue"))
                 .Requires("path", "EmptyPath")
                 .Requires("shape", "Shape")
                 .Requires("access", "PropertyValueReadAccess"));

--- a/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
+++ b/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
@@ -641,13 +641,17 @@ namespace Alis.Reactive.PlanModel
                 .Requires("items", "ValueExpression[]")
                 .Requires("shape", "Shape"));
 
-            contract.Declare(LiteralUnion("ArrayOp", new[] { "count", "filter" }));
+            contract.Declare(LiteralUnion("ArrayOp", new[]
+            {
+                "count", "filter", "map", "sum", "any", "all", "find", "orderBy", "orderByDescending",
+            }));
 
             contract.Declare(Interface("ArrayOperationExpression")
                 .Requires("kind", Literal("array-op"))
                 .Requires("op", "ArrayOp")
                 .Requires("source", "ValueExpression")
                 .Optional("predicate", "ValidationCondition")
+                .Optional("projection", "ValueExpression")
                 .Requires("itemShape", "Shape")
                 .Requires("shape", "Shape"));
 

--- a/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
+++ b/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
@@ -641,12 +641,13 @@ namespace Alis.Reactive.PlanModel
                 .Requires("items", "ValueExpression[]")
                 .Requires("shape", "Shape"));
 
-            contract.Declare(LiteralUnion("ArrayOp", new[] { "count" }));
+            contract.Declare(LiteralUnion("ArrayOp", new[] { "count", "filter" }));
 
             contract.Declare(Interface("ArrayOperationExpression")
                 .Requires("kind", Literal("array-op"))
                 .Requires("op", "ArrayOp")
                 .Requires("source", "ValueExpression")
+                .Optional("predicate", "ValidationCondition")
                 .Requires("itemShape", "Shape")
                 .Requires("shape", "Shape"));
 
@@ -974,6 +975,12 @@ namespace Alis.Reactive.PlanModel
             return this;
         }
 
+        internal TypeScriptInterface Optional(string name, string type)
+        {
+            _properties.Add(TypeScriptProperty.Optional(name, type));
+            return this;
+        }
+
         internal override void Render(TypeScriptWriter writer)
         {
             writer.Line("export interface " + _name + " {");
@@ -989,8 +996,9 @@ namespace Alis.Reactive.PlanModel
     {
         private readonly string _name;
         private readonly string _type;
+        private readonly bool _optional;
 
-        private TypeScriptProperty(string name, string type)
+        private TypeScriptProperty(string name, string type, bool optional)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Property name is required.", nameof(name));
@@ -999,14 +1007,18 @@ namespace Alis.Reactive.PlanModel
 
             _name = name;
             _type = type;
+            _optional = optional;
         }
 
         internal static TypeScriptProperty Required(string name, string type) =>
-            new TypeScriptProperty(name, type);
+            new TypeScriptProperty(name, type, false);
+
+        internal static TypeScriptProperty Optional(string name, string type) =>
+            new TypeScriptProperty(name, type, true);
 
         internal void Render(TypeScriptWriter writer)
         {
-            writer.Line(_name + ": " + _type + ";");
+            writer.Line(_name + (_optional ? "?" : string.Empty) + ": " + _type + ";");
         }
     }
 

--- a/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
+++ b/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
@@ -266,7 +266,7 @@ namespace Alis.Reactive.PlanModel
                 .Requires("kind", Literal("when"))
                 .Requires("condition", "ValidationCondition"));
 
-            contract.Declare(Union("Source", "ComponentSource", "PayloadSource", "UrlSource", "PluginSource"));
+            contract.Declare(Union("Source", "ComponentSource", "PayloadSource", "UrlSource", "PluginSource", "DomSource"));
             contract.Declare(Union("RuntimeObjectSource", "ComponentSource", "PluginSource"));
             contract.Declare(Union("SetTargetSource", "ComponentSource", "PayloadSource"));
             contract.Declare(Union("CallTargetSource", "ComponentSource", "PayloadSource", "PluginSource"));
@@ -277,6 +277,10 @@ namespace Alis.Reactive.PlanModel
 
             contract.Declare(Interface("UrlSource")
                 .Requires("kind", Literal("url")));
+
+            contract.Declare(Interface("DomSource")
+                .Requires("kind", Literal("dom"))
+                .Requires("element", "string"));
 
             contract.Declare(Interface("PluginSource")
                 .Requires("kind", Literal("plugin"))
@@ -549,7 +553,8 @@ namespace Alis.Reactive.PlanModel
                 "UrlParameterReadExpression",
                 "PayloadPathReadExpression",
                 "WholePayloadReadExpression",
-                "WholeElementReadExpression"));
+                "WholeElementReadExpression",
+                "DomPropertyReadExpression"));
 
             contract.Declare(Interface("LiteralExpression")
                 .Requires("kind", Literal("literal"))
@@ -616,6 +621,14 @@ namespace Alis.Reactive.PlanModel
                 .Requires("from", "PayloadSource")
                 .Requires("member", Literal("elementValue"))
                 .Requires("path", "EmptyPath")
+                .Requires("shape", "Shape")
+                .Requires("access", "PropertyValueReadAccess"));
+
+            contract.Declare(Interface("DomPropertyReadExpression")
+                .Requires("kind", Literal("read"))
+                .Requires("from", "DomSource")
+                .Requires("member", "string")
+                .Requires("path", "StructuredPath")
                 .Requires("shape", "Shape")
                 .Requires("access", "PropertyValueReadAccess"));
 

--- a/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
+++ b/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
@@ -539,7 +539,8 @@ namespace Alis.Reactive.PlanModel
                 "LiteralExpression",
                 "ReadExpression",
                 "ObjectExpression",
-                "ArrayExpression"));
+                "ArrayExpression",
+                "ArrayOperationExpression"));
 
             contract.Declare(Union(
                 "ReadExpression",
@@ -638,6 +639,15 @@ namespace Alis.Reactive.PlanModel
             contract.Declare(Interface("ArrayExpression")
                 .Requires("kind", Literal("array"))
                 .Requires("items", "ValueExpression[]")
+                .Requires("shape", "Shape"));
+
+            contract.Declare(LiteralUnion("ArrayOp", new[] { "count" }));
+
+            contract.Declare(Interface("ArrayOperationExpression")
+                .Requires("kind", Literal("array-op"))
+                .Requires("op", "ArrayOp")
+                .Requires("source", "ValueExpression")
+                .Requires("itemShape", "Shape")
                 .Requires("shape", "Shape"));
 
             contract.Declare(Union(

--- a/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
+++ b/Alis.Reactive/PlanModel/PlanTypeScriptContract.cs
@@ -554,7 +554,8 @@ namespace Alis.Reactive.PlanModel
                 "PayloadPathReadExpression",
                 "WholePayloadReadExpression",
                 "WholeElementReadExpression",
-                "DomPropertyReadExpression"));
+                "DomPropertyReadExpression",
+                "ElementMethodReadExpression"));
 
             contract.Declare(Interface("LiteralExpression")
                 .Requires("kind", Literal("literal"))
@@ -631,6 +632,14 @@ namespace Alis.Reactive.PlanModel
                 .Requires("path", "StructuredPath")
                 .Requires("shape", "Shape")
                 .Requires("access", "PropertyValueReadAccess"));
+
+            contract.Declare(Interface("ElementMethodReadExpression")
+                .Requires("kind", Literal("read"))
+                .Requires("from", "PayloadSource")
+                .Requires("member", "string")
+                .Requires("path", "StructuredPath")
+                .Requires("shape", "Shape")
+                .Requires("access", "MethodValueReadAccess"));
 
             contract.Declare(Union(
                 "ValueReadAccess",

--- a/Alis.Reactive/PlanModel/Source.cs
+++ b/Alis.Reactive/PlanModel/Source.cs
@@ -125,4 +125,28 @@ namespace Alis.Reactive.PlanModel
         private UrlSource() { }
         internal static UrlSource Instance { get; } = new UrlSource();
     }
+
+    /// <summary>Identifies a DOM element (by id) whose members are read directly via getElementById.</summary>
+    /// <remarks>
+    /// A DOM element is a JS object; its members are reached with the same RuntimePath primitive
+    /// that resolves component/plugin members — no BrowserObjectContract is required. Element ids
+    /// are plan-carried (Rule 7: getElementById only, no scanning). The member name is stringly at
+    /// this DOM boundary, like plugin names.
+    /// </remarks>
+    public sealed class DomSource : Source
+    {
+        private readonly string _element;
+
+        /// <summary>Gets the kind. Always <c>"dom"</c>.</summary>
+        public string Kind => "dom";
+        /// <summary>Gets the element id resolved via getElementById.</summary>
+        public string Element => _element;
+
+        private DomSource(string element)
+        {
+            _element = element ?? throw new ArgumentNullException(nameof(element));
+        }
+
+        internal static DomSource Of(string element) => new DomSource(element);
+    }
 }

--- a/Alis.Reactive/PlanModel/Source.cs
+++ b/Alis.Reactive/PlanModel/Source.cs
@@ -92,6 +92,9 @@ namespace Alis.Reactive.PlanModel
         internal static PayloadSource Dispatch(string type) => Dispatch(PayloadContract.Named(type));
 
         internal static PayloadSource Local() => new PayloadSource(PayloadScope.Local, PayloadContract.Untyped);
+
+        /// <summary>The current array element under an array operation (top of the element scope stack).</summary>
+        internal static PayloadSource Element() => new PayloadSource(PayloadScope.Element, PayloadContract.Untyped);
     }
 
     /// <summary>Reads a value from a named plugin object registered by the application.</summary>

--- a/Alis.Reactive/PlanModel/ValueExpression.cs
+++ b/Alis.Reactive/PlanModel/ValueExpression.cs
@@ -129,6 +129,32 @@ namespace Alis.Reactive.PlanModel
         internal static ValueExpression ArrayFilter(ValueExpression source, ConditionGraph predicate, Shape itemShape) =>
             new ArrayOperationExpression("filter", source, itemShape, Shape.ArrayOf(itemShape), predicate);
 
+        /// <summary>Projects each element through a per-element value expression.</summary>
+        internal static ValueExpression ArrayMap(ValueExpression source, ValueExpression projection, Shape itemShape, Shape resultItemShape) =>
+            new ArrayOperationExpression("map", source, itemShape, Shape.ArrayOf(resultItemShape), predicate: null, projection: projection);
+
+        /// <summary>Sums a numeric per-element projection (or the elements themselves when projection is null).</summary>
+        internal static ValueExpression ArraySum(ValueExpression source, ValueExpression? projection, Shape itemShape) =>
+            new ArrayOperationExpression("sum", source, itemShape, Shape.Number, predicate: null, projection: projection);
+
+        /// <summary>True when any element matches the predicate (or the array is non-empty when predicate is null).</summary>
+        internal static ValueExpression ArrayAny(ValueExpression source, ConditionGraph? predicate, Shape itemShape) =>
+            new ArrayOperationExpression("any", source, itemShape, Shape.Boolean, predicate: predicate);
+
+        /// <summary>True when every element matches the predicate.</summary>
+        internal static ValueExpression ArrayAll(ValueExpression source, ConditionGraph predicate, Shape itemShape) =>
+            new ArrayOperationExpression("all", source, itemShape, Shape.Boolean, predicate: predicate);
+
+        /// <summary>Returns the first matching element (optionally projected), or null when none match.</summary>
+        internal static ValueExpression ArrayFind(
+            ValueExpression source, ConditionGraph? predicate, ValueExpression? projection, Shape itemShape, Shape resultShape) =>
+            new ArrayOperationExpression("find", source, itemShape, resultShape, predicate: predicate, projection: projection);
+
+        /// <summary>Orders elements by a per-element key projection (ascending or descending).</summary>
+        internal static ValueExpression ArrayOrderBy(ValueExpression source, ValueExpression key, Shape itemShape, bool descending) =>
+            new ArrayOperationExpression(
+                descending ? "orderByDescending" : "orderBy", source, itemShape, Shape.ArrayOf(itemShape), predicate: null, projection: key);
+
         private static (IReadOnlyDictionary<string, ValueExpression> Fields, Shape Shape) ObjectFields(
             IReadOnlyDictionary<string, ValueExpression> fields)
         {
@@ -508,19 +534,33 @@ namespace Alis.Reactive.PlanModel
         /// </remarks>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ConditionGraph? Predicate { get; }
+        /// <summary>Gets the per-element projection for map/sum/find/orderBy, or null when unused.</summary>
+        /// <remarks>
+        /// Nullable by design (Rule 6): absent for count/filter/any/all; present for map (the
+        /// projected shape), sum/orderBy (the numeric/key selector), and find (optional field
+        /// fold). It is a value expression evaluated against the element scope.
+        /// </remarks>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ValueExpression? Projection { get; }
         /// <summary>Gets the declared element shape of the source array.</summary>
         public Shape ItemShape { get; }
         /// <summary>Gets the declared output shape of the operation.</summary>
         public Shape Shape { get; }
 
         internal ArrayOperationExpression(
-            string op, ValueExpression source, Shape itemShape, Shape shape, ConditionGraph? predicate = null)
+            string op,
+            ValueExpression source,
+            Shape itemShape,
+            Shape shape,
+            ConditionGraph? predicate = null,
+            ValueExpression? projection = null)
         {
             Op = op ?? throw new ArgumentNullException(nameof(op));
             Source = source ?? throw new ArgumentNullException(nameof(source));
             ItemShape = itemShape ?? throw new ArgumentNullException(nameof(itemShape));
             Shape = shape ?? throw new ArgumentNullException(nameof(shape));
             Predicate = predicate;
+            Projection = projection;
         }
 
         internal override Shape OutputShape => Shape;

--- a/Alis.Reactive/PlanModel/ValueExpression.cs
+++ b/Alis.Reactive/PlanModel/ValueExpression.cs
@@ -121,6 +121,10 @@ namespace Alis.Reactive.PlanModel
             return new ArrayExpression(arrayItems.Items, shape);
         }
 
+        /// <summary>Counts the elements produced by <paramref name="source"/> (a value of array shape).</summary>
+        internal static ValueExpression ArrayCount(ValueExpression source, Shape itemShape) =>
+            new ArrayOperationExpression("count", source, itemShape, Shape.Number);
+
         private static (IReadOnlyDictionary<string, ValueExpression> Fields, Shape Shape) ObjectFields(
             IReadOnlyDictionary<string, ValueExpression> fields)
         {
@@ -469,6 +473,37 @@ namespace Alis.Reactive.PlanModel
         internal ArrayExpression(IReadOnlyList<ValueExpression> items, Shape shape)
         {
             _items = items ?? throw new ArgumentNullException(nameof(items));
+            Shape = shape ?? throw new ArgumentNullException(nameof(shape));
+        }
+
+        internal override Shape OutputShape => Shape;
+    }
+
+    /// <summary>A deterministic operation over the elements of an array-shaped value.</summary>
+    /// <remarks>
+    /// One node, op sub-discriminator (mirrors <c>CompareCondition</c>). The runtime
+    /// iterates the source array — normalizing array-like/iterable browser values at the
+    /// input boundary — and produces the declared output. Predicate and projection
+    /// operands are added by the ops that use them (filter/map/sum/find/...).
+    /// </remarks>
+    public sealed class ArrayOperationExpression : ValueExpression
+    {
+        /// <summary>Gets the kind. Always <c>"array-op"</c>.</summary>
+        public string Kind => "array-op";
+        /// <summary>Gets the operation: <c>count</c> (and, as ops land, filter/map/sum/...).</summary>
+        public string Op { get; }
+        /// <summary>Gets the value expression that produces the source array.</summary>
+        public ValueExpression Source { get; }
+        /// <summary>Gets the declared element shape of the source array.</summary>
+        public Shape ItemShape { get; }
+        /// <summary>Gets the declared output shape of the operation.</summary>
+        public Shape Shape { get; }
+
+        internal ArrayOperationExpression(string op, ValueExpression source, Shape itemShape, Shape shape)
+        {
+            Op = op ?? throw new ArgumentNullException(nameof(op));
+            Source = source ?? throw new ArgumentNullException(nameof(source));
+            ItemShape = itemShape ?? throw new ArgumentNullException(nameof(itemShape));
             Shape = shape ?? throw new ArgumentNullException(nameof(shape));
         }
 

--- a/Alis.Reactive/PlanModel/ValueExpression.cs
+++ b/Alis.Reactive/PlanModel/ValueExpression.cs
@@ -102,6 +102,15 @@ namespace Alis.Reactive.PlanModel
         internal static ValueExpression Invoke(RuntimeObjectSource from, string method, Shape returns, IReadOnlyList<ValueExpression> args) =>
             new ReadExpression(ValueRead.Method(from, method, returns, args));
 
+        /// <summary>Invokes a method on the current array element (element scope), reusing the same
+        /// RuntimePath.call engine as component/plugin method reads. The path carries the receiver
+        /// traversal plus the method name, so the runtime walks to the owner before calling.</summary>
+        internal static ValueExpression InvokeElement(string receiverPath, string method, Shape returns, IReadOnlyList<ValueExpression> args)
+        {
+            var fullPath = string.IsNullOrEmpty(receiverPath) ? method : receiverPath + "." + method;
+            return new ReadExpression(ValueRead.Method(PayloadSource.Element(), method, Path.Parse(fullPath), returns, args));
+        }
+
         internal static ObjectExpression Object(IReadOnlyDictionary<string, ValueExpression> fields)
         {
             var objectFields = ObjectFields(fields);
@@ -343,6 +352,12 @@ namespace Alis.Reactive.PlanModel
         internal static ValueRead Method(RuntimeObjectSource from, string member, Shape shape, IReadOnlyList<ValueExpression> args) =>
             new ValueRead(
                 ValueReadTarget.ForMember(from, member),
+                shape,
+                ValueReadAccess.Method(args));
+
+        internal static ValueRead Method(Source from, string member, Path path, Shape shape, IReadOnlyList<ValueExpression> args) =>
+            new ValueRead(
+                ValueReadTarget.ForMember(from, member, path),
                 shape,
                 ValueReadAccess.Method(args));
 

--- a/Alis.Reactive/PlanModel/ValueExpression.cs
+++ b/Alis.Reactive/PlanModel/ValueExpression.cs
@@ -87,6 +87,13 @@ namespace Alis.Reactive.PlanModel
         internal static ValueExpression ReadWholePayload(PayloadSource from, Shape shape) =>
             new ReadExpression(ValueRead.WholePayload(from, shape));
 
+        /// <summary>Reads the current array element itself (identity, <c>x =&gt; x</c>) for primitive-element arrays.</summary>
+        internal static ValueExpression ReadWholeElement() =>
+            new ReadExpression(ValueRead.WholeElement(PayloadSource.Element(), Shape.None));
+
+        internal static ValueExpression ReadWholeElement(Shape shape) =>
+            new ReadExpression(ValueRead.WholeElement(PayloadSource.Element(), shape));
+
         internal static ValueExpression Invoke(RuntimeObjectSource from, string method, Shape returns, IReadOnlyList<ValueExpression> args) =>
             new ReadExpression(ValueRead.Method(from, method, returns, args));
 
@@ -305,11 +312,18 @@ namespace Alis.Reactive.PlanModel
                 ValueReadTarget.ForWholePayload(from),
                 shape,
                 ValueReadAccess.Property);
+
+        internal static ValueRead WholeElement(PayloadSource from, Shape shape) =>
+            new ValueRead(
+                ValueReadTarget.ForWholeElement(from),
+                shape,
+                ValueReadAccess.Property);
     }
 
     internal sealed class ValueReadTarget
     {
         private const string WholePayloadMember = "responseBody";
+        private const string WholeElementMember = "elementValue";
 
         private ValueReadTarget(Source from, MemberName member, Path path)
         {
@@ -330,6 +344,9 @@ namespace Alis.Reactive.PlanModel
 
         internal static ValueReadTarget ForWholePayload(PayloadSource from) =>
             new ValueReadTarget(from, MemberName.Of(WholePayloadMember), Path.None);
+
+        internal static ValueReadTarget ForWholeElement(PayloadSource from) =>
+            new ValueReadTarget(from, MemberName.Of(WholeElementMember), Path.None);
 
         private static ValueReadTarget ForMember(Source from, MemberName member) =>
             new ValueReadTarget(from, member, ValueReadPath.For(from, member));

--- a/Alis.Reactive/PlanModel/ValueExpression.cs
+++ b/Alis.Reactive/PlanModel/ValueExpression.cs
@@ -125,6 +125,10 @@ namespace Alis.Reactive.PlanModel
         internal static ValueExpression ArrayCount(ValueExpression source, Shape itemShape) =>
             new ArrayOperationExpression("count", source, itemShape, Shape.Number);
 
+        /// <summary>Filters the elements of <paramref name="source"/> by a per-element sync predicate.</summary>
+        internal static ValueExpression ArrayFilter(ValueExpression source, ConditionGraph predicate, Shape itemShape) =>
+            new ArrayOperationExpression("filter", source, itemShape, Shape.ArrayOf(itemShape), predicate);
+
         private static (IReadOnlyDictionary<string, ValueExpression> Fields, Shape Shape) ObjectFields(
             IReadOnlyDictionary<string, ValueExpression> fields)
         {
@@ -490,21 +494,33 @@ namespace Alis.Reactive.PlanModel
     {
         /// <summary>Gets the kind. Always <c>"array-op"</c>.</summary>
         public string Kind => "array-op";
-        /// <summary>Gets the operation: <c>count</c> (and, as ops land, filter/map/sum/...).</summary>
+        /// <summary>Gets the operation: <c>count</c>, <c>filter</c> (and, as ops land, map/sum/...).</summary>
         public string Op { get; }
         /// <summary>Gets the value expression that produces the source array.</summary>
         public ValueExpression Source { get; }
+        /// <summary>Gets the per-element predicate for filtering ops, or null when the op takes no predicate.</summary>
+        /// <remarks>
+        /// Nullable by design: count/map carry no predicate while filter/any/all/find do. An
+        /// "always true" sentinel would conflate "no predicate" with "match all" and muddy count
+        /// semantics, so absence is modeled as null and omitted from the JSON. The predicate is the
+        /// SYNC condition subset (compare/all/any/not) — never a confirm — so per-element evaluation
+        /// stays on the immediate lane.
+        /// </remarks>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ConditionGraph? Predicate { get; }
         /// <summary>Gets the declared element shape of the source array.</summary>
         public Shape ItemShape { get; }
         /// <summary>Gets the declared output shape of the operation.</summary>
         public Shape Shape { get; }
 
-        internal ArrayOperationExpression(string op, ValueExpression source, Shape itemShape, Shape shape)
+        internal ArrayOperationExpression(
+            string op, ValueExpression source, Shape itemShape, Shape shape, ConditionGraph? predicate = null)
         {
             Op = op ?? throw new ArgumentNullException(nameof(op));
             Source = source ?? throw new ArgumentNullException(nameof(source));
             ItemShape = itemShape ?? throw new ArgumentNullException(nameof(itemShape));
             Shape = shape ?? throw new ArgumentNullException(nameof(shape));
+            Predicate = predicate;
         }
 
         internal override Shape OutputShape => Shape;

--- a/Alis.Reactive/PlanModel/ValueExpression.cs
+++ b/Alis.Reactive/PlanModel/ValueExpression.cs
@@ -63,6 +63,11 @@ namespace Alis.Reactive.PlanModel
         internal static ValueExpression ReadUrl(string paramName, Shape shape) =>
             Read(UrlSource.Instance, paramName, shape);
 
+        /// <summary>Reads a member from a DOM element resolved via getElementById. The member path is
+        /// carried in the read so the runtime reaches it with RuntimePath — no contract needed.</summary>
+        internal static ValueExpression ReadDom(string elementId, string member, Shape shape) =>
+            Read(DomSource.Of(elementId), member, Path.Parse(member), shape);
+
         internal static ValueExpression Read(Source from, string member) =>
             new ReadExpression(ValueRead.Property(from, member, Shape.None));
 

--- a/docs/superpowers/specs/2026-05-29-reactive-array-operations-dsl-design.md
+++ b/docs/superpowers/specs/2026-05-29-reactive-array-operations-dsl-design.md
@@ -1,0 +1,589 @@
+# Reactive Array Operations DSL — Design Proposal
+
+Date: 2026-05-29
+Status: APPROVED & VALIDATED — senior-architect panel: clean approval (0 blocking). JS ground-truth (real EJ2 + DOM): true-with-additions (§14.11 array-like normalization, starts-with→v1 core; dataset stays plugin). Cleared for implementation per §8.
+Author: design session, grounded in first-hand DSL source study
+
+## 1. One-line statement
+
+Add a **typed, custom array-operations DSL** — `ReactiveArray<T>` — that captures
+what the author expresses in C# (predicates, projections, aggregations) as
+**expression trees**, compiles them into **closed plan-JSON nodes**, and executes
+them through the framework's **deterministic runtime interpreter**. No
+developer-authored JavaScript. No plugin escape hatch for these operations. The
+array source is any existing value: a `.Reactive()` event payload (`e.Data` of
+`T[]`), a component property/method that returns an array, or an HTTP response
+body path.
+
+## 2. Problem and intent
+
+Today, "complex array manipulation" is explicitly delegated to the **plugin
+escape hatch** (root `CLAUDE.md`: *"Plugin is the intentional escape hatch when
+deterministic JSON DSL is not enough, such as URL APIs, DOM APIs, or complex
+array manipulation."*). The sandbox proves the demand and the cost: the
+`ArrayPlugin` (`Areas/Sandbox/Views/Plugins/ArrayManager/Index.cshtml:170-186`)
+hand-registers `count`, `pluck`, `filter`, `sum`, `some` as **opaque JS
+functions** in `sandbox-plugins.ts`. That logic is JavaScript that "stands" — it
+is **not** in the plan graph, not visible to the plan contract, not in the
+coverage matrix, and not deterministic by construction.
+
+The intent: promote a deterministic, **closed** set of array operations out of
+the plugin escape hatch and into **first-class plan vocabulary**. After this
+change, `filter`/`count`/`sum`/etc. are plan nodes the runtime interprets, not
+JS the developer wrote. The plugin remains for its own distinct
+job — integrating 3rd-party JS libraries/objects and composing multiple browser
+calls into one named operation — not as a fallback for array work.
+
+### Non-goals
+
+- **Not** an arbitrary JS engine. The author cannot express "any JS." The node
+  set is closed; anything outside it throws at C# build time.
+- **Not** `IQueryable`/LINQ. We deliberately avoid LINQ to prevent server-side
+  execution and name collision (see §4).
+- **Not** a new reaction node. Array operations are **values**, consumed by the
+  reactions that already exist (set/call/dispatch/condition/gather/inject).
+
+## 3. Source-grounded architecture (what the study established)
+
+All claims below were verified first-hand or by five parallel code-explorer
+passes over actual source.
+
+1. **The value path is universal — one resolver.** `evaluateValue()`
+   (`runtime/core/evaluate.ts:21`) is the single recursive entry point for every
+   value: set, call, dispatch, condition, gather, inject all call it. The switch
+   at `evaluate.ts:35` handles exactly four kinds — `literal`, `read`, `object`,
+   `array` — with `assertNever(expression, "value expression kind")` at line 54.
+   A new value kind is **new cases in this one switch**; every consumer inherits
+   it for free. This is why array operations belong as **values**, not reactions.
+
+2. **Array sources already exist and already carry element shape.**
+   - `.Reactive()` event payload: `e.Data`/`e.Value` typed `T[]` compiles to a
+     `read` from `PayloadSource{scope:"event"}` carrying `Shape.ArrayOf(item)`
+     (`PayloadTypedSource.cs`, `ExpressionPathHelper.ToEventPath`). Runtime reads
+     `ctx.event.value` — a live JS array (`trigger.ts`, `evaluate.ts:126`).
+   - Component property/method: `multiSelect.Value()` → `TypedComponentSource<string[]>`;
+     `schedule.GetEvents()` → `TypedComponentSource<FusionScheduleEventData[]>`
+     (`ComponentRef.Read<T>`, `FusionScheduleExtensions.cs:87`).
+   - HTTP response body path: `responseBody.Read(r => r.Items)` (`scope:"success"`).
+   - Element shape round-trips fully: C# `Shape.ArrayOf(inner)` → JSON
+     `{kind:"array", item: inner}` → runtime `applyShape(item, shape.item)`
+     (`Shape.cs:40-47`, `shape-convert.ts:62-64`).
+
+3. **The runtime scope model is immutable and frame-based.**
+   `ExecutionContext` (`execution-context.ts`) grows by spreading a new frame:
+   `withRequest(...)` / `withResponse(...)` (lines 39-45). Scopes resolved in
+   `resolvePayload` (line 47): `event`, `dispatch`, `success`, `error`,
+   `request`, `local`. **`local` is reserved but unused** (`Source.cs:94`,
+   `execution-context.ts:58`) — the slot for ad-hoc scoped values was
+   anticipated. A per-element binding is the same pattern: a `withElement(item)`
+   frame.
+
+4. **The one deliberately-closed door — the expression compiler.**
+   `ExpressionPathHelper` translates `x => x.Address.City` to a dot-path but
+   **throws on computed expressions** (`ExpressionPathHelper.cs:122-124`:
+   *"only supports property-access chains and MVC indexer paths… Got unsupported
+   expression node"*). To let an author write `x => x.Price * x.Qty` or
+   `x => x.Status == "active" && x.Age > 65` and have it become **plan JSON**, we
+   need a *new, richer* expression compiler. This build-time throw discipline is
+   exactly what keeps the custom DSL from degrading into arbitrary JS.
+
+5. **Predicates already have a deterministic algebra: `ConditionGraph`.**
+   `CompareCondition` carries `op` over 21 operators (`CompareOp.cs`), and
+   `conditions.ts` evaluates them through the *same* `evaluateValue` (one
+   resolver, confirmed). `all`/`any`/`not` compose them. So a `Where` predicate
+   *is* a `ConditionGraph` whose leaf reads target the element scope — no new
+   boolean algebra needed.
+
+6. **Adding a value kind is a known, low-cost, well-fenced change.** The TS
+   contract is hand-emitted in `PlanModel/PlanTypeScriptContract.cs` (not
+   reflection); `WriteOnlyPolymorphicConverter` needs **zero** changes (it
+   delegates to `value.GetType()`, and the public `Kind` property becomes the
+   discriminator automatically). `assertNever` at every switch forces the runtime
+   to handle the new kind or fail to compile.
+
+## 4. Authoring surface — the capture constraint (load-bearing)
+
+If `e.Data` is `IReadOnlyList<Resident>` and the author writes `.Where(x => …)`,
+that binds to **`System.Linq.Enumerable.Where`**: it takes a `Func<>`, executes
+**server-side**, and returns a filtered list. Nothing is captured; nothing
+reaches the plan. That is unacceptable — we must **collect what the author
+expressed**, not run it.
+
+The resolution is a single design choice that solves both "typed" and "no LINQ
+collision":
+
+- The source is wrapped in a **dedicated, strongly-typed builder**,
+  `ReactiveArray<T>`, that **does not implement `IEnumerable<T>` or
+  `IQueryable<T>`**. Therefore LINQ extension methods are not candidates at all —
+  zero collision, and no stray `using System.Linq` can hijack a call.
+- Every operator parameter is **`Expression<Func<T, …>>`, not `Func<T, …>`** — so
+  the lambda is **captured as an expression tree**, never invoked.
+- The element type **flows through transforms, fully typed**:
+  - `Where(Expression<Func<T,bool>>)            → ReactiveArray<T>`
+  - `Select<TOut>(Expression<Func<T,TOut>>)     → ReactiveArray<TOut>`
+  - `Count() / Count(Expression<Func<T,bool>>)  → ReactiveValue<int>`
+  - `Sum(Expression<Func<T,decimal>>)           → ReactiveValue<decimal>`
+  - `Any(Expression<Func<T,bool>>)              → ReactiveValue<bool>`
+  - `OrderBy<TKey>(Expression<Func<T,TKey>>)    → ReactiveArray<T>`
+
+Both `ReactiveArray<T>` (array-valued) and `ReactiveValue<TScalar>` (scalar-valued)
+are thin builders that **carry an accumulating `ValueExpression`** and expose
+`.ToValueExpression()` internally. They plug into every place a `TypedSource<T>`
+is accepted today (set, dispatch payload, condition operand, gather, element text).
+
+```csharp
+// p.From captures e => e.Data as an Expression and returns OUR builder (not IEnumerable):
+ReactiveArray<Resident> src = p.From(args, e => e.Data);
+
+ReactiveArray<Resident> active =
+    src.Where(x => x.Status == "active" && x.Age > 65);          // CAPTURED, not run
+
+ReactiveArray<ResidentRow> rows =
+    active.OrderByDescending(x => x.LastVisit)
+          .Select(x => new ResidentRow(x.Name, x.Price * x.Qty)); // typed projection, CAPTURED
+
+// Consumed by an existing reaction — array result written to a component property:
+p.Component<FusionGrid>(m => m.Grid).SetDataSource(rows);
+
+// Scalar result into element text:
+p.Element("active-count").SetText(src.Count(x => x.Status == "active"));
+```
+
+Method names (`Where`/`Select`/…) are familiar but they live on a
+non-enumerable type, so there is no collision regardless. Naming is open (see §10).
+
+## 5. Plan domain additions — reuse first, add only what is missing
+
+| Captured C# | Compiles to (plan node) | Reused or new |
+|---|---|---|
+| `x.Status` (member on element) | `read` from `PayloadSource{scope:"element"}`, path `status` | **reuse** `ReadExpression` |
+| `x.Status == "active" && x.Age > 65` (predicate) | `ConditionGraph` (`all[compare(eq…), compare(gt…)]`), leaves read element scope | **reuse** `ConditionGraph` |
+| `new ResidentRow(x.Name, …)` / `new { … }` (projection) | `object` `ValueExpression` over element reads | **reuse** `ObjectExpression` |
+| `x.Price * x.Qty` (arithmetic) | `compute` value node (`op:"mul"`, left, right) | **NEW** — no arithmetic node today |
+| `x.Age > 65` *as a projected value* | `condition-value` bridge wrapping a `ConditionGraph` | **NEW** — small bridge |
+| `.Where/.Select/.Count/.Sum/.Any/.OrderBy…` | `array-op` value node (source + op + predicate/projection/key) | **NEW** — the array-op family |
+
+### 5.1 Element scope (the one new scope)
+
+- C#: `PayloadScope.Element` → JSON `scope:"element"` (`Source.cs`).
+  `PayloadSource.Element()` factory.
+- Runtime: `ExecutionContext.withElement(item)` — same immutable spread as
+  `withResponse`; maintained as a **stack** so a nested op binds its own element.
+  `resolvePayload` gains `case "element": return top-of-element-stack`.
+- A per-element member read is then **just a normal `read`** from
+  `PayloadSource{scope:"element"}` — no new read kind.
+
+### 5.2 Array-operation node — one kind, op sub-discriminator
+
+Mirror `CompareCondition`'s proven pattern (one `kind`, an `op` field, op-specific
+payload), rather than one class per operation:
+
+```
+ArrayOperationExpression : ValueExpression   // Kind => "array-op"
+  Op        : string            // "filter" | "map" | "count" | "sum" | "any" | ...
+  Source    : ValueExpression   // produces the input array
+  Predicate : ValidationCondition?  // SYNC subset (compare/all/any/not); Confirm excluded — see §14.2
+  Projection: ValueExpression?  // map/select; sum/avg/min/max key; orderBy key
+  ItemShape : Shape             // element shape, carried for the runtime
+  Shape     : Shape             // declared output shape (array<TOut>, number, bool, T)
+```
+
+Runtime: one `case "array-op"` in `evaluate.ts`, which switches on `op` with its
+own `assertNever` over the closed op set — exactly how `conditions.ts` switches
+on `condition.op`. For element-wise ops it iterates the evaluated source, pushes
+`withElement(item)`, evaluates predicate/projection against that frame.
+
+### 5.3 Scalar computation nodes (projections / arithmetic)
+
+```
+ComputeExpression : ValueExpression          // Kind => "compute"
+  Op    : string         // "add" | "sub" | "mul" | "div" | "mod" | "neg" | "concat"
+  Left  : ValueExpression
+  Right : ValueExpression?  // null for unary "neg"
+  Shape : Shape
+
+ConditionValueExpression : ValueExpression    // Kind => "condition-value"
+  Condition : ValidationCondition  // SYNC subset (compare/all/any/not); Confirm excluded
+  Shape     : Shape  // Boolean
+```
+
+`ConditionValueExpression` is the one bridge that lets a projection yield a
+boolean (`Select(x => x.Age > 65)`) while keeping a **single** boolean algebra
+(`ConditionGraph`). It is intentionally tiny.
+
+## 6. The C# expression compiler (the real engineering core)
+
+A new `ExpressionVisitor`-based translator — call it `ValueExpressionCompiler` —
+that converts a captured `Expression<Func<T, …>>` into the node tree above, given
+an element scope. It handles a **whitelist**:
+
+- `ParameterExpression` (the element `x`) → element scope marker.
+- `MemberExpression` chain on the element → `read` from `scope:"element"` with a
+  dot/index path (reuse `ExpressionPathHelper`'s chain extraction).
+- `ConstantExpression` → `literal`.
+- `BinaryExpression`:
+  - arithmetic (`+ - * / %`) → `compute`.
+  - comparison (`== != > >= < <=`) → `CompareCondition`.
+  - logical (`&& ||`) → `all`/`any` `ConditionGraph`.
+- `UnaryExpression` `!` → `not`; numeric negate → `compute{neg}`.
+- `ConditionalExpression` (ternary) → **throws at C# build time in v1** (deferred
+  to v1.1 as a `condition-value` + select or a dedicated `case` node). The throw is
+  mandatory — silently ignoring ternary would break the closed-boundary guarantee
+  of §2.
+- `NewExpression` / `MemberInitExpression` (projection `new {…}` / `new Row(…)`)
+  → `object`.
+- A small **whitelisted** `MethodCallExpression` set (e.g. `string.Contains`,
+  `string.StartsWith`, `Math.Min/Max/Abs`) mapped to known nodes.
+
+**Anything else throws at C# build time** with a precise message naming the
+unsupported node — the same contract `ExpressionPathHelper.cs:122` already
+enforces. This throw is the boundary that guarantees the plan only ever carries
+closed, deterministic nodes.
+
+## 7. Generated TS + runtime
+
+1. `PlanTypeScriptContract.cs`: add `"ArrayOperationExpression"`,
+   `"ComputeExpression"`, `"ConditionValueExpression"` to the `ValueExpression`
+   union and declare their interfaces. Run
+   `npm run generate:plan-types -w Alis.Reactive.Assets` (do not hand-edit
+   `plan.ts`).
+2. `evaluate.ts`: new `case`s before `assertNever`. Array-op case maintains the
+   element-scope stack and delegates predicate evaluation to the existing
+   conditions evaluator (shared `evaluateValue`).
+3. `execution-context.ts`: `withElement(item)` + `element` scope resolution +
+   the stack.
+4. `WriteOnlyPolymorphicConverter`: **no change** (delegates to `GetType()`; the
+   public `Kind` property is the discriminator).
+
+## 8. Vertical slice / build sequence (closes one matrix row at a time)
+
+Following the repo's 10-step new-primitive checklist and "one matrix row per
+commit" rule. Each row: `<DSL source call> -> <domain term> -> <runtime behavior>`.
+
+1. **Element scope** — `PayloadScope.Element`, `withElement`, `resolvePayload`
+   case, runtime test. (Foundation; no DSL surface yet.)
+2. **`compute` node** — arithmetic value node + `evaluate.ts` case + tests.
+3. **`array-op: count`** — simplest op (no predicate). `ReactiveValue<int>` from a
+   `read` array source → `SetText`. C# `VerifyJson` + vitest + Playwright +
+   sandbox view.
+4. **`array-op: filter`** — predicate via `ConditionGraph` + element scope. Prove
+   `filter(...).Count()` composition.
+5. **`array-op: map` + projection** — `object` projection reading element scope;
+   `condition-value` bridge.
+6. **Aggregates** — `sum`/`average`/`min`/`max`/`any`/`all`/`find`.
+7. **Ordering / slicing / distinct** — `orderBy`/`thenBy`/`take`/`skip`/`distinct`.
+8. **`ValueExpressionCompiler`** — the expression-tree visitor, fronting all of
+   the above so the author writes natural lambdas. (Can be built incrementally:
+   member-only first, then arithmetic, then method whitelist.)
+9. **`groupBy`** — most complex; last.
+
+A working slice is `count` end-to-end (steps 1-3): `.Reactive()` event delivers
+`e.Data` (`Resident[]`) → `p.From(args,e=>e.Data).Count(x=>x.Status=="active")`
+→ plan JSON `array-op{op:count, predicate: compare(eq, read(element,status),
+"active")}` → runtime iterates, counts → `SetText` shows the number. Fully
+deterministic, zero developer JS.
+
+## 9. Decisions made (defaults, open to change)
+
+- **D1 — Predicates reuse `ConditionGraph`.** `Where`/`Any`/`All`/`Find`/`Count(pred)`
+  predicates compile to condition graphs evaluated per-element, rather than a
+  parallel boolean algebra. Rationale: smallest new surface, every node maps to
+  an existing DSL graph node, conditions already share `evaluateValue`.
+  *Alternative:* one unified new expression tree (rejected — duplicates a tested
+  algebra; violates "smallest clear set of concepts").
+- **D2 — v1 operation closure (tiered), locked after the SF acceptance test.**
+  - **v1 core (must-have, the SF surface demands all of these):**
+    - element scope + **element-self read** (`x => x`, §14.4) — without the
+      self-read, no `string[]`/`int[]` surface works.
+    - `array-op`: `Where, Select, Count, Sum, Any, All, Find/First` (find/first
+      carry an optional projection, §14.5), `OrderBy/OrderByDescending`.
+    - `compute` (arithmetic `add/sub/mul/div/mod`, unary `neg`, string `concat`).
+    - `condition-value` bridge.
+    - per-component `ReactiveArray<T>` builder overloads (§14.8) — `SetDataSource`
+      on Grid/MultiSelect/DropDownList/AutoComplete/MultiColumnComboBox/Schedule/
+      PivotView/Kanban; `SetValue` on NativeCheckList/MultiSelect; `SelectByIndexes`
+      on ChipList.
+  - **v1.1 fast-follow:** `Average, Min, Max, ThenBy, Take, Skip, Distinct,
+    Contains`; date/string `compute` ops (`date-diff-days`, …); member-of-scalar
+    via a named-local scope.
+  - **v2:** `SelectMany, GroupBy`, ternary projections, cross-level (outer)
+    element access in nested ops.
+- **D3 — Single-level element scope in v1.** A predicate/projection reads its own
+  array's element. Nested ops (e.g. inner op referencing the outer element) are a
+  documented v1 limitation; the scope is modeled as a **stack** so the extension
+  (named/depth-addressed frames) is additive, not a rewrite.
+- **D4 — `array-op` is one node with an `op` sub-discriminator** (mirrors
+  `CompareCondition`), not one class per operation. Keeps the TS union and the
+  runtime switch small.
+
+## 10. Resolved decisions (were open questions)
+
+1. **Builder naming — LOCKED.** Authoring surface: `ReactiveArray<T>` (array-valued)
+   and `ReactiveValue<T>` (scalar-valued). Plan nodes: `ArrayOperationExpression`,
+   `ComputeExpression`, `ConditionValueExpression`. (`Query` avoided to not imply
+   LINQ.)
+2. **First proof slice — LOCKED.** `Count() → SetText` (smallest visible proof),
+   then `Where(...) → SetDataSource` on a grid.
+3. **Source entry — BOTH, LOCKED.** `p.From(args, e => e.Data)` for event-payload
+   arrays, AND the operators are usable as extensions on the existing
+   `TypedComponentSource<T[]>` / `PayloadTypedSource<…, T[]>` so they compose with
+   what authors already write (`multiSelect.Value().Count()`).
+4. **Compiler method-whitelist — LOCKED (refined by JS ground-truth).**
+   `string.Contains/StartsWith/EndsWith` ARE **v1 core** — they compile to the
+   existing `CompareOp` operators `contains`/`starts-with`/`ends-with`
+   (`evaluateTextComparison`, `conditions.ts:354-372`), so they add no new node.
+   `Math.Min/Max/Abs` (which would need a compute/method node) stay v1.1. Anything
+   outside the set throws at build time.
+
+## 11. Risks
+
+- **R1 — "rebuilding a scripting interpreter" drift.** The repo philosophy
+  forbids generic interpreters. Mitigation: the node set is **closed and named**;
+  the compiler **throws** on anything outside it; every op maps to a matrix row.
+  If the closure starts growing toward "any expression," stop — that is the
+  signal to push the case to the plugin hatch instead.
+- **R2 — expression-compiler surface area.** The `ExpressionVisitor` is the
+  hardest, highest-risk piece. Mitigation: build it last (step 8), after the plan
+  nodes and runtime are proven via explicit construction in tests; ship
+  member-only translation first, grow the whitelist behind build-time throws.
+- **R3 — element-shape fidelity for object arrays.** `Shape.ArrayOf(item)` over
+  `ObjectOf` must carry projected field shapes so downstream reads stay typed.
+  Mitigation: derive output `Shape` in the C# builder from `TOut` at authoring
+  time (the builder knows the type); covered by `VerifyJson` snapshots.
+- **R4 — nested-op scope (D3).** Cross-level element access is deferred; if real
+  demand appears early, the stack model already accommodates depth addressing.
+
+## 12. Closure checklist (per repo standard)
+
+A module (op) is done only when: the DSL source row exists in the blueprint; the
+C# domain names match; generated `plan.ts` carries the concept; the runtime
+executes it without defensive policy; focused C# (`VerifyJson`) + vitest +
+Playwright tests prove behavior; and the slice is committed. Before
+implementation, update `docs/reactive-plan-source-blueprint.md`,
+`docs/reactive-plan-domain-language.md`, and
+`docs/design/dsl-graph-coverage-matrix.md` with the new rows.
+
+## 13. Strategic arc — one deterministic algebra over the whole browser object model
+
+The array-operations DSL is not a special case. It is the first concrete instance
+of a unifying principle the domain language already states
+(`reactive-plan-domain-language.md`): *"Components, DOM elements, app-level
+objects, plugins, event payloads, and HTTP responses are all modeled by how the
+plan reads or writes those objects."* A browser object is a JS object with
+properties, methods, and events. An array is a JS object. A DOM element is a JS
+object. A complex SF component API is a JS object. Same shape.
+
+The three primitives that make array element-operations work are object-agnostic,
+so they generalize without a new mechanism — only new member contracts:
+
+- **Object member read** (`ValueExpression`) — already universal via `evaluateValue`.
+- **The focus scope** (`element`) — "the current object under operation": the
+  array item, or the DOM node under a walk.
+- **The value algebra** (`compute`, `condition-value`, `array-op`) — deterministic
+  operations over reads.
+
+The arc:
+
+- **Phase 1 — Arrays (this proposal).** Operate on / read from elements the
+  onboarded components only *bind* today. Proves element scope + value algebra.
+- **Phase 2 — Compute over complex component APIs.** SF components expose rich
+  members (`grid.getSelectedRecords()`, `scheduler.getEvents()`, aggregates).
+  Today you can read them but cannot deterministically compute over them without a
+  plugin. The same algebra closes that:
+  `grid.getSelectedRecords().Count(r => r.Status == "active")` becomes a plan
+  node, not JS.
+- **Phase 3 — DOM as a browser object.** A DOM element gets a declarable member
+  contract (`textContent`, `value`, `classList`, `dataset`, `children`,
+  `checked`…), modeled exactly as components are — resolved by `getElementById`
+  (NOT scanning; plan-driven IDs preserved). The value algebra then reads and
+  operates on DOM members deterministically, in plan JSON, with no inline JS in
+  views.
+
+This is where the framework shines: one value algebra, one runtime interpreter,
+one plan contract — covering components, arrays, and the DOM uniformly, all
+deterministic, no developer JS.
+
+### Guardrails that keep the arc working with (not fighting) the architecture
+
+- **Plan-driven IDs, no DOM scanning (Rule 7).** DOM-as-object resolves via
+  `getElementById`; the plan carries the id. No `querySelectorAll`, no traversal
+  to discover objects.
+- **Closed node set; build-time throw.** Each phase adds named deterministic
+  nodes; the C# compiler rejects anything outside them at build time.
+- **The plugin endures as the integration + orchestration boundary.** Its job is
+  not "whatever the algebra can't make deterministic." It is (a) onboarding
+  **3rd-party JS** libraries/objects the framework has not modeled, and (b)
+  **composing several browser calls** into one named operation (imperative
+  orchestration not worth modeling as plan nodes). The value algebra and the
+  plugin are complementary, not competing: the algebra expresses deterministic
+  reads/operations over *modeled* browser objects; the plugin integrates *foreign*
+  objects and combines calls. The arc clarifies the division of labor — it does
+  not push the plugin toward zero.
+
+## 14. Caveats ironed out — surgical resolutions
+
+Each resolution below is grounded in the two verification passes (architecture-fit:
+viable, 0 blocking; SF acceptance: passes-with-extensions) and cites the constraint
+it satisfies. This section is authoritative where it refines §5–§7.
+
+### 14.1 Import graph — no cycle (the one real risk, resolved)
+
+Today: `conditions/conditions.ts:31` imports `evaluateValue` from `core/evaluate`
+(one-way); `core/evaluate.ts` imports nothing from conditions (it is a leaf);
+`execution/execute.ts` imports both. Making the array-op predicate reuse condition
+evaluation would otherwise force `evaluate → conditions → evaluate`.
+
+Resolution — **dependency injection through a leaf module.** Extract the sync
+condition evaluator into `conditions/sync-condition.ts` whose entry takes the
+value-evaluator as a parameter:
+`evaluateSyncCondition(cond, plan, ctx, evalValue): boolean`. It imports nothing
+from `core/evaluate`. Then `core/evaluate.ts` (array-op case) imports
+`evaluateSyncCondition` and passes its own `evaluate`; `conditions/conditions.ts`
+delegates its sync subset to the same module, passing `evaluateValue`. Resulting
+graph: `evaluate.ts → sync-condition.ts` (leaf); `conditions.ts →
+{sync-condition.ts, evaluate.ts}`. No cycle. The single-resolver invariant holds —
+all operands still resolve through the one `evaluateValue`.
+
+### 14.2 Predicates are the SYNC condition subset — Confirm excluded
+
+`ConditionGraph` includes `ConfirmCondition` (async → `Promise<boolean>`); a Promise
+inside a synchronous `.filter()`/`.every()` loop is silently truthy → wrong results.
+Resolution: an array-op predicate is typed as the **sync `ValidationCondition`
+subset** (compare/all/any/not), never the full `ConditionGraph`. Naturally enforced
+(a per-element lambda cannot express a user confirm) and locked at the type level.
+**C# gate:** `ValidationCondition` exists today only as a generated TS union — the
+C# plan model has no sync-subset base. To make the C# compiler a gate (not only the
+expression-compiler whitelist), `ArrayOperationExpression.Predicate` is typed against
+an internal C# sync-condition marker (a narrow base or internal factory that accepts
+only `Compare`/`All`/`Any`/`Not`), so a `ConfirmCondition` cannot be assigned even by
+internal builder code. `evaluateSyncCondition`
+handles only compare/all/any/not with its own `assertNever`. Array ops stay 100% on
+the immediate lane — confirmed compatible with `executeSequence` async promotion
+(array-op evaluation is internal to a synchronous `evaluateValue` and never returns
+a Promise, so it cannot trigger lane promotion).
+
+### 14.3 Element binding lives on `ExecContext` as a STACK
+
+`execute.ts` passes `context.raw` (the plain `ExecContext`) to `evaluateValue`,
+stripping the `ExecutionContext` class wrapper — a class-only field would be
+invisible to evaluation. Resolution: add `element?: readonly unknown[]` (a stack)
+to the `ExecContext` interface (`types/context.ts`). `withElement(item)` returns a
+new context spreading `{ ...raw, element: [...(raw.element ?? []), item] }` (same
+immutable pattern as `withRequest`/`withResponse`). `resolvePayload` adds
+`case "element": return values.element?.[values.element.length - 1]` (innermost /
+top of stack). v1 reads the innermost element; outer-element access in nested ops is
+v2 (depth-addressed) and additive on the same stack. The C# side registers the scope
+in three coupled places: `PlanTerms.cs` `PayloadScope.Known` dict, `Source.cs`
+`PayloadSource.Element()` factory, and the `PayloadScope` literal union in
+`PlanTypeScriptContract.cs` (then regenerate `plan.ts`).
+
+### 14.4 Element-self read for primitive arrays (`string[]`/`int[]`) — `x => x`
+
+The decision that unlocks the most SF surfaces. `MultiSelect.Value()`,
+`ChipList.SelectedChipValues()`, `NativeCheckList.Value()`, and event arrays are
+`string[]`/`int[]` — the element has no member, so filter/any/map must read the
+element ITSELF. Resolution: the identity lambda `x => x` (a bare
+`ParameterExpression`) compiles to a **whole-element read** — a `read` from
+`PayloadSource{scope:"element"}` with empty path — exactly analogous to the existing
+`ReadWholePayload` / `readsWholePayload` (`evaluate.ts:136`). So
+`multiSelect.Value().Any(x => x == "fall-risk")` and `checklist.Value().Count()` are
+expressible.
+
+**Sentinel mechanism (decided, per panel nit).** A `PayloadPathReadExpression`
+cannot carry an empty path (`StructuredPath` is a non-empty tuple, `plan.ts:1113`).
+So the element-self read is a **dedicated `WholeElementReadExpression`** — `read`
+from `PayloadSource{scope:"element"}` with sentinel `member: "elementValue"` and
+empty path — added to the `ReadExpression` union and declared in
+`PlanTypeScriptContract.cs`, mirroring `WholePayloadReadExpression` (which uses the
+`responseBody` sentinel). The runtime adds a `readsWholeElement` gate (sibling to
+`readsWholePayload`) that returns the resolved element root directly, then runs
+`applyShapeWhenPresent` exactly as payload reads do — so primitive element shapes
+(`string`/`number`) round-trip identically to payload values.
+
+### 14.5 `Find`/`First` carry an optional projection (folds "find then read a field")
+
+The `Data[0].field` idiom reads a member from a scalar op result, which a plain
+`read`-from-source cannot do. Resolution: `find`/`first`/`last` carry an optional
+`Projection : ValueExpression?`. `arr.Find(pred).Read(x => x.Id)` compiles to a single
+`find` op with `predicate` + `projection: read(element.id)`; the builder folds the
+trailing `.Read(...)` into the find node's projection. Arbitrary member-of-any-scalar
+beyond this fold is v1.1 (named-local scope).
+
+### 14.6 `ValueEvaluation` evaluates per element via a child context
+
+`ValueEvaluation` holds a fixed `this.context`; the array-op case must not mutate it.
+Resolution (decided, per panel nit): per element, the array-op case constructs a
+**fresh child `ValueEvaluation`** — `new ValueEvaluation(this.plan,
+this.context.withElement(item))` — and evaluates predicate/projection through it.
+This mirrors how the existing `array` literal case recurses with `this.evaluate`
+(`evaluate.ts:48-51`) and keeps `this.context` immutable. Purely synchronous
+recursion; no async promotion. (The alternative of threading raw `ExecContext` is
+rejected to avoid two evaluation entry shapes.)
+
+### 14.7 New-node `OutputShape` + projected object shape
+
+The three new C# nodes implement the abstract `ValueExpression.OutputShape`:
+`ArrayOperationExpression` → `ArrayOf(itemOrProjectedShape)` for
+filter/map/orderBy/take/skip/distinct, `Number` for count/sum/avg/min/max, `Boolean`
+for any/all, element-or-projected shape for find; `ComputeExpression` → its declared
+numeric/string shape; `ConditionValueExpression` → `Boolean`. Because
+`Shape.FromClrType(customClass)` returns `Shape.Any` (not `ObjectOf`),
+`ReactiveArray<T>.Select(x => new Row(...))` builds the projected `Shape.ObjectOf(fields)`
+**explicitly** from the captured projection's members/types, so array<object> outputs
+keep field-level shapes for downstream typed reads.
+
+### 14.8 Per-component builder overloads (no new plan nodes)
+
+Binding a computed `ReactiveArray<T>`/`ReactiveValue<T>` to a component is a plain
+`set`/`call`. v1 adds one builder overload per onboarded array surface
+(`SetDataSource(ReactiveArray<T>)`, `SetValue(ReactiveArray<string>)`,
+`SelectByIndexes(ReactiveArray<int>)`) — same `EmitSet`/`EmitCall` pattern as the
+existing `SetDataSource(ResponseBody<T>, path)` overloads, zero runtime/plan-node
+change.
+
+### 14.9 `compute` scope for v1
+
+`compute` v1 ops = `add/sub/mul/div/mod` + unary `neg` + string `concat`. Date
+arithmetic (`date-diff-days`, `date-add-days`) and richer string ops are v1.1 —
+additive op strings on the same node, no structural change.
+
+### 14.10 Inventory completeness (from the SF acceptance critic)
+
+Surfaces the inventory initially missed but which the v1 set covers once §14.4 and
+§14.8 land: `FusionAIAssistViewPromptRequestArgs.PromptSuggestions` (string[]),
+`FusionKanbanQueryCellInfoArgs.Data`, `FusionChipList.SetSelectedChipIndexes`
+(literal overload already exists), `FusionAutoComplete.UpdateData`,
+`FusionKanbanDataBindingArgs.Result`. None require new plan nodes.
+
+### 14.11 Array-like → `Array` normalization at the array-op input boundary
+
+Confirmed by the JS ground-truth pass against the real EJ2 typings and DOM APIs.
+Real JS sources are not all `Array`: `multiSelect.value` is `string[] | null`;
+`chipList.selectedChips` is a scalar `number` in single-select mode; DOM `classList`
+(DOMTokenList), `children`/`selectedOptions` (HTMLCollection), `files` (FileList),
+`querySelectorAll` (NodeList) are **iterable but `Array.isArray` is false**. The
+array-op case normalizes at its **input boundary**, before the op sub-switch, via a
+private `normalizeToArray(value, label)` in `evaluate.ts` (or a boundary-local module
+imported only by evaluate.ts). Decision tree:
+
+1. `Array.isArray(v)` → use as-is (EJ2 `dataSource`/`getEvents`/`value`; every
+   intermediate array-op result is a real array).
+2. `v == null` → `[]` (true boundary: `multiSelect.value` null, `files` null).
+3. `typeof v === "number" | "string"` → `[v]` (scalar-to-singleton: chipList
+   single-select).
+4. `typeof v === "object" && Symbol.iterator in v` → `Array.from(v)` (DOMTokenList/
+   HTMLCollection/FileList/NodeList; snapshots live collections at entry, which is
+   the correct iteration semantics).
+5. else → **throw** `[alis] array-op source is not iterable: <label>` — fail-fast
+   boundary error (e.g. `DOMStringMap`/`dataset`, which has no `Symbol.iterator`).
+
+**Why this does not corrupt the framework:** it is NOT in `shape-convert.ts:toArray`
+(changing that alters scalar→singleton coercion for conditions/gather/execute — SRP).
+It is NOT a plan validator or fallback — it normalizes the underdetermined union the
+browser/EJ2 JS API returns, which C#'s `T[]` type cannot constrain at authoring time;
+this is the same external-boundary category as `getElementById` returning null
+(`runtime-path.ts:88-92 requireMember` precedent). Plan-driven IDs are preserved (the
+value is already in hand via `getElementById` + member read — no scanning). **`dataset`/
+DOMStringMap stays plugin**: step 5 throws rather than silently `Array.from`-ing to
+`[]`; its only enumeration is `Object.entries` (a distinct bridge, not iterable
+normalization), so it remains the plugin escape hatch's job (§13 division of labor).

--- a/docs/superpowers/specs/2026-05-30-array-dsl-followups.md
+++ b/docs/superpowers/specs/2026-05-30-array-dsl-followups.md
@@ -27,7 +27,10 @@ flow today into:
 - `p.When(...).NotEmpty()` / comparisons — `ConditionStart`/`GuardBuilder` take `TypedSource<TProp>`.
 - `Element.SetText(TypedSource<TProp>)` — `ElementBuilder.cs:87`.
 - `DispatchPayloadBuilder.Set(field, TypedSource<T>)`.
-- `gather.Include(...)` / `gather.Plugin(...)` — array members route into the HTTP payload.
+
+(NOT gather: `gather.Include` is typed to `TypedComponentSource<T>` and `gather.Plugin` to
+`TypedPluginSource<T>`, so a plain `AsSource()`/`ReactiveValue` does not route there. To gather an
+array, read the array member straight off the component — that source IS a `TypedComponentSource`.)
 
 And the read+transform half already spans components: `p.From(component.arrayMember())` seeds a
 `ReactiveArray<T>` from any `TypedSource<T[]>` (`PipelineBuilder.Arrays.cs:15`). No reinvention
@@ -36,8 +39,8 @@ reused, not duplicated.
 
 ## What shipped in this pass (the missing edge — DONE)
 
-The one asymmetry was the **sink**: a transformed array could reach `When`/`SetText`/`dispatch`/
-`gather`, but **not** a component's `dataSource` member — `SetDataSource` only accepted
+The one asymmetry was the **sink**: a transformed array could reach `When`/`SetText`/`dispatch`,
+but **not** a component's `dataSource` member — `SetDataSource` only accepted
 `ResponseBody`/event-payload. Completing it makes routing symmetric: *any value, including a
 transformed array, → any array-typed member sink.* Implemented:
 
@@ -68,7 +71,34 @@ constraint is already enforced behaviorally at lambda-compile time. Narrowing th
 `ValidationCondition` union. Add the marker to `ConditionGraph` only when that hierarchy is being
 touched for another reason; not standalone work.
 
-### 2. Per-element side-effecting reaction (foreach) — distinct primitive, narrower than first thought
+### Remaining quality debt (adversarial audit, 2026-05-30)
+
+An adversarial audit (10 of 14 findings survived refutation) cleared a must-fix and the cheap items
+inline; these two are deliberately scheduled as their own passes, not crammed in:
+
+- **eval-1 — Rule 6 type-split of `ArrayOperationExpression` (should-fix).** `evaluate.ts` has four
+  `if (predicate/projection === undefined) throw` guards defending shapes the DSL always provides
+  (filter/any/all always carry a predicate; map/orderBy/sum always carry a projection; only
+  `find.projection` is legitimately optional). Rule 6 says the runtime must not throw for
+  DSL-controlled shapes. Correct fix: split `ArrayOperationExpression` in the generated `plan.ts`
+  into per-op discriminated sub-interfaces with **non-optional** fields (via `PlanTypeScriptContract`),
+  regenerate `plan.ts`, narrow `evaluateArrayOp`, and delete the guards. Deferred because it touches
+  the generated plan contract and deserves a focused pass with `npm run typecheck` + vitest, not a
+  rushed edit.
+
+- **array-2 — per-element method whitelist is name-only (should-fix, needs a design decision).**
+  The whitelist matches a camelCased C# method name against JS method names (`getDay`, `trim`,
+  `getAttribute`, …). A domain method that happens to camelCase to a whitelisted name (e.g. a DTO
+  `GetDate()`) is accepted at authoring time but calls the JS Date/String/DOM method on an arbitrary
+  object at runtime. The audit's proposed receiver-type check does not cleanly apply because the C#
+  side is a developer stub, not a real `DateTime`/`String`. The robust fix is a contract decision
+  (explicit per-method opt-in, or a typed element-kind marker), not a name heuristic — recorded for a
+  design pass rather than a half-measure.
+
+(Also tracked: XML docs for the 16 pre-existing undocumented `FusionKanbanExtensions` methods — scout-rule
+hygiene, unrelated to the array DSL.)
+
+### Per-element side-effecting reaction (foreach) — distinct primitive, narrower than first thought
 
 The "update each row in a grid" case is **already solved** by the functional rebind shipped above:
 `grid.SetDataSource(roster.Where(...).Select(...).OrderBy(...).AsSource())` replaces the whole data

--- a/docs/superpowers/specs/2026-05-30-array-dsl-followups.md
+++ b/docs/superpowers/specs/2026-05-30-array-dsl-followups.md
@@ -1,0 +1,77 @@
+# Array DSL — recorded follow-ups (broader-framework, NOT made here)
+
+Date: 2026-05-30
+Status: RECORDED ONLY — these touch framework code outside the array-DSL slice. They were
+deliberately not implemented in the quality/extension pass (scope was "only change the array
+DSL; record broader wins"). Each is specified precisely so the owning layer can execute.
+
+The array-DSL pass itself (quality fixes, per-element method calls, `AsSource()` adapter) is
+complete and verified: vitest green, typecheck clean, C# build clean, ArrayOps + DomOps
+Playwright slices green.
+
+## 1. Fusion `SetDataSource(TypedSource<T[]>)` overloads — HIGH confidence, clear win
+
+**Why a massive win:** `ReactiveArray<T>.AsSource()` already exposes a transformed array as a
+`TypedSource<T[]>` (shipped in this pass). The only missing half is a component-side overload to
+consume it, which unlocks binding a **client-side filtered/sorted/mapped** array straight to a
+component data source **without an HTTP round-trip** — e.g. filter a loaded roster by a dropdown
+selection and rebind the grid, entirely in the plan.
+
+**Why not made here:** the component extension files live in the Fusion layer (vendor scope), not
+the array-DSL scope.
+
+**Exact change (one overload per file, identical structural pattern to the existing
+`SetDataSource(ResponseBody<T>, path)` overloads — a single `EmitSet`):**
+
+```csharp
+public static ComponentRef<TComponent, TModel> SetDataSource<TModel, TElement>(
+    this ComponentRef<TComponent, TModel> self, TypedSource<TElement[]> source)
+    where TModel : class
+    => self.EmitSet(DataSourceProperty, source.ToValueExpression());
+```
+
+Files: `FusionGridExtensions.cs`, `FusionDropDownListExtensions.cs`, `FusionMultiSelectExtensions.cs`,
+`FusionAutoCompleteExtensions.cs`, `FusionMultiColumnComboBoxExtensions.cs`, `FusionKanbanExtensions.cs`
+(Kanban also calls `EmitCall(DataBindMethod)` to match its existing overloads). Do NOT auto-`Refresh()`
+— keep the explicit-refresh convention of the existing overloads. Schedule/PivotView are excluded
+(their dataSource semantics differ — a Fusion-layer judgement).
+
+Enables: `p.Component<FusionGrid>("grid").SetDataSource(residents.Where(r => r.Active).OrderBy(r => r.LastName).AsSource()).Refresh();`
+
+## 2. C# sync-condition marker for array-op predicates — MEDIUM confidence, defense-in-depth
+
+**Why a win:** `ArrayOperationExpression.Predicate` is typed `ConditionGraph?` (the broad base).
+The expression compiler only ever emits `compare/all/any/not` (never `Confirm`), so a Promise-in-
+filter bug is already prevented in practice — but the C# *type* doesn't enforce it. Narrowing the
+predicate type to a sync-only marker makes the compiler a hard gate (matches the generated TS
+`ValidationCondition` union and spec §14.2).
+
+**Why not made here:** there is no sync-only C# condition base today; introducing one means adding a
+marker interface to the shared `ConditionGraph` hierarchy (`Compare/All/Any/Not` implement it) —
+a broader-framework edit. Low practical risk (compiler can't emit `Confirm`), so deferred.
+
+**Change:** add `internal interface ISyncCondition` (or an abstract `SyncCondition` base) in
+`ConditionGraph.cs`; have `CompareCondition/AllCondition/AnyCondition/NotCondition` implement it
+(NOT `ConfirmCondition`); change `ArrayOperationExpression.Predicate`, the `Array*` factories, and
+`ElementExpressionCompiler.CompilePredicate` return type to that marker.
+
+## 3. Per-element side-effecting method calls (foreach reaction) — distinct concept, larger
+
+**Why recorded:** per-element method calls land in this pass as **value projections** and are
+intentionally restricted to PURE, deterministic methods (the `ElementExpressionCompiler` whitelist).
+Side-effecting per-element methods — e.g. EJ2 Grid `Row.setCellValue(field, value)` for each selected
+row — are NOT value projections; they are *iteration with side effects*. The value algebra is for
+reading/computing, so these do not belong as an `array-op` projection.
+
+**The right shape:** a new **per-element reaction** ("for-each") node — a reaction (not a value) that
+iterates an array source, binds each element to the element scope, and runs a sub-pipeline of
+reactions (set/call/dispatch) against it. This reuses the element-scope stack already in place
+(`ExecutionContext.withElement`) and the existing reaction executor. It is a Layer-1→3 primitive
+(new reaction kind + builder + runtime case), larger than the array-DSL value work, and belongs in
+its own slice. Until then, side-effecting per-element work stays in the plugin escape hatch.
+
+## Confirmed NON-changes (verified, for the record)
+
+Per-element method calls required **no** change to `runtime-path.ts` (`call()`/`fn.apply` already
+exists), `execution-context.ts` (`withElement` already exists), or `Source.cs` (`PayloadSource.Element()`
+already exists) — the capability was inherent in the existing primitives, exactly as established.

--- a/docs/superpowers/specs/2026-05-30-array-dsl-followups.md
+++ b/docs/superpowers/specs/2026-05-30-array-dsl-followups.md
@@ -1,77 +1,86 @@
-# Array DSL — recorded follow-ups (broader-framework, NOT made here)
+# Array DSL as a first-class citizen — value-routing law, completion + follow-ups
 
 Date: 2026-05-30
-Status: RECORDED ONLY — these touch framework code outside the array-DSL slice. They were
-deliberately not implemented in the quality/extension pass (scope was "only change the array
-DSL; record broader wins"). Each is specified precisely so the owning layer can execute.
+Supersedes the earlier "recorded follow-ups" framing, which was a patch mentality. The array DSL
+is not a feature bolted on; it completes one law the framework already had.
 
-The array-DSL pass itself (quality fixes, per-element method calls, `AsSource()` adapter) is
-complete and verified: vitest green, typecheck clean, C# build clean, ArrayOps + DomOps
-Playwright slices green.
+## The one law
 
-## 1. Fusion `SetDataSource(TypedSource<T[]>)` overloads — HIGH confidence, clear win
+A browser object (component, plugin, app object, DOM node) has members. A member's value is a
+scalar, an object, or an **array**. The framework's whole job is:
 
-**Why a massive win:** `ReactiveArray<T>.AsSource()` already exposes a transformed array as a
-`TypedSource<T[]>` (shipped in this pass). The only missing half is a component-side overload to
-consume it, which unlocks binding a **client-side filtered/sorted/mapped** array straight to a
-component data source **without an HTTP round-trip** — e.g. filter a loaded roster by a dropdown
-selection and rebind the grid, entirely in the plan.
+> read any member of any browser object; route any value to any member of any browser object —
+> expressed in typed C#, compiled to a deterministic plan, generated into TS, executed by a dumb
+> runtime that keeps pure reads **sync** and only HTTP / confirm / inject **async**.
 
-**Why not made here:** the component extension files live in the Fusion layer (vendor scope), not
-the array-DSL scope.
+The array DSL completes that law for **array-typed members**: before it you could *read* an array
+member (`multiSelect.Value() : string[]`, `kanban.Cards() : Card[]`) but it was hard to express
+intent over the **elements' own members**. Now `x => x.Status == Active`, `x => x.Balance`,
+`x => x.GetDay()` are first-class — the full member graph of every element, deterministic and typed.
 
-**Exact change (one overload per file, identical structural pattern to the existing
-`SetDataSource(ResponseBody<T>, path)` overloads — a single `EmitSet`):**
+## What was already possible (no new code) — the honest correction
 
-```csharp
-public static ComponentRef<TComponent, TModel> SetDataSource<TModel, TElement>(
-    this ComponentRef<TComponent, TModel> self, TypedSource<TElement[]> source)
-    where TModel : class
-    => self.EmitSet(DataSourceProperty, source.ToValueExpression());
-```
+`TypedSource<T>` is the universal value intake and has **no array restriction**. So a
+DSL-transformed array (`ReactiveArray.AsSource()`) and a scalar result (`ReactiveValue<T>`) already
+flow today into:
 
-Files: `FusionGridExtensions.cs`, `FusionDropDownListExtensions.cs`, `FusionMultiSelectExtensions.cs`,
-`FusionAutoCompleteExtensions.cs`, `FusionMultiColumnComboBoxExtensions.cs`, `FusionKanbanExtensions.cs`
-(Kanban also calls `EmitCall(DataBindMethod)` to match its existing overloads). Do NOT auto-`Refresh()`
-— keep the explicit-refresh convention of the existing overloads. Schedule/PivotView are excluded
-(their dataSource semantics differ — a Fusion-layer judgement).
+- `p.When(...).NotEmpty()` / comparisons — `ConditionStart`/`GuardBuilder` take `TypedSource<TProp>`.
+- `Element.SetText(TypedSource<TProp>)` — `ElementBuilder.cs:87`.
+- `DispatchPayloadBuilder.Set(field, TypedSource<T>)`.
+- `gather.Include(...)` / `gather.Plugin(...)` — array members route into the HTTP payload.
 
-Enables: `p.Component<FusionGrid>("grid").SetDataSource(residents.Where(r => r.Active).OrderBy(r => r.LastName).AsSource()).Refresh();`
+And the read+transform half already spans components: `p.From(component.arrayMember())` seeds a
+`ReactiveArray<T>` from any `TypedSource<T[]>` (`PipelineBuilder.Arrays.cs:15`). No reinvention
+happened — `ObjectExpression`, `ArrayExpression`, the element scope, and `RuntimePath.call` were all
+reused, not duplicated.
 
-## 2. C# sync-condition marker for array-op predicates — MEDIUM confidence, defense-in-depth
+## What shipped in this pass (the missing edge — DONE)
 
-**Why a win:** `ArrayOperationExpression.Predicate` is typed `ConditionGraph?` (the broad base).
-The expression compiler only ever emits `compare/all/any/not` (never `Confirm`), so a Promise-in-
-filter bug is already prevented in practice — but the C# *type* doesn't enforce it. Narrowing the
-predicate type to a sync-only marker makes the compiler a hard gate (matches the generated TS
-`ValidationCondition` union and spec §14.2).
+The one asymmetry was the **sink**: a transformed array could reach `When`/`SetText`/`dispatch`/
+`gather`, but **not** a component's `dataSource` member — `SetDataSource` only accepted
+`ResponseBody`/event-payload. Completing it makes routing symmetric: *any value, including a
+transformed array, → any array-typed member sink.* Implemented:
 
-**Why not made here:** there is no sync-only C# condition base today; introducing one means adding a
-marker interface to the shared `ConditionGraph` hierarchy (`Compare/All/Any/Not` implement it) —
-a broader-framework edit. Low practical risk (compiler can't emit `Confirm`), so deferred.
+- `SetDataSource<TModel, TElement>(TypedSource<TElement[]>)` on **FusionGrid, FusionDropDownList,
+  FusionMultiSelect, FusionAutoComplete, FusionMultiColumnComboBox** (single `EmitSet`) and
+  **FusionKanban** (`EmitSet` + `EmitCall(dataBind)`, matching its established pattern). Pattern is
+  `ElementBuilder.SetText<TProp>(TypedSource<TProp>)` — the abstract base with a free type
+  parameter (NOT `TypedComponentSource<string>`). `EmitSet` + `ToValueExpression()` already existed;
+  `InternalsVisibleTo` already grants Fusion access. Zero plan-domain / TS / runtime change.
+- `FusionGrid.Data<TModel, TRow>()` — the read counterpart (mirrors `FusionKanban.Cards()`),
+  so the rows on screen can be re-filtered and rebound without re-fetching.
+- Comparison Shape in `ElementExpressionCompiler` is now **member-driven** (from the typed member
+  operand), matching `ConditionSourceBuilder` instead of taking the left operand positionally. The
+  runtime coerces both operands to one Shape before `===`, so the Shape must come from the member.
 
-**Change:** add `internal interface ISyncCondition` (or an abstract `SyncCondition` base) in
-`ConditionGraph.cs`; have `CompareCondition/AllCondition/AnyCondition/NotCondition` implement it
-(NOT `ConfirmCondition`); change `ArrayOperationExpression.Predicate`, the `Array*` factories, and
-`ElementExpressionCompiler.CompilePredicate` return type to that marker.
+Browser proof: `WhenBindingArrayToGrid` — roster loads once, `OrderBy` transform routes into the
+grid (`SetDataSource(TypedSource<T[]>)`), and "Show Active Only" re-filters the grid's own rows
+client-side (`Data()` → `Where` → rebind), no HTTP round-trip. Sandbox: `/Sandbox/Components/ArrayGrid`.
 
-## 3. Per-element side-effecting method calls (foreach reaction) — distinct concept, larger
+## Genuinely-remaining follow-ups (NOT made — broader framework)
 
-**Why recorded:** per-element method calls land in this pass as **value projections** and are
-intentionally restricted to PURE, deterministic methods (the `ElementExpressionCompiler` whitelist).
-Side-effecting per-element methods — e.g. EJ2 Grid `Row.setCellValue(field, value)` for each selected
-row — are NOT value projections; they are *iteration with side effects*. The value algebra is for
-reading/computing, so these do not belong as an `array-op` projection.
+### 1. C# sync-condition marker for array-op predicates — LOW priority, defense-in-depth
 
-**The right shape:** a new **per-element reaction** ("for-each") node — a reaction (not a value) that
-iterates an array source, binds each element to the element scope, and runs a sub-pipeline of
-reactions (set/call/dispatch) against it. This reuses the element-scope stack already in place
-(`ExecutionContext.withElement`) and the existing reaction executor. It is a Layer-1→3 primitive
-(new reaction kind + builder + runtime case), larger than the array-DSL value work, and belongs in
-its own slice. Until then, side-effecting per-element work stays in the plugin escape hatch.
+`ArrayOperationExpression.Predicate` is typed `ConditionGraph?` (the broad base). The expression
+compiler only ever emits `compare/all/any/not` — there is no path to `Confirm` — so the sync-only
+constraint is already enforced behaviorally at lambda-compile time. Narrowing the type to an
+`ISyncCondition` marker would make the compiler a hard gate, matching the generated TS
+`ValidationCondition` union. Add the marker to `ConditionGraph` only when that hierarchy is being
+touched for another reason; not standalone work.
 
-## Confirmed NON-changes (verified, for the record)
+### 2. Per-element side-effecting reaction (foreach) — distinct primitive, narrower than first thought
 
-Per-element method calls required **no** change to `runtime-path.ts` (`call()`/`fn.apply` already
-exists), `execution-context.ts` (`withElement` already exists), or `Source.cs` (`PayloadSource.Element()`
-already exists) — the capability was inherent in the existing primitives, exactly as established.
+The "update each row in a grid" case is **already solved** by the functional rebind shipped above:
+`grid.SetDataSource(roster.Where(...).Select(...).OrderBy(...).AsSource())` replaces the whole data
+source — which is how every existing sandbox view updates a grid. A `ForEach` reaction is needed
+ONLY for true imperative per-rendered-row mutation (e.g. EJ2 `Row.setCellValue` on an
+already-rendered row without replacing the dataSource). That is a genuinely new reaction kind
+(`ReactionGraph` has Sequence/Parallel/Branch/Set/Call/Request/Dispatch/Inject/ShowValidationErrors
+— no iteration). It reuses the element-scope stack already in place, is a Layer-1→3 primitive, and
+belongs in its own slice. Until then, imperative per-element mutation stays in the plugin escape hatch.
+
+A known DSL boundary worth recording: element predicates compare members to **literals/captured
+constants** only (the compiler evaluates the non-element side to a literal). Comparing an element
+member to a *runtime* value (e.g. a dropdown's current selection) is not yet expressible in a
+predicate — it would need the predicate's right operand to accept a `ValueExpression` source, not
+just a literal. Recorded as a future capability, not made here.

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenBindingArrayToGrid.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenBindingArrayToGrid.cs
@@ -1,0 +1,59 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+/// <summary>
+/// The array DSL routed into a component data source, end-to-end in the browser. A roster loads
+/// once over HTTP, then a client-side ReactiveArray transform feeds the grid via
+/// SetDataSource(TypedSource&lt;T[]&gt;) — the same value-routing law that already binds When/SetText/
+/// gather, now reaching a component's dataSource member. Re-filtering reads the grid's own
+/// dataSource member (the read counterpart) and rebinds, with no HTTP round-trip.
+///
+/// Roster: Ada(active), Bo(discharged), Cy(active), Di(critical), Ed(active) — 5 rows, 3 active.
+/// Page under test: /Sandbox/Components/ArrayGrid. Isolated slice.
+/// </summary>
+[TestFixture]
+public class WhenBindingArrayToGrid : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/ArrayGrid";
+
+    private async Task NavigateAndWaitForRoster()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#grid-status"))
+            .ToHaveTextAsync("roster loaded", new() { Timeout = 10000 });
+    }
+
+    [Test]
+    public async Task roster_loads_into_grid_sorted_by_name()
+    {
+        await NavigateAndWaitForRoster();
+
+        var rows = Page.Locator("#roster-grid .e-row");
+        await Expect(rows).ToHaveCountAsync(5, new() { Timeout = 10000 });
+
+        // OrderBy(x => x.Name) — the client-side transform routed into the grid: Ada is first.
+        await Expect(rows.First).ToContainTextAsync("Ada", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task showing_active_only_filters_the_grid_client_side()
+    {
+        await NavigateAndWaitForRoster();
+        await Expect(Page.Locator("#roster-grid .e-row")).ToHaveCountAsync(5, new() { Timeout = 10000 });
+
+        await Page.Locator("#show-active-btn").ClickAsync();
+
+        await Expect(Page.Locator("#grid-status"))
+            .ToHaveTextAsync("active only", new() { Timeout = 5000 });
+
+        // Where(x => x.Status == "active") over the grid's own rows: 3 remain (Ada, Cy, Ed),
+        // and no discharged/critical row survives.
+        await Expect(Page.Locator("#roster-grid .e-row")).ToHaveCountAsync(3, new() { Timeout = 10000 });
+        await Expect(Page.Locator("#roster-grid")).Not.ToContainTextAsync("discharged", new() { Timeout = 5000 });
+        await Expect(Page.Locator("#roster-grid")).Not.ToContainTextAsync("critical", new() { Timeout = 5000 });
+
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenFilteringWithChips.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Fusion/WhenFilteringWithChips.cs
@@ -1,0 +1,72 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Fusion;
+
+/// <summary>
+/// Multi-select ChipList as a filter, end-to-end in the browser. The chip selection is broadcast as
+/// a custom event whose payload carries getSelectedChips().data (the selected chip objects); the
+/// array DSL counts and guards them by member (p.From(payload, x => x.Selection.Data)), and the
+/// selected texts gather into a POST that filters the resident grid server-side.
+///
+/// Roster: Ada/Cy/Gus = Memory Care, Bo/Fay = Assisted, Di = Skilled Nursing, Ed = Independent (7).
+/// Page under test: /Sandbox/Components/ChipFilter. Isolated slice.
+/// </summary>
+[TestFixture]
+public class WhenFilteringWithChips : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/ChipFilter";
+
+    private async Task NavigateAndLoad()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Expect(Page.Locator("#filter-status"))
+            .ToHaveTextAsync("all residents", new() { Timeout = 10000 });
+    }
+
+    private async Task SelectChip(string text)
+    {
+        var chip = Page.Locator("#care-filters .e-chip").Filter(new() { HasText = text });
+        await Expect(chip).ToBeVisibleAsync(new() { Timeout = 5000 });
+        await chip.ClickAsync();
+    }
+
+    [Test]
+    public async Task grid_shows_all_residents_on_load()
+    {
+        await NavigateAndLoad();
+        await Expect(Page.Locator("#care-grid .e-row")).ToHaveCountAsync(7, new() { Timeout = 10000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selecting_chips_counts_the_selection_and_guards_by_member()
+    {
+        await NavigateAndLoad();
+
+        await SelectChip("Memory Care");
+        await SelectChip("Assisted");
+        await Page.Locator("#apply-filters-btn").ClickAsync();
+
+        // Array DSL over the selected chip OBJECTS: 2 selected; Memory Care included (by Value).
+        await Expect(Page.Locator("#filter-count")).ToHaveTextAsync("2", new() { Timeout = 10000 });
+        await Expect(Page.Locator("#memory-on")).ToBeVisibleAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task applying_the_chip_selection_filters_the_grid()
+    {
+        await NavigateAndLoad();
+
+        await SelectChip("Memory Care");
+        await SelectChip("Assisted");
+        await Page.Locator("#apply-filters-btn").ClickAsync();
+
+        await Expect(Page.Locator("#filter-status"))
+            .ToHaveTextAsync("filtered", new() { Timeout = 10000 });
+
+        // Memory Care (Ada, Cy, Gus) + Assisted (Bo, Fay) = 5 rows; no Independent/Skilled.
+        await Expect(Page.Locator("#care-grid .e-row")).ToHaveCountAsync(5, new() { Timeout = 10000 });
+        await Expect(Page.Locator("#care-grid")).Not.ToContainTextAsync("Skilled Nursing", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenArrayOpsCountsSelection.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenArrayOpsCountsSelection.cs
@@ -1,0 +1,83 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Native;
+
+/// <summary>
+/// Exercises the deterministic array-operations DSL end-to-end in the browser:
+/// NativeCheckList Changed -> p.From(args, e => e.Value).Count() ->
+/// p.Element("selected-count").SetText(count). Proves the array-op plan node executes
+/// in the runtime against a real string[] event payload, with no plugin and no hand-written JS.
+///
+/// Page under test: /Sandbox/Components/ArrayOps
+/// Isolated slice — touches no other vertical slice.
+/// </summary>
+[TestFixture]
+public class WhenArrayOpsCountsSelection : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/ArrayOps";
+    private const string Scope = "Alis_Reactive_SandboxApp_Areas_Sandbox_Models_ArrayOpsModel__";
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 5000);
+    }
+
+    [Test]
+    public async Task page_loads_without_errors()
+    {
+        await NavigateAndBoot();
+        await Expect(Page).ToHaveTitleAsync("ArrayOps — Alis.Reactive Sandbox");
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_count_shows_one_after_first_activity_is_checked()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator($"#{Scope}SelectedActivities_c0").ClickAsync();
+
+        var count = Page.Locator("#selected-count");
+        await Expect(count).ToHaveTextAsync("1", new() { Timeout = 3000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_count_increments_as_more_activities_are_checked()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator($"#{Scope}SelectedActivities_c0").ClickAsync();
+        await Page.Locator($"#{Scope}SelectedActivities_c1").ClickAsync();
+
+        var count = Page.Locator("#selected-count");
+        await Expect(count).ToHaveTextAsync("2", new() { Timeout = 3000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_count_decrements_when_an_activity_is_unchecked()
+    {
+        await NavigateAndBoot();
+
+        await Page.Locator($"#{Scope}SelectedActivities_c0").ClickAsync();
+        await Page.Locator($"#{Scope}SelectedActivities_c1").ClickAsync();
+        await Page.Locator($"#{Scope}SelectedActivities_c0").ClickAsync();
+
+        var count = Page.Locator("#selected-count");
+        await Expect(count).ToHaveTextAsync("1", new() { Timeout = 3000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task selected_count_shows_full_total_when_all_activities_are_checked()
+    {
+        await NavigateAndBoot();
+
+        for (var i = 0; i < 5; i++)
+            await Page.Locator($"#{Scope}SelectedActivities_c{i}").ClickAsync();
+
+        var count = Page.Locator("#selected-count");
+        await Expect(count).ToHaveTextAsync("5", new() { Timeout = 3000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenArrayOpsTransformsResidents.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenArrayOpsTransformsResidents.cs
@@ -1,0 +1,75 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Native;
+
+/// <summary>
+/// Complex array operations over an object array, end-to-end in the browser — a deterministic
+/// replacement for the ArrayManager plugin. On DomReady the plan loads a resident roster via HTTP
+/// then, in OnSuccess, operates on the array entirely in the closed DSL:
+///   residents.Count()                                                 -> total
+///   residents.Count(x => x.Status == "active")                        -> member predicate
+///   residents.Count(x => x.Status == "active" && x.Age >= 65)         -> compound predicate
+///   residents.Where(x => x.Status == "active").Sum(x => x.Age)        -> chained filter -> sum
+///   residents.Where(active).OrderByDescending(x => x.Age).Find(.., x => x.Name) -> filter/order/find/project
+///   residents.Any(x => x.Status == "critical")                        -> predicate guard
+/// No plugin, no hand-written JS.
+///
+/// Page under test: /Sandbox/Components/ArrayOps. Isolated slice.
+/// </summary>
+[TestFixture]
+public class WhenArrayOpsTransformsResidents : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/ArrayOps";
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 5000);
+    }
+
+    [Test]
+    public async Task counts_total_residents_from_the_loaded_array()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#res-total")).ToHaveTextAsync("5", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task counts_active_residents_by_member_predicate()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#res-active")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task counts_active_seniors_by_compound_member_predicate()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#res-active-seniors")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task sums_ages_of_active_residents_via_chained_filter_then_sum()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#res-active-age-sum")).ToHaveTextAsync("206", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task finds_oldest_active_resident_via_filter_orderby_find()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#res-oldest-active")).ToHaveTextAsync("Cy", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task flags_a_critical_resident_via_any_predicate_guard()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#res-critical-yes")).ToBeVisibleAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenDomOpsTransformElements.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenDomOpsTransformElements.cs
@@ -1,0 +1,70 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Native;
+
+/// <summary>
+/// The array DSL over NATIVE DOM, end-to-end in the browser. A DOM element resolved by
+/// getElementById is a JS object; its classList (DOMTokenList) and children (HTMLCollection)
+/// are array-likes the runtime normalizes, so the closed array ops apply directly:
+///   p.FromDom("dom-card", "classList").Count()
+///   p.FromDom("dom-card", "classList").Where(x => x.StartsWith("risk-")).Count()
+///   p.FromDom("dom-list", "children").Count()
+///   p.FromDom("dom-card", "classList").Any(x => x == "care-memory")  -> guard
+/// and DOM mutation + recompute in one tick (AddClass then re-count).
+/// No plugin, no hand-written JS.
+///
+/// Page under test: /Sandbox/Components/DomOps. Isolated slice.
+/// </summary>
+[TestFixture]
+public class WhenDomOpsTransformElements : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/DomOps";
+
+    private async Task NavigateAndBoot()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 5000);
+    }
+
+    [Test]
+    public async Task counts_the_css_classes_of_a_dom_element()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#dom-total-classes")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task counts_risk_classes_by_prefix_filter_over_classList()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#dom-risk-count")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task counts_child_elements_of_a_dom_collection()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#dom-child-count")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task flags_a_memory_care_class_via_any_predicate_over_classList()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#dom-memory-yes")).ToBeVisibleAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task recounts_risk_classes_after_mutating_the_dom_element()
+    {
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#dom-risk-count")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+
+        await Page.Locator("#dom-add-risk-btn").ClickAsync();
+
+        await Expect(Page.Locator("#dom-risk-count")).ToHaveTextAsync("3", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenDomOpsTransformElements.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenDomOpsTransformElements.cs
@@ -67,4 +67,14 @@ public class WhenDomOpsTransformElements : PlaywrightTestBase
         await Expect(Page.Locator("#dom-risk-count")).ToHaveTextAsync("3", new() { Timeout = 5000 });
         AssertNoConsoleErrors();
     }
+
+    [Test]
+    public async Task counts_high_risk_children_by_calling_getAttribute_per_element()
+    {
+        // Per-element METHOD call: each child is a live DOM element; the plan calls
+        // x.GetAttribute("data-risk") on each and counts those == "high" (2 of 3).
+        await NavigateAndBoot();
+        await Expect(Page.Locator("#dom-high-risk-count")).ToHaveTextAsync("2", new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
 }

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenOperatingOnCustomEventPayloadArray.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenOperatingOnCustomEventPayloadArray.cs
@@ -1,0 +1,66 @@
+namespace Alis.Reactive.PlaywrightTests.Components.Native;
+
+/// <summary>
+/// The array DSL operating on a CUSTOM event payload, end-to-end in the browser. A button loads the
+/// alert roster, then dispatches the custom event <c>shift-report</c> whose payload carries
+/// ResidentAlert[]; the listener runs filter/aggregate/find/guard over the payload's element members
+/// (p.From(payload, x =&gt; x.Alerts)). Proves a developer-defined event payload array is fully operable.
+///
+/// Alerts: Maple(critical,9,unack), Birch(stable,2), Cedar(critical,7), Aspen(urgent,5), Oak(critical,4,unack).
+/// Page under test: /Sandbox/Components/ShiftReport. Isolated slice.
+/// </summary>
+[TestFixture]
+public class WhenOperatingOnCustomEventPayloadArray : PlaywrightTestBase
+{
+    private const string Path = "/Sandbox/Components/ShiftReport";
+
+    private async Task NavigateAndGenerateReport()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Page.Locator("#load-report-btn").ClickAsync();
+    }
+
+    [Test]
+    public async Task counts_every_alert_in_the_custom_payload_array()
+    {
+        await NavigateAndGenerateReport();
+        await Expect(Page.Locator("#alert-total")).ToHaveTextAsync("5", new() { Timeout = 10000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task counts_only_critical_alerts_by_element_member()
+    {
+        await NavigateAndGenerateReport();
+        await Expect(Page.Locator("#critical-count")).ToHaveTextAsync("3", new() { Timeout = 10000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task sums_priority_of_critical_alerts()
+    {
+        await NavigateAndGenerateReport();
+        // Where(Severity == "critical").Sum(Priority) = 9 + 7 + 4
+        await Expect(Page.Locator("#critical-priority-sum")).ToHaveTextAsync("20", new() { Timeout = 10000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task finds_the_highest_priority_critical_resident()
+    {
+        await NavigateAndGenerateReport();
+        // Where(critical).OrderByDescending(Priority).Find(first).Resident => Maple (priority 9)
+        await Expect(Page.Locator("#top-critical")).ToHaveTextAsync("Maple", new() { Timeout = 10000 });
+        AssertNoConsoleErrors();
+    }
+
+    [Test]
+    public async Task guards_on_an_unacknowledged_critical_alert()
+    {
+        await NavigateAndGenerateReport();
+        // Any(Severity == "critical" && !Acknowledged) => true (Maple, Oak)
+        await Expect(Page.Locator("#unack-warning")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        AssertNoConsoleErrors();
+    }
+}

--- a/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenOperatingOnCustomEventPayloadArray.cs
+++ b/tests/Alis.Reactive.PlaywrightTests/Components/Native/WhenOperatingOnCustomEventPayloadArray.cs
@@ -63,4 +63,17 @@ public class WhenOperatingOnCustomEventPayloadArray : PlaywrightTestBase
         await Expect(Page.Locator("#unack-warning")).ToBeVisibleAsync(new() { Timeout = 10000 });
         AssertNoConsoleErrors();
     }
+
+    [Test]
+    public async Task guard_clears_when_all_critical_alerts_are_acknowledged()
+    {
+        await NavigateTo(Path);
+        await WaitForTraceMessage("booted", 10000);
+        await Page.Locator("#clear-report-btn").ClickAsync();
+
+        // Same array DSL guard, all-acknowledged roster => Else branch: clear shown, warning not.
+        await Expect(Page.Locator("#unack-clear")).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Expect(Page.Locator("#unack-warning")).Not.ToBeVisibleAsync(new() { Timeout = 5000 });
+        AssertNoConsoleErrors();
+    }
 }


### PR DESCRIPTION
# Array-operations DSL — `ReactiveArray<T>`, value routing, and component integration

Promotes a closed, deterministic set of array operations out of the plugin escape hatch into
first-class plan vocabulary, then completes the framework's value-routing law and proves it across
native DOM, HTTP, custom events, a Fusion grid, and a Fusion ChipList. The author writes natural C#
lambdas; they are **captured** (not executed) and compiled into closed **plan-JSON** nodes that the
runtime interpreter evaluates per element. No developer JS. The plugin remains only for 3rd-party
integration / call composition.

Design + approval: `docs/superpowers/specs/2026-05-29-reactive-array-operations-dsl-design.md`
(senior-architect panel: clean approval). Follow-ups and the value-routing law:
`docs/superpowers/specs/2026-05-30-array-dsl-followups.md`.

---

## 1. The array-operations DSL

- **Ops:** `Where, Select, Count, Sum, Any, All, Find(+field), OrderBy/OrderByDescending` — predicates
  and projections from lambdas, composable (`Where(...).Sum(...)`).
- **Element scope:** per-element predicates/selectors read the element via a new `element` payload
  scope; `x => x` reads a primitive element itself.
- **Sources:** `.Reactive()` event arrays (`e.Value`), HTTP response arrays
  (`json.Read(x => x.Residents)`), component array members, and **native DOM**
  (`p.FromDom("card","classList")` — `classList`/`children` normalized).
- **Array-like normalization** at the input boundary (Array / null→`[]` / scalar→`[v]` /
  iterable→`Array.from` for DOMTokenList/HTMLCollection/FileList; non-iterable throws). dataset stays plugin.
- **Per-element method calls:** `x => x.GetDay()`, `x => x.GetAttribute("data-risk")`,
  `x => x.Address.GetCity()` — routed through the existing contract-free `RuntimePath.call` at the
  element scope. Whitelisted to pure, deterministic methods.

## 2. Value-routing law completed — `SetDataSource(TypedSource<T[]>)`

A DSL-transformed array already flowed into `When` / `SetText` / dispatch payloads (the universal
`TypedSource` intake). The one missing edge — a component's `dataSource` member — is now closed:

- `SetDataSource<TModel, TElement>(TypedSource<TElement[]>)` on **FusionGrid, FusionDropDownList,
  FusionMultiSelect, FusionAutoComplete, FusionMultiColumnComboBox** (single `EmitSet`) and
  **FusionKanban** (`EmitSet` + `dataBind`). Zero plan/TS/runtime change — `EmitSet` +
  `ToValueExpression` already existed.
- `ReactiveArray.AsSource()` exposes a transformed array as `TypedSource<TElement[]>`.
- `FusionGrid.Data<TModel, TRow>()` — the read counterpart (mirrors `FusionKanban.Cards()`), so
  on-screen rows can be re-filtered and rebound **with no HTTP round-trip**.

## 3. Custom event payloads carrying arrays

A developer-defined `CustomEvent<TPayload>` whose payload carries `T[]` is fully operable:
`p.From(payload, x => x.Alerts)` runs the array DSL over the payload's element members.

## 4. ChipList multi-select onboarding (Fusion)

Onboards `getSelectedChips().data` (proven from shipped `chip-list.js`) as a typed array of the
selected chip objects: `FusionSelectedChips.Data : FusionChipItem[]`. Multi-select chips become an
array-DSL source — operate on the selection by member, then filter a grid.

---

## Sandbox slices (each isolated, Playwright-proven)

| URL | Demonstrates |
|-----|--------------|
| `/Sandbox/Components/ArrayOps` | object-array ops over an HTTP roster (filter / aggregate / find / guard) + live checklist count |
| `/Sandbox/Components/DomOps` | array ops over native DOM (`classList`/`children`) + per-element `getAttribute` |
| `/Sandbox/Components/ArrayGrid` | client-side `OrderBy` → `SetDataSource(TypedSource<T[]>)`; `Data()` → `Where` → rebind, no HTTP |
| `/Sandbox/Components/ShiftReport` | array DSL over a **custom event payload** array (count / filter / sum / find / guard, incl. Else branch) |
| `/Sandbox/Components/ChipFilter` | **multi-select chips as a filter** — array DSL over selected chip objects + server-side grid filter |

## Architecture

- New `ValueExpression` kind (`array-op`), `element` payload scope, `DomSource`, `InvokeElement` /
  `ReadWholeElement`; reuses the single `evaluateValue` resolver, `ConditionGraph` for predicates,
  `ObjectExpression` for projections. Comparison `Shape` is **member-driven** (matches
  `ConditionSourceBuilder`), so JS-land comparisons coerce correctly.
- Import-cycle resolution: a sync-condition subset in `conditions/sync-condition.ts` (DI leaf) lets
  `core/evaluate` use it without a cycle.
- Vendor isolation maintained: zero runtime/`resolver.ts` changes for the Fusion sink edge — all C#
  vertical slices.

## Quality

Closed an adversarial quality audit (independent reviewers per dimension, each finding refuted
against code). Fixes landed: a must-fix `OrderBy` non-scalar-key trap (silently sorted by
`"[object Object]"` → now throws at authoring time), a constant-predicate hole, and accuracy
corrections. Two items deliberately scheduled (not crammed): a Rule-6 `plan.ts` type-split of
`ArrayOperationExpression`, and a per-element-method whitelist contract decision. The ChipList
`Indexes` casing limitation (Syncfusion capital-`Indexes`) is documented with the recorded fix.

## Tests

- **vitest: 192/192 green.** `npm run typecheck`: clean. **C# build: clean.**
- **Playwright (per slice):** ArrayOps + DomOps + ArrayGrid + ShiftReport + ChipFilter all green;
  the pre-existing FusionGrid (7) and FusionChipList (10) slices unchanged — confirming additive,
  non-regressing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
