### PR TITLE
[codex] Keep docs deploy focused on Pages build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -48,49 +48,8 @@ jobs:
           name: docs-dist
           path: docs-site/dist
 
-  playwright:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    env:
-      Syncfusion__LicenseKey: ${{ secrets.SYNCFUSION_LICENSE_KEY }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Build app and Playwright project
-        run: scripts/build.sh
-
-      - name: Install Playwright browsers
-        run: pwsh tests/Alis.Reactive.PlaywrightTests/bin/Debug/net10.0/playwright.ps1 install --with-deps chromium
-
-      - name: Run observable Playwright tests
-        run: scripts/playwright.sh --no-build
-
-      - name: Upload Playwright report + screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: |
-            tests/Alis.Reactive.PlaywrightTests/TestResults/observable/*.log
-            tests/Alis.Reactive.PlaywrightTests/TestResults/observable/*.trx
-            tests/Alis.Reactive.PlaywrightTests/TestResults/observable/*.diag.log
-            tests/Alis.Reactive.PlaywrightTests/bin/TestResults/playwright-traces/*
-          retention-days: 14
-
   deploy:
-    needs: [build-docs, playwright]
-    if: always() && needs.build-docs.result == 'success'
+    needs: build-docs
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -102,14 +61,7 @@ jobs:
           name: docs-dist
           path: site
 
-      - name: Download Playwright report
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: playwright-report
-          path: site/reports/playwright
-
-      - name: Upload merged Pages artifact
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: site


### PR DESCRIPTION
## What changed

- Removed the Playwright report job from the GitHub Pages docs deploy workflow.
- Made the deploy job depend only on the docs build artifact.

## Why

The post-merge docs build passed, but Pages deployment was still waiting on a full Playwright report job. That job is unrelated to publishing the docs site and is already covered by the repository CI workflow. Keeping it inside `deploy-docs.yml` delays or blocks the docs action even when the docs build itself is green.

## Validation

- Parsed `.github/workflows/deploy-docs.yml` with Ruby/Psych.
- Searched the docs deploy workflow for leftover Playwright/report references.
- Confirmed the previous post-merge `build-docs` job had already passed with `npm ci`, `npm run build`, and artifact upload.